### PR TITLE
ci(release-please): migrate to googleapis action v5 and add changelog config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,4 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4.1.1
-        with:
-          release-type: rust
+      - uses: googleapis/release-please-action@v5.0.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
+  "changelog-sections": [
+    { "type": "feat",     "section": "Features" },
+    { "type": "fix",      "section": "Bug Fixes" },
+    { "type": "perf",     "section": "Performance Improvements" },
+    { "type": "revert",   "section": "Reverts" },
+    { "type": "docs",     "section": "Documentation" },
+    { "type": "deps",     "section": "Dependencies" },
+    { "type": "build",    "hidden": true },
+    { "type": "chore",    "hidden": true },
+    { "type": "ci",       "hidden": true },
+    { "type": "refactor", "hidden": true },
+    { "type": "style",    "hidden": true },
+    { "type": "test",     "hidden": true }
+  ]
+}


### PR DESCRIPTION
## Summary

- Migrates from deprecated `google-github-actions/release-please-action` to `googleapis/release-please-action@v5`
- Adds `release-please-config.json` with explicit changelog sections: `feat`, `fix`, `perf`, `revert`, `docs`, `deps` visible — `chore`, `ci`, `refactor`, `style`, `test`, `build` hidden
- `release-type` moved from workflow input to config file (single source of truth)