### PR TITLE
ci(label): auto-label PRs from conventional commit title

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,16 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `label.yml` workflow using `bcoe/conventional-release-labels@v1.3.1`
- Triggers on PR open, edit, and push
- Creates and applies labels automatically based on the PR title prefix (`feat:` → `feature`, `fix:` → `bug`, `ci:` → `ci`, etc.)