### PR TITLE
feat(cockpit): display app version in status bar

### DIFF
--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2085,10 +2085,11 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
         Span::styled(error_part, Style::default().fg(Color::Red)),
     ]);
 
+    let app_version = env!("CARGO_PKG_VERSION");
     let api_version = state.api_version
         .map(|v| format!("API v{v}  "))
         .unwrap_or_default();
-    let right_text = format!("{api_version}⟳ {last}   next: {next}");
+    let right_text = format!("v{app_version}  {api_version}⟳ {last}   next: {next}");
     let right_len = right_text.chars().count() as u16;
     let right = Paragraph::new(right_text)
         .alignment(Alignment::Right)


### PR DESCRIPTION
## Summary

Displays the binary version (from `Cargo.toml` via `env!("CARGO_PKG_VERSION")`) in the status bar, to the left of the API version.

Before: `API v11  ⟳ 12s   next: 4m 2s`
After:  `v11.0.0  API v11  ⟳ 12s   next: 4m 2s`