### PR TITLE
fix(ci): wrap release-please config in packages block

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,18 +1,22 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
-  "changelog-sections": [
-    { "type": "feat",     "section": "Features" },
-    { "type": "fix",      "section": "Bug Fixes" },
-    { "type": "perf",     "section": "Performance Improvements" },
-    { "type": "revert",   "section": "Reverts" },
-    { "type": "docs",     "section": "Documentation" },
-    { "type": "deps",     "section": "Dependencies" },
-    { "type": "build",    "hidden": true },
-    { "type": "chore",    "hidden": true },
-    { "type": "ci",       "hidden": true },
-    { "type": "refactor", "hidden": true },
-    { "type": "style",    "hidden": true },
-    { "type": "test",     "hidden": true }
-  ]
+  "packages": {
+    ".": {
+      "release-type": "rust",
+      "changelog-sections": [
+        { "type": "feat",     "section": "Features" },
+        { "type": "fix",      "section": "Bug Fixes" },
+        { "type": "perf",     "section": "Performance Improvements" },
+        { "type": "revert",   "section": "Reverts" },
+        { "type": "docs",     "section": "Documentation" },
+        { "type": "deps",     "section": "Dependencies" },
+        { "type": "build",    "hidden": true },
+        { "type": "chore",    "hidden": true },
+        { "type": "ci",       "hidden": true },
+        { "type": "refactor", "hidden": true },
+        { "type": "style",    "hidden": true },
+        { "type": "test",     "hidden": true }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

In release-please v5 with a config file, the top-level `release-type` is ignored when scanning commits by path. The package must be declared explicitly under `packages` so release-please knows to associate commits with path `.`.

Without this, every run logs `Splitting 0 commits by path` and never creates a release PR.