### PR TITLE
ci(release-please): use GitHub App token (Bob) to trigger release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Replaces the default `GITHUB_TOKEN` in release-please with a token generated from the **Bob** GitHub App (`APP_ID` + `APP_PRIVATE_KEY` secrets)
- Tokens created by a GitHub App are not subject to the "no cascading workflow triggers" restriction, so merging the release PR will now correctly fire the `release: published` event and trigger `release.yml`
- Removes the now-redundant `permissions` block (the App token carries its own scopes)