### PR TITLE
ci(release-please): use client-id for GitHub App token (Bob)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5.0.0


### PR DESCRIPTION
## Summary

Two fixes for the Bob GitHub App token generation:

- `app-id` → `client-id` (renamed input in `actions/create-github-app-token@v3`) using the `CLIENT_ID` secret (`Iv23li...`)
- The `APP_ID` secret is no longer used

**Note:** Bob must be installed on this repository for the token generation to succeed (`https://github.com/settings/apps/bob-johansson/installations`).