### PR TITLE
ci(release): use friendly platform names for binary archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,19 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            platform: linux-x86_64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            platform: linux-aarch64
           - target: x86_64-apple-darwin
             os: macos-13
+            platform: macos-x86_64
           - target: aarch64-apple-darwin
             os: macos-latest
+            platform: macos-aarch64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            platform: windows-x86_64
 
     steps:
       - uses: actions/checkout@v6
@@ -44,9 +49,8 @@ jobs:
         shell: bash
         run: |
           BIN=neumann-cockpit
-          TARGET=${{ matrix.target }}
-          ARCHIVE="${BIN}-${TARGET}.tar.gz"
-          tar czf "$ARCHIVE" -C "target/${TARGET}/release" "$BIN"
+          ARCHIVE="${BIN}-${{ matrix.platform }}.tar.gz"
+          tar czf "$ARCHIVE" -C "target/${{ matrix.target }}/release" "$BIN"
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
       - name: Package (Windows)
@@ -54,9 +58,8 @@ jobs:
         shell: pwsh
         run: |
           $BIN = "neumann-cockpit"
-          $TARGET = "${{ matrix.target }}"
-          $ARCHIVE = "${BIN}-${TARGET}.zip"
-          Compress-Archive -Path "target\${TARGET}\release\${BIN}.exe" -DestinationPath $ARCHIVE
+          $ARCHIVE = "${BIN}-${{ matrix.platform }}.zip"
+          Compress-Archive -Path "target\${{ matrix.target }}\release\${BIN}.exe" -DestinationPath $ARCHIVE
           "ARCHIVE=${ARCHIVE}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload to release


### PR DESCRIPTION
## Summary

Adds a `platform` field to the matrix and uses it for archive naming instead of the full Rust target triple.

| Before | After |
|---|---|
| `neumann-cockpit-x86_64-unknown-linux-gnu.tar.gz` | `neumann-cockpit-linux-x86_64.tar.gz` |
| `neumann-cockpit-aarch64-unknown-linux-gnu.tar.gz` | `neumann-cockpit-linux-aarch64.tar.gz` |
| `neumann-cockpit-x86_64-apple-darwin.tar.gz` | `neumann-cockpit-macos-x86_64.tar.gz` |
| `neumann-cockpit-aarch64-apple-darwin.tar.gz` | `neumann-cockpit-macos-aarch64.tar.gz` |
| `neumann-cockpit-x86_64-pc-windows-msvc.zip` | `neumann-cockpit-windows-x86_64.zip` |