### PR TITLE
docs(readme): add CI and release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # neumann-cockpit
 
+[![CI](https://github.com/MagiCrazy/neumann-cockpit/actions/workflows/ci.yml/badge.svg)](https://github.com/MagiCrazy/neumann-cockpit/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/MagiCrazy/neumann-cockpit)](https://github.com/MagiCrazy/neumann-cockpit/releases/latest)
+
 A terminal UI cockpit for [Von Neumann Game](https://github.com/gnieark/Von-Neumann-Game) — control your probe and its mannies from the command line.
 
 The official game instance runs at **[https://neumann-probe.net](https://neumann-probe.net)** (default endpoint).


### PR DESCRIPTION
Adds CI status and latest release version badges at the top of the README.