### PR TITLE
chore(deps): add Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 9am on monday"],
+  "labels": ["dependencies"],
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "Rust dependencies",
+      "automerge": true,
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true,
+      "matchUpdateTypes": ["patch", "minor", "digest"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `renovate.json` to automate dependency updates via the [Renovate GitHub App](https://github.com/apps/renovate)
- Disables Dependabot (security updates + alerts) — replaced by Renovate + `osvVulnerabilityAlerts`

## Config highlights

- **`config:recommended`** — base preset, includes `helpers:pinGitHubActionDigests` (keeps Actions pinned by SHA + comment, pairs with #15)
- **Cargo deps** — all grouped into a single PR, automerged for patch and minor
- **GitHub Actions** — grouped, automerged for patch/minor/digest (SHA pin updates)
- **`osvVulnerabilityAlerts: true`** — Renovate opens PRs for CVEs via OSV database, replacing Dependabot security alerts
- **Schedule** — Monday morning, avoids mid-week noise

## Setup required

Install the Renovate GitHub App on this repo: https://github.com/apps/renovate