### PR TITLE
feat: v23 API, dynamic recipes, scanner enhancements, mannies actions

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d3f4f98f-450c-44c0-8f59-98691c6926f6","pid":188473,"procStart":"536309","acquiredAt":1780950078226}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ A terminal UI cockpit for [Von Neumann Game](https://github.com/gnieark/Von-Neum
 
 The official game instance runs at **[https://neumann-probe.net](https://neumann-probe.net)** (default endpoint).
 
+## Install
+
+**Prebuilt binaries** for Linux, macOS, and Windows are available on the [releases page](https://github.com/MagiCrazy/neumann-cockpit/releases/latest).
+
+```bash
+# Linux x86_64 example
+curl -sL https://github.com/MagiCrazy/neumann-cockpit/releases/latest/download/neumann-cockpit-linux-x86_64.tar.gz | tar xz
+./neumann-cockpit
+```
+
 ## Quickstart
 
 **1. Get an API key** — create an account on [neumann-probe.net](https://neumann-probe.net), go to Settings and generate an API key. It is shown only once.
@@ -29,7 +39,7 @@ api_key  = "vng_your_api_key_here"
 **3. Run**
 
 ```bash
-cargo run --release
+neumann-cockpit
 ```
 
 ## Features
@@ -50,6 +60,8 @@ The UI refreshes automatically when a movement completes — the timer is set to
 Requires a stable Rust toolchain (`rustup` recommended).
 
 ```bash
+git clone https://github.com/MagiCrazy/neumann-cockpit
+cd neumann-cockpit
 cargo build --release
 ./target/release/neumann-cockpit
 ```

--- a/TODO_TESTS.md
+++ b/TODO_TESTS.md
@@ -1,0 +1,333 @@
+# TODO — CI + Tests
+
+## Context
+
+Rust TUI app, currently no test suite. CI runs check + clippy + build only.
+
+Layers to cover:
+- `src/api/types.rs` — serde types, camelCase renames, Unknown fallbacks
+- `src/api/client.rs` — reqwest HTTP client, 14 endpoints
+- `src/app.rs` — AppState, 50+ methods, complex state machine
+- `src/ui/cockpit.rs` — 39 ratatui render functions, 2300 lines
+
+---
+
+## Dev dependencies to add
+
+```toml
+[dev-dependencies]
+wiremock  = "0.6"
+insta     = { version = "1", features = ["json", "ron"] }
+proptest  = "1"
+```
+
+Also install via cargo-binstall (not a dev-dep):
+- `cargo-nextest` — faster test runner, better CI output
+- `cargo-llvm-cov` — LLVM-based coverage
+
+---
+
+## File structure
+
+```
+tests/
+  fixtures/
+    probe_idle.json
+    probe_moving.json
+    probe_low_resources.json
+    mannies_two.json
+    sector_asteroid.json
+    sector_empty.json
+  api/
+    client_test.rs
+    types_test.rs
+  app/
+    state_test.rs
+    coords_test.rs
+  ui/
+    snapshots/          ← insta auto-generated, committed
+    cockpit_test.rs
+```
+
+---
+
+## Step 1 — JSON fixtures
+
+Create `tests/fixtures/` with realistic anonymised API responses.
+
+| File | Content |
+|---|---|
+| `probe_idle.json` | Probe status=Idle, fuel 80%, integrity 100% |
+| `probe_moving.json` | Probe with active movement, phase=Cruising |
+| `probe_low_resources.json` | fuel 15%, integrity 20% (gauge color testing) |
+| `mannies_two.json` | 2 mannies — one idle, one mining at 42% |
+| `sector_asteroid.json` | SectorObservation with 3 minable asteroids |
+| `sector_empty.json` | Empty sector, freshness=Unavailable |
+
+---
+
+## Step 2 — API types deserialization (`tests/api/types_test.rs`)
+
+```rust
+#[test]
+fn probe_idle_deserializes() {
+    let json = include_str!("../fixtures/probe_idle.json");
+    let probe: Probe = serde_json::from_str(json).unwrap();
+    assert_eq!(probe.status, ProbeStatus::Idle);
+    assert!(probe.movement.is_none());
+}
+
+#[test]
+fn unknown_probe_status_falls_back() {
+    // inject unknown variant → ProbeStatus::Unknown, no panic
+}
+
+#[test]
+fn probe_moving_has_movement() { ... }
+#[test]
+fn manny_task_unknown_falls_back() { ... }
+#[test]
+fn sector_observation_deserializes_objects() { ... }
+```
+
+Goal: cover all enums with `#[serde(other)] Unknown` + all camelCase structs.
+
+---
+
+## Step 3 — API client HTTP (`tests/api/client_test.rs`)
+
+```rust
+use wiremock::{MockServer, Mock, ResponseTemplate};
+use wiremock::matchers::{method, path, body_json};
+
+#[tokio::test]
+async fn get_probe_happy_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/probe"))
+        .respond_with(ResponseTemplate::new(200)
+            .set_body_raw(include_str!("../fixtures/probe_idle.json"), "application/json"))
+        .mount(&server)
+        .await;
+
+    let client = ApiClient::new(server.uri(), "test_key".into()).unwrap();
+    let probe = client.get_probe().await.unwrap();
+    assert_eq!(probe.name, "neumann");
+}
+
+#[tokio::test]
+async fn unauthorized_returns_clear_error() {
+    // 401 → anyhow error containing "check api_key"
+}
+
+#[tokio::test]
+async fn move_probe_sends_correct_body() {
+    // verify POST body contains { "target": { "x": 2, "y": 0, "z": 0 } }
+    // via body_json matcher
+}
+
+#[tokio::test]
+async fn server_error_propagates() {
+    // 500 → error, no panic
+}
+```
+
+Target: 14 endpoints × happy path + 401 + 500 ≈ 42 tests.
+
+---
+
+## Step 4 — AppState logic (`tests/app/state_test.rs`)
+
+```rust
+#[test]
+fn parse_scan_coords_valid() {
+    // (2,0,0) — sum even → ok
+}
+
+#[test]
+fn parse_scan_coords_odd_sum_rejected() {
+    // (1,0,0) — sum odd → err
+}
+
+#[test]
+fn parse_scan_coords_non_numeric_rejected() { ... }
+
+#[test]
+fn neighbors_d1_returns_six_even_sum_coords() {
+    let ns = AppState::neighbors_d1((0, 0, 0));
+    assert_eq!(ns.len(), 6);
+    for (x, y, z) in ns {
+        assert_eq!((x + y + z) % 2, 0);
+    }
+}
+
+#[test]
+fn mine_max_amount_capped_by_free_cargo() {
+    // free_capacity = 10, available = 100 → max = 10
+}
+
+#[test]
+fn mine_max_amount_capped_by_available_resource() {
+    // free_capacity = 100, available = 5 → max = 5
+}
+
+#[test]
+fn travel_preview_computes_eta() {
+    // inject Probe at (0,0,0), request move to (2,0,0)
+    // verify fuel_cost and eta_minutes are nonzero and plausible
+}
+
+#[test]
+fn next_refresh_instant_no_movement_is_far_future() {
+    // no movement → deadline is ~24h away
+}
+
+#[test]
+fn next_refresh_instant_with_arrival_is_bounded() {
+    // arrival_at = now + 5min → deadline ≈ now + 5min
+}
+```
+
+Target: ~25 tests on pure-logic AppState methods.
+
+---
+
+## Step 5 — Property-based coords (`tests/app/coords_test.rs`)
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn valid_coords_accepted(x in -100i32..100, y in -100i32..100) {
+        let z = if (x + y) % 2 == 0 { 0 } else { 1 };
+        let input = format!("{x},{y},{z}");
+        prop_assert!(state.parse_scan_coords(&input).is_ok());
+    }
+
+    #[test]
+    fn odd_sum_coords_rejected(x in -100i32..100, y in -100i32..100) {
+        let z = if (x + y) % 2 == 0 { 1 } else { 0 };
+        let input = format!("{x},{y},{z}");
+        prop_assert!(state.parse_scan_coords(&input).is_err());
+    }
+}
+```
+
+---
+
+## Step 6 — UI snapshots (`tests/ui/cockpit_test.rs`)
+
+```rust
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+fn render_to_string(state: &AppState, width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| cockpit::render(f, state)).unwrap();
+    // read cells from buffer → String
+    buffer_to_string(terminal.backend().buffer())
+}
+
+#[test]
+fn probe_panel_idle() {
+    let state = AppState { probe: Some(fixture_probe_idle()), ..Default::default() };
+    insta::assert_snapshot!(render_to_string(&state, 120, 30));
+}
+
+#[test]
+fn probe_panel_moving() { ... }
+
+#[test]
+fn probe_panel_low_resources_red_gauges() { ... }
+
+#[test]
+fn mannies_panel_two_mannies() { ... }
+
+#[test]
+fn scanner_panel_asteroid_sector() { ... }
+
+#[test]
+fn travel_overlay_typing_state() { ... }
+
+#[test]
+fn error_banner_displayed() { ... }
+
+#[test]
+fn loading_state_no_data() { ... }
+```
+
+Workflow: first run generates snapshots under `tests/ui/snapshots/`, committed to git.
+Any visual regression fails CI. Review with `cargo insta review`.
+
+---
+
+## Step 7 — CI update (`ci.yml`)
+
+Add after existing clippy step:
+
+```yaml
+- name: Install nextest + llvm-cov
+  uses: taiki-e/install-action@v2
+  with:
+    tool: nextest,cargo-llvm-cov
+
+- name: Run tests
+  run: cargo nextest run --all-features
+
+- name: Generate coverage
+  run: cargo llvm-cov nextest --lcov --output-path lcov.info
+
+- name: Upload to Codecov
+  uses: codecov/codecov-action@v5
+  with:
+    files: lcov.info
+    fail_ci_if_error: true
+```
+
+Also upgrade clippy step to catch dead code:
+```yaml
+run: cargo clippy -- -D warnings -D dead_code
+```
+
+Add weekly audit job:
+```yaml
+audit:
+  runs-on: ubuntu-latest
+  if: github.event_name == 'schedule'
+  steps:
+    - uses: actions/checkout@...
+    - run: cargo install cargo-audit && cargo audit
+```
+
+---
+
+## Metrics summary
+
+| Metric | Tool | Integration |
+|---|---|---|
+| Code coverage | cargo-llvm-cov | Codecov, PR diff, badge |
+| Snapshot regressions | insta | Fail on any visual drift |
+| Property violations | proptest | Fail + shrunk counterexample |
+| Security audit | cargo-audit | Weekly cron CI job |
+| Dead code | clippy -D dead_code | Existing CI step upgrade |
+| Build time | swatinem/rust-cache | Already in place |
+
+Codecov thresholds to configure: 70% minimum to not block PRs, target 85%.
+
+---
+
+## Implementation order
+
+| Step | Estimated time |
+|---|---|
+| 1. JSON fixtures | 1-2h |
+| 2. Types deserialization | 2h |
+| 3. Client wiremock | 3-4h |
+| 4. AppState logic | 3h |
+| 5. CI update (nextest + llvm-cov + codecov) | 1h |
+| 6. UI snapshots | 4-5h |
+| 7. Proptest coords | 1h |
+
+**Total: ~2 days for a solid base with green CI.**

--- a/api-specs/v23.yaml
+++ b/api-specs/v23.yaml
@@ -1,0 +1,2570 @@
+openapi: 3.0.3
+info:
+  title: Von Neumann Game API
+  version: '23'
+servers:
+  - url: /
+    description: Current host
+security:
+  - bearerAuth: []
+paths:
+  /api/version:
+    get:
+      security: []
+      summary: Get API version
+      responses:
+        '200':
+          description: Current API version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiVersionResponse'
+              example:
+                apiVersion: 23
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+  /api/session:
+    post:
+      security: []
+      summary: Create a password session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionRequest'
+            example:
+              username: remi
+              password: secret
+      responses:
+        '200':
+          description: Session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionResponse'
+              example:
+                token: eyJlocalExampleToken
+                expiresAt: '2026-05-28T12:00:00+00:00'
+                player:
+                  id: 1
+                  username: remi
+                  displayName: Remi
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+  /api/me:
+    get:
+      summary: Get authenticated player
+      responses:
+        '200':
+          description: Current player
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [player]
+                properties:
+                  player:
+                    $ref: '#/components/schemas/Player'
+              example:
+                player:
+                  id: 1
+                  username: remi
+                  displayName: Remi
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/me/api-key:
+    post:
+      summary: Create an API key for the authenticated player
+      description: >
+        Returns a new API key that can be used as a Bearer token on protected
+        API endpoints. The clear token is shown only in this response; only its
+        hash is stored server-side.
+      responses:
+        '201':
+          description: API key created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyResponse'
+              example:
+                apiKey:
+                  id: 1
+                  token: vng_exampleGeneratedSecret
+                  label: default
+                  lastFour: cret
+                  createdAt: '2026-06-01T12:00:00+00:00'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/crafting-recipes:
+    get:
+      summary: List available crafting recipes
+      responses:
+        '200':
+          description: Available crafting recipes
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [recipes]
+                properties:
+                  recipes:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CraftingRecipe'
+              example:
+                recipes:
+                  - id: waypoint_bookmark
+                    name: Waypoint bookmark
+                    craftableBy: [manny]
+                    ingredients:
+                      - type: metals
+                        quantity: 0.01
+                        unit: earth_container_equivalent
+                    durationSeconds: 600
+                    output:
+                      type: waypoint_bookmark
+                      name: Waypoint bookmark
+                      containerSpace: 0.01
+                      containerSpaceUnit: earth_container_equivalent
+                  - id: integrated_circuit
+                    name: Integrated circuit
+                    craftableBy: [atomic_3d_printer]
+                    ingredients:
+                      - type: micro_conductor
+                        quantity: 2
+                        unit: item
+                      - type: ceramic_insulator
+                        quantity: 2
+                        unit: item
+                      - type: crystal_substrate
+                        quantity: 1
+                        unit: item
+                      - type: dopant_matrix
+                        quantity: 1
+                        unit: item
+                      - type: deuterium
+                        quantity: 0.05
+                        unit: earth_container_equivalent
+                    durationSeconds: 1200
+                    output:
+                      type: integrated_circuit
+                      name: Integrated circuit
+                      containerSpace: 0.001
+                      containerSpaceUnit: earth_container_equivalent
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/probe:
+    get:
+      summary: Get current Neumann probe
+      responses:
+        '200':
+          description: Current probe
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [probe]
+                properties:
+                  probe:
+                    $ref: '#/components/schemas/Probe'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/probe/storage-containers:
+    get:
+      summary: List probe storage containers
+      description: >
+        Returns the probe core storage and each additional container created
+        from an additional_container inventory item. The deuterium tank is not
+        managed here.
+      responses:
+        '200':
+          description: Storage containers
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [containers]
+                properties:
+                  containers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/StorageContainer'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/probe/storage-containers/{containerId}:
+    get:
+      summary: Get one storage container content
+      parameters:
+        - $ref: '#/components/parameters/StorageContainerId'
+      responses:
+        '200':
+          description: Container inventory
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageContainerInventoryResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/probe/storage-containers/{containerId}/rules:
+    patch:
+      summary: Update storage routing rules for a container
+      description: >
+        Priority routes matching new items to this container first unless it is
+        full. Exclusion avoids this container unless no other non-strict
+        container can accept the item. Strict exclusion prevents automatic
+        placement into this container.
+      parameters:
+        - $ref: '#/components/parameters/StorageContainerId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StorageContainerRules'
+            example:
+              priority: [metals]
+              exclusion: [ice]
+              strictExclusion: [manny]
+      responses:
+        '200':
+          description: Rules updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageContainerRulesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/probe/storage-moves:
+    post:
+      summary: Assign a Manny to move stock between containers
+      description: >
+        Starts a moving_stockage task on an idle onboard Manny. Unit items take
+        10 seconds; resources take 10 seconds per 0.05 ECE.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StorageMoveRequest'
+            examples:
+              resource:
+                value:
+                  actorMannyId: mny_actor
+                  kind: resource
+                  resourceType: metals
+                  amount: 0.1
+                  fromContainerId: probe-core
+                  toContainerId: container-itm_extra
+              item:
+                value:
+                  actorMannyId: mny_actor
+                  kind: item
+                  itemIds: [itm_steel_bar, itm_steel_bar_2]
+                  quantity: 2
+                  toContainerId: container-itm_extra
+      responses:
+        '202':
+          description: Storage move task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny, inventory]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+                  inventory:
+                    $ref: '#/components/schemas/ProbeInventory'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Manny unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Move is impossible because of capacity or item rules
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/messages:
+    get:
+      summary: List messages received by the current probe
+      description: >
+        Returns messages where the authenticated player's probe is the
+        recipient. Messages are sorted newest first, include their read
+        status, and are limited to the 50 latest messages by default.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of messages to return. Defaults to 50.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          description: Number of newest messages to skip before returning the page.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Received probe messages
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbeMessagesResponse'
+              example:
+                messages:
+                  - id: 12
+                    sender:
+                      probeId: 2
+                      name: Probe of nova
+                    recipient:
+                      probeId: 1
+                      name: Probe of remi
+                    sector:
+                      relative: { x: 0, y: 0, z: 0 }
+                    body: Signal local reçu.
+                    status: unread
+                    readAt: null
+                    createdAt: '2026-06-06T12:00:00+00:00'
+                    updatedAt: '2026-06-06T12:00:00+00:00'
+                pagination:
+                  limit: 50
+                  offset: 0
+                  count: 1
+                  total: 67
+                  hasMore: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    post:
+      summary: Send a message to another probe in the same sector
+      description: >
+        Creates an unread message for another probe. The recipient probe must
+        currently be in the exact same sector as the sender probe.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProbeMessageSendRequest'
+            example:
+              recipientProbeId: 2
+              body: Signal local reçu ?
+      responses:
+        '201':
+          description: Probe message sent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbeMessageResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Recipient probe is invalid or not in the same sector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/messages/sent:
+    get:
+      summary: List messages sent by the current probe
+      description: >
+        Returns messages where the authenticated player's probe is the sender.
+        Messages are sorted newest first and are limited to the 50 latest
+        messages by default. This endpoint does not expose recipient read
+        state fields.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of messages to return. Defaults to 50.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          description: Number of newest messages to skip before returning the page.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Sent probe messages
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbeSentMessagesResponse'
+              example:
+                messages:
+                  - id: 12
+                    sender:
+                      probeId: 1
+                      name: Probe of remi
+                    recipient:
+                      probeId: 2
+                      name: Probe of nova
+                    sector:
+                      relative: { x: 0, y: 0, z: 0 }
+                    body: Signal local reçu ?
+                    createdAt: '2026-06-06T12:00:00+00:00'
+                pagination:
+                  limit: 50
+                  offset: 0
+                  count: 1
+                  total: 3
+                  hasMore: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /api/probe/messages/{messageId}/read:
+    patch:
+      summary: Mark a received probe message as read
+      description: >
+        Only the recipient probe can mark a message as read. Repeating the call
+        on an already-read message is safe and returns the message unchanged.
+      parameters:
+        - $ref: '#/components/parameters/ProbeMessageId'
+      responses:
+        '200':
+          description: Probe message marked read
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbeMessageResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/probe/visited-sectors:
+    get:
+      summary: List sectors already visited by the current probe
+      description: >
+        Returns the authenticated player's visited-sector history for the
+        current probe. Coordinates are relative to the player's home sector and
+        sorted by most recent visit first.
+      responses:
+        '200':
+          description: Visited sectors for the current probe
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbeVisitedSectorsResponse'
+              example:
+                visitedSectors:
+                  - relativeCoordinates: { x: 0, y: 0, z: 0 }
+                    firstVisitedAt: '2026-06-01T12:00:00+00:00'
+                    lastVisitedAt: '2026-06-01T12:00:00+00:00'
+                    visitCount: 1
+                  - relativeCoordinates: { x: 1, y: 1, z: 0 }
+                    firstVisitedAt: '2026-06-01T13:15:00+00:00'
+                    lastVisitedAt: '2026-06-01T15:45:00+00:00'
+                    visitCount: 2
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/probe/sector:
+    get:
+      summary: Get observable probe sector and onboard inventory
+      responses:
+        '200':
+          description: Current sector summary and probe inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [sector, inventory]
+                properties:
+                  sector:
+                    $ref: '#/components/schemas/SectorObservation'
+                  inventory:
+                    $ref: '#/components/schemas/ProbeInventory'
+              example:
+                sector:
+                  relativeCoordinates: { x: 0, y: 0, z: 0 }
+                  distance: 0
+                  knowledgeLevel: detailed
+                  confidence: 1
+                  objects:
+                    - type: solar_system
+                      name: System abc123
+                      summary: Stellar system with 1 star(s) and 4 orbital body(ies).
+                      radius: 5.4
+                      radiusUnit: astronomical_unit
+                  probes:
+                    - id: 2
+                      name: Probe of nova
+                      moving: false
+                  scan:
+                    currentSectorResidenceSeconds: 42
+                    requiredResidenceSeconds: 0
+                    scanQuality: 1
+                inventory:
+                  capacity: 1
+                  capacityUnit: earth_container_equivalent
+                  usedCapacity: 0.5
+                  freeCapacity: 0.5
+                  items:
+                    - id: probe-1-atomic-3d-printer
+                      type: atomic_3d_printer
+                      name: Imprimante atomique
+                      containerSpace: 0.3
+                      currentTask: null
+                      taskProgressPercent: 0
+                      container:
+                        id: probe-core
+                        kind: probe
+                        label: Sonde
+                        sortOrder: 0
+                    - id: mny_8d4a2c1f5a91b334
+                      type: manny
+                      name: manny-1
+                      containerSpace: 0.05
+                      currentTask: null
+                      taskProgressPercent: 0
+                      location:
+                        type: probe
+                      cargo:
+                        capacity: 0.05
+                        deuterium: 0
+                        metals: 0
+                        ice: 0
+                        organicCompounds: 0
+                        capacityUnit: earth_container_equivalent
+                      container:
+                        id: probe-core
+                        kind: probe
+                        label: Sonde
+                        sortOrder: 0
+                  resourceStocks:
+                    - id: probe-1-stock-metals
+                      type: metals
+                      name: Métaux
+                      amount: 0
+                      containerSpace: 0
+                      capacityUnit: earth_container_equivalent
+                      containers: []
+                    - id: probe-1-stock-ice
+                      type: ice
+                      name: Glace
+                      amount: 0
+                      containerSpace: 0
+                      capacityUnit: earth_container_equivalent
+                      containers: []
+                    - id: probe-1-stock-organic-compounds
+                      type: carbon_compounds
+                      name: Composés organiques
+                      amount: 0
+                      containerSpace: 0
+                      capacityUnit: earth_container_equivalent
+                      containers: []
+                  containers:
+                    - id: probe-core
+                      kind: probe
+                      label: Sonde
+                      sortOrder: 0
+                      capacity: 1
+                      usedCapacity: 0.5
+                      freeCapacity: 0.5
+                      capacityUnit: earth_container_equivalent
+                      rules:
+                        priority: []
+                        exclusion: []
+                        strictExclusion: []
+                  externalTanks:
+                    - id: probe-1-deuterium-tank
+                      type: deuterium
+                      name: Cuve externe de deutérium
+                      fillPercent: 100
+                      external: true
+                      usesCargoCapacity: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Probe is dead
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '400':
+          description: Sensors unavailable while cruising
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: sensors_unavailable
+                  message: External sensors are unavailable at current relativistic velocity.
+  /api/probe/move:
+    post:
+      summary: Start an asynchronous intersector movement
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProbeMoveRequest'
+            example:
+              target: { x: 1, y: 1, z: 0 }
+      responses:
+        '202':
+          description: Movement accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [movement]
+                properties:
+                  movement:
+                    $ref: '#/components/schemas/ProbeMovement'
+              example:
+                movement:
+                  status: preparing
+                  origin: { x: 0, y: 0, z: 0 }
+                  target: { x: 1, y: 1, z: 0 }
+                  distance: 1
+                  fuelCostDeuterium: 2
+                  startedAt: '2026-05-28T12:00:00+00:00'
+                  arrivalAt: '2026-05-28T12:40:00+00:00'
+                  phase: preparing
+                  secondsRemaining: 2400
+                  sensorMode: normal
+                  estimatedVelocityC: 0
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Probe is already moving or dead
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                moving:
+                  value:
+                    error:
+                      code: probe_already_moving
+                      message: The probe is already moving between sectors.
+                dead:
+                  value:
+                    error:
+                      code: probe_dead
+                      message: The probe is no longer operational.
+        '422':
+          description: Insufficient deuterium
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: insufficient_fuel
+                  message: Insufficient deuterium for movement.
+  /api/probe/inventory/{itemId}:
+    get:
+      summary: Get task state for an onboard inventory item
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: string
+          example: mny_8d4a2c1f5a91b334
+      responses:
+        '200':
+          description: Inventory item task state
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [item]
+                properties:
+                  item:
+                    $ref: '#/components/schemas/ProbeInventoryItemTask'
+              example:
+                item:
+                  id: mny_8d4a2c1f5a91b334
+                  type: manny
+                  name: manny-1
+                  currentTask: null
+                  taskProgressPercent: 0
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/probe/inventory/{itemId}/jettison:
+    post:
+      summary: Jettison an inventory entry into space
+      description: >
+        Discards stored metals/non-metal materials by amount, ejects an idle onboard Manny
+        into the current sector, or adds supported crafted items to an aggregated
+        drifting-item stack in the current sector. Non-persisted core equipment
+        and additional containers cannot be jettisoned. The external deuterium
+        tank is not jettisonable.
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            metals:
+              value: probe-1-stock-metals
+            manny:
+              value: mny_8d4a2c1f5a91b334
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProbeInventoryJettisonRequest'
+            examples:
+              partialStock:
+                value:
+                  amount: 0.05
+                  containerId: probe-core
+              wholeItem:
+                value: {}
+      responses:
+        '200':
+          description: Inventory entry jettisoned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProbeInventoryJettisonResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: The requested Manny cannot be ejected now
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Entry cannot be jettisoned or requested amount is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies:
+    get:
+      summary: List persisted Manny robots for the current probe
+      responses:
+        '200':
+          description: Manny robots
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [mannies]
+                properties:
+                  mannies:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Manny'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/probe/mannies/{mannyId}:
+    patch:
+      summary: Rename a Manny robot
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyRenameRequest'
+            example:
+              name: atelier
+      responses:
+        '200':
+          description: Manny renamed
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Duplicate Manny name
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/repair:
+    post:
+      summary: Start restoring probe integrity with a Manny
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyRepairRequest'
+            example:
+              integrityPercent: 2
+      responses:
+        '202':
+          description: Repair task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Manny unavailable or probe cannot be repaired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Insufficient metals
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/mine:
+    post:
+      summary: Start mining a small body with a Manny
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyMineRequest'
+            example:
+              objectId: mine-rock
+              resources: [metals, ice, carbon_compounds]
+              targetAmount: 0.05
+      responses:
+        '202':
+          description: Mining task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Manny unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Invalid target, unavailable resource, or insufficient cargo capacity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/craft:
+    post:
+      summary: Start crafting a Manny-built inventory item
+      description: Atomic-printer recipes must be started through `/api/probe/atomic-printer/craft`; that endpoint reserves an available Manny as printer assistant.
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyCraftRequest'
+            example:
+              recipe: waypoint_bookmark
+      responses:
+        '202':
+          description: Crafting task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Manny unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Insufficient resources, ingredients, or cargo capacity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/atomic-printer/craft:
+    post:
+      summary: Start crafting an atomic-printer item
+      description: >
+        Starts a recipe whose `craftableBy` includes `atomic_3d_printer`.
+        The atomic printer reserves one available Manny aboard the probe for
+        loading and unloading; that Manny exposes the
+        `assisting_atomic_printer` task until the craft completes or is
+        recalled.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AtomicPrinterCraftRequest'
+            example:
+              recipe: integrated_circuit
+      responses:
+        '202':
+          description: Atomic-printer crafting task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny, inventory]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+                  inventory:
+                    $ref: '#/components/schemas/ProbeInventory'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Atomic printer busy or no Manny available to assist it
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Insufficient resources, ingredients, or cargo capacity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/salvage:
+    post:
+      summary: Recover a drifting sector object with a Manny
+      description: >
+        Starts a five-minute recovery task. The target is checked again when
+        the delay ends; if another player has already recovered it, the task
+        completes with a failed result and no object is transferred.
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannySalvageRequest'
+            example:
+              objectId: manny-mny_abandoned
+      responses:
+        '202':
+          description: Recovery task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Manny unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Object is not recoverable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/detach-storage-container:
+    post:
+      summary: Detach an additional storage container
+      description: >
+        Starts a detaching_storage_container task on an idle onboard Manny.
+        The target must be an additional storage container, never probe-core.
+        The container, its stored resources/items, and routing rules are
+        removed from the probe inventory when the order is accepted. On
+        completion it becomes either a visible drifting detached container or a
+        hidden container attached to an asteroid.
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyDetachStorageContainerRequest'
+            examples:
+              drifting:
+                value:
+                  containerId: container-itm_extra
+                  mode: drifting
+              hidden:
+                value:
+                  containerId: container-itm_extra
+                  mode: hidden_on_asteroid
+                  objectId: asteroid-abc123
+      responses:
+        '202':
+          description: Detach task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Manny unavailable, probe moving, or probe no longer operational
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Container or asteroid target is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/inspect-asteroid:
+    post:
+      summary: Inspect an asteroid with a Manny
+      description: >
+        Sends a Manny to an asteroid and back without mining. If the asteroid
+        has a hidden detached storage container, the Manny task includes
+        artificialObjectDetected with the detached object id, but not the
+        container contents.
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyInspectAsteroidRequest'
+            example:
+              objectId: asteroid-abc123
+      responses:
+        '202':
+          description: Inspection task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Manny unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Target is not an asteroid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/recover-storage-container:
+    post:
+      summary: Recover a detached storage container
+      description: >
+        Starts a salvage-duration recovery task for a detached storage
+        container. Drifting containers can also be recovered through the
+        salvage endpoint. Hidden containers are recovered by the object id
+        returned from mining or inspect-asteroid detection.
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyRecoverStorageContainerRequest'
+            example:
+              objectId: detached-container-container-itm_extra
+              source: asteroid
+      responses:
+        '202':
+          description: Recovery task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Detached container not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Manny unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Detached container cannot be recovered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/install-bookmark:
+    post:
+      summary: Start installing a waypoint bookmark with a Manny
+      description: >
+        Assigns an idle onboard Manny to install one stocked waypoint bookmark
+        on a current-sector celestial object. The Manny consumes one bookmark
+        item when the order is accepted, spends 10 seconds giving it the needed
+        impulse, then the normal waypoint bookmark persistence is applied to the
+        target object.
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MannyWaypointBookmarkInstallRequest'
+            example:
+              objectId: asteroid-abc123
+              name: North ice marker
+      responses:
+        '202':
+          description: Bookmark installation task accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Manny, bookmark item, or target object not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Manny unavailable, probe already moving, or probe no longer operational
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Target is not a celestial object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/probe/mannies/{mannyId}/recall:
+    post:
+      summary: Recall an exterior Manny to the probe
+      parameters:
+        - $ref: '#/components/parameters/MannyId'
+      responses:
+        '202':
+          description: Recall accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [manny]
+                properties:
+                  manny:
+                    $ref: '#/components/schemas/Manny'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Manny is outside the probe current sector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/sector:
+    get:
+      summary: Observe a sector by player-relative coordinates
+      description: >
+        Coordinates are relative to the authenticated player's reference frame.
+        Absolute sector coordinates are never exposed. Detail depends on whether
+        the sector is current, visited, or only passively scanned from the probe
+        current sector. During blind cruise, only already visited sectors can be
+        consulted as historical cartography.
+      parameters:
+        - name: x
+          in: query
+          required: true
+          schema:
+            type: integer
+          example: 1
+        - name: y
+          in: query
+          required: true
+          schema:
+            type: integer
+          example: 1
+        - name: z
+          in: query
+          required: true
+          schema:
+            type: integer
+          example: 0
+      responses:
+        '200':
+          description: Sector observation
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [sector]
+                properties:
+                  sector:
+                    $ref: '#/components/schemas/SectorObservation'
+              examples:
+                detailed:
+                  value:
+                    sector:
+                      relativeCoordinates: { x: 0, y: 0, z: 0 }
+                      distance: 0
+                      knowledgeLevel: detailed
+                      confidence: 1
+                      objects:
+                        - type: solar_system
+                          name: System abc123
+                          estimated: false
+                          summary: Stellar system with 1 star(s) and 4 orbital body(ies).
+                          radius: 5.4
+                          radiusUnit: astronomical_unit
+                          dangerLevel: low
+                      scan:
+                        currentSectorResidenceSeconds: 42
+                        requiredResidenceSeconds: 0
+                        scanQuality: 1
+                neighborScan:
+                  value:
+                    sector:
+                      relativeCoordinates: { x: 1, y: 1, z: 0 }
+                      distance: 1
+                      knowledgeLevel: neighbor_scan
+                      confidence: 0.82
+                      estimatedObjects:
+                        star: true
+                        planetCountMin: 3
+                        planetCountMax: 7
+                        blackHoleProbability: 0.01
+                        dangerEstimate: low
+                        signalAge: recent
+                      scan:
+                        currentSectorResidenceSeconds: 1832
+                        requiredResidenceSeconds: 300
+                        scanQuality: 1
+                distantScan:
+                  value:
+                    sector:
+                      relativeCoordinates: { x: 2, y: 0, z: 0 }
+                      distance: 2
+                      knowledgeLevel: distant_scan
+                      confidence: 0.41
+                      possibleObjects: [stellar_mass_detected, dust_cloud_possible]
+                      dangerEstimate: moderate
+                      scan:
+                        currentSectorResidenceSeconds: 3600
+                        requiredResidenceSeconds: 1800
+                        scanQuality: 0.5
+                longRange:
+                  value:
+                    sector:
+                      relativeCoordinates: { x: 3, y: 3, z: 0 }
+                      distance: 3
+                      knowledgeLevel: long_range_estimation
+                      confidence: 0.12
+                      navigationalRisk: high
+                      message: Insufficient sensor accuracy.
+                      scan:
+                        currentSectorResidenceSeconds: 28800
+                        requiredResidenceSeconds: 7200
+                        scanQuality: 1
+        '400':
+          description: Bad request or insufficient scan data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidCoordinates:
+                  value:
+                    error:
+                      code: bad_request
+                      message: 'Invalid coordinates (1, 0, 0): sum must be even (got 1)'
+                insufficientScanData:
+                  value:
+                    error:
+                      code: insufficient_scan_data
+                      message: Too little passive scan data available to estimate nearby objects.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Probe is dead
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Use a session token from /api/session or an API key generated from /api/me/api-key.
+  parameters:
+    MannyId:
+      name: mannyId
+      in: path
+      required: true
+      schema:
+        type: string
+      example: mny_8d4a2c1f5a91b334
+    StorageContainerId:
+      name: containerId
+      in: path
+      required: true
+      schema:
+        type: string
+      example: probe-core
+    ProbeMessageId:
+      name: messageId
+      in: path
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+      example: 12
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error:
+              code: unauthorized
+              message: Missing or invalid bearer token
+    MethodNotAllowed:
+      description: Method not allowed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              enum: [bad_request, unauthorized, not_found, method_not_allowed, insufficient_scan_data, sensors_unavailable, probe_already_moving, probe_dead, probe_trapped_by_black_hole, insufficient_fuel, same_destination, manny_not_found, duplicate_manny_name, manny_busy, manny_out_of_range, manny_not_on_probe, probe_integrity_full, insufficient_metals, insufficient_ice, insufficient_carbon_compounds, insufficient_deuterium, insufficient_crafting_ingredients, invalid_recipe, atomic_printer_busy, no_available_manny, invalid_mining_target, invalid_salvage_target, invalid_storage_container, storage_container_not_detachable, invalid_asteroid_target, detached_container_not_found, detached_container_not_recoverable, resource_unavailable, insufficient_target_resources, insufficient_cargo_capacity, item_not_jettisonable, item_not_movable, invalid_storage_move, storage_container_not_found, nothing_to_jettison, insufficient_inventory_amount, waypoint_bookmark_not_found, bookmark_target_not_found, invalid_bookmark_target, invalid_message_recipient, probe_not_in_same_sector, internal_error]
+            message:
+              type: string
+    ApiVersionResponse:
+      type: object
+      required: [apiVersion]
+      properties:
+        apiVersion:
+          type: integer
+          minimum: 1
+          description: Monotonic public API version. Increment it when the API contract changes.
+    SessionRequest:
+      type: object
+      required: [username, password]
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+          format: password
+    SessionResponse:
+      type: object
+      required: [token, expiresAt, player]
+      properties:
+        token:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+        player:
+          $ref: '#/components/schemas/Player'
+    Player:
+      type: object
+      required: [id, username]
+      properties:
+        id:
+          type: integer
+        username:
+          type: string
+        displayName:
+          type: string
+          nullable: true
+    ApiKeyResponse:
+      type: object
+      required: [apiKey]
+      properties:
+        apiKey:
+          $ref: '#/components/schemas/ApiKey'
+    ApiKey:
+      type: object
+      required: [id, token, label, lastFour, createdAt]
+      properties:
+        id:
+          type: integer
+        token:
+          type: string
+          description: Clear API key shown only once. Use it as the Bearer token.
+        label:
+          type: string
+        lastFour:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    CraftingRecipe:
+      type: object
+      required: [id, name, craftableBy, ingredients, durationSeconds, output]
+      properties:
+        id:
+          type: string
+          enum: [waypoint_bookmark, steel_bar, steel_plate, additional_container, micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+        name:
+          type: string
+        craftableBy:
+          type: array
+          description: Inventory item types that can start this recipe.
+          items:
+            type: string
+            enum: [manny, atomic_3d_printer]
+        ingredients:
+          type: array
+          items:
+            $ref: '#/components/schemas/CraftingRecipeIngredient'
+        durationSeconds:
+          type: integer
+          minimum: 0
+          description: Real seconds needed to complete the crafting task.
+        output:
+          $ref: '#/components/schemas/CraftingRecipeOutput'
+    CraftingRecipeIngredient:
+      type: object
+      required: [type, quantity, unit]
+      properties:
+        type:
+          type: string
+          enum: [deuterium, metals, ice, carbon_compounds, steel_bar, steel_plate, micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+        quantity:
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+        unit:
+          type: string
+          enum: [earth_container_equivalent, item]
+        kind:
+          type: string
+          enum: [resource, item]
+    CraftingRecipeOutput:
+      type: object
+      required: [type, name, containerSpace, containerSpaceUnit]
+      properties:
+        type:
+          type: string
+          enum: [waypoint_bookmark, steel_bar, steel_plate, additional_container, micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+        name:
+          type: string
+        containerSpace:
+          type: number
+          minimum: 0
+        containerSpaceUnit:
+          type: string
+          enum: [earth_container_equivalent]
+        capacityBonus:
+          type: number
+          minimum: 0
+          description: Present on additional_container; each one creates one storage container.
+        capacityBonusUnit:
+          type: string
+          enum: [earth_container_equivalent]
+    Vector:
+      type: object
+      required: [x, y, z]
+      properties:
+        x: { type: number }
+        y: { type: number }
+        z: { type: number }
+    ProbeMoveRequest:
+      type: object
+      required: [target]
+      properties:
+        target:
+          $ref: '#/components/schemas/Vector'
+    ProbeVisitedSectorsResponse:
+      type: object
+      required: [visitedSectors]
+      properties:
+        visitedSectors:
+          type: array
+          items:
+            $ref: '#/components/schemas/VisitedSector'
+    VisitedSector:
+      type: object
+      required: [relativeCoordinates, firstVisitedAt, lastVisitedAt, visitCount]
+      properties:
+        relativeCoordinates:
+          $ref: '#/components/schemas/Vector'
+        firstVisitedAt:
+          type: string
+          format: date-time
+        lastVisitedAt:
+          type: string
+          format: date-time
+        visitCount:
+          type: integer
+          minimum: 1
+    ProbeMovement:
+      type: object
+      required: [status, origin, target, distance, fuelCostDeuterium, startedAt, arrivalAt]
+      properties:
+        status:
+          type: string
+          enum: [preparing, accelerating, cruising, decelerating, arrived, failed, destroyed]
+        origin:
+          $ref: '#/components/schemas/Vector'
+        target:
+          $ref: '#/components/schemas/Vector'
+        distance:
+          type: integer
+        fuelCostDeuterium:
+          type: number
+        startedAt:
+          type: string
+          format: date-time
+        arrivalAt:
+          type: string
+          format: date-time
+        phase:
+          type: string
+          enum: [idle, preparing, accelerating, cruising, decelerating, arrived, failed, destroyed]
+        secondsRemaining:
+          type: integer
+        sensorMode:
+          type: string
+          enum: [normal, degraded, blind]
+        estimatedVelocityC:
+          type: number
+    Probe:
+      type: object
+      required: [id, name, status, fuel, sensorMode, movement, inventory]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        status:
+          type: string
+          enum: [idle, preparing, accelerating, cruising, decelerating, orbiting, disabled, dead]
+        fuel:
+          type: object
+          properties:
+            deuterium:
+              type: number
+        sensorMode:
+          type: string
+          enum: [normal, degraded, blind]
+        sector:
+          type: object
+          nullable: true
+          properties:
+            relative:
+              $ref: '#/components/schemas/Vector'
+        movement:
+          nullable: true
+          $ref: '#/components/schemas/ProbeMovement'
+        navigation:
+          type: object
+          properties:
+            velocityC: { type: number }
+            accelerationCPerDay: { type: number }
+            direction:
+              $ref: '#/components/schemas/Vector'
+        systems:
+          type: object
+          properties:
+            integrityPercent:
+              type: number
+              minimum: 0
+              maximum: 100
+            energyStored:
+              type: number
+            internalClockRate:
+              type: number
+            currentTask:
+              type: string
+              nullable: true
+        inventory:
+          $ref: '#/components/schemas/ProbeInventory'
+    StorageContainer:
+      type: object
+      required: [id, kind, label, sortOrder, capacity, usedCapacity, freeCapacity, capacityUnit, rules]
+      properties:
+        id:
+          type: string
+          description: Stable storage container uid. probe-core is the probe hull.
+          example: probe-core
+        kind:
+          type: string
+          enum: [probe, container]
+        label:
+          type: string
+          example: Sonde
+        sortOrder:
+          type: integer
+        capacity:
+          type: number
+          example: 1
+        usedCapacity:
+          type: number
+        freeCapacity:
+          type: number
+        capacityUnit:
+          type: string
+          enum: [earth_container_equivalent]
+        rules:
+          $ref: '#/components/schemas/StorageContainerRules'
+    StorageContainerSummary:
+      type: object
+      required: [id, kind, label, sortOrder]
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+          enum: [probe, container]
+        label:
+          type: string
+        sortOrder:
+          type: integer
+    StorageContainerRules:
+      type: object
+      properties:
+        priority:
+          type: array
+          items:
+            type: string
+          description: Item/resource types routed here first when new stock arrives.
+        exclusion:
+          type: array
+          items:
+            type: string
+          description: Item/resource types routed here only if no regular destination has room.
+        strictExclusion:
+          type: array
+          items:
+            type: string
+          description: Item/resource types never automatically routed here.
+    StorageContainerRulesResponse:
+      type: object
+      required: [container, inventory]
+      properties:
+        container:
+          $ref: '#/components/schemas/StorageContainer'
+        inventory:
+          $ref: '#/components/schemas/ProbeInventory'
+    StorageContainerInventoryResponse:
+      type: object
+      required: [container, inventory]
+      properties:
+        container:
+          $ref: '#/components/schemas/StorageContainer'
+        inventory:
+          type: object
+          required: [capacityUnit, items, resourceStocks]
+          properties:
+            capacityUnit:
+              type: string
+              enum: [earth_container_equivalent]
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProbeInventoryItem'
+            resourceStocks:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProbeResourceStock'
+    StorageMoveRequest:
+      type: object
+      required: [actorMannyId, kind, toContainerId]
+      properties:
+        actorMannyId:
+          type: string
+          description: Idle onboard Manny that will perform the move.
+        kind:
+          type: string
+          enum: [resource, item, manny]
+        toContainerId:
+          type: string
+        fromContainerId:
+          type: string
+          description: Required for resource moves.
+        resourceType:
+          type: string
+          enum: [metals, ice, carbon_compounds]
+        amount:
+          type: number
+          description: Required for resource moves, in ECE.
+        itemId:
+          type: string
+          description: Single item id for item moves. Use itemIds for batch moves.
+        itemIds:
+          type: array
+          description: Multiple item ids for batch item moves.
+          items:
+            type: string
+        targetMannyId:
+          type: string
+          description: Single Manny id for Manny moves. Use targetMannyIds for batch moves.
+        targetMannyIds:
+          type: array
+          description: Multiple Manny ids for batch Manny storage moves.
+          items:
+            type: string
+        quantity:
+          type: integer
+          minimum: 1
+          description: Optional cap applied to itemIds or targetMannyIds.
+    ProbeMessageSendRequest:
+      type: object
+      required: [recipientProbeId, body]
+      properties:
+        recipientProbeId:
+          type: integer
+          minimum: 1
+          description: Probe id of another probe currently in the same sector.
+        body:
+          type: string
+          minLength: 1
+          maxLength: 2000
+    ProbeMessageResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          $ref: '#/components/schemas/ProbeMessage'
+    ProbeMessagesResponse:
+      type: object
+      required: [messages, pagination]
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProbeMessage'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+    ProbeSentMessagesResponse:
+      type: object
+      required: [messages, pagination]
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProbeSentMessage'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+    Pagination:
+      type: object
+      required: [limit, offset, count, total, hasMore]
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+        offset:
+          type: integer
+          minimum: 0
+        count:
+          type: integer
+          minimum: 0
+        total:
+          type: integer
+          minimum: 0
+        hasMore:
+          type: boolean
+    ProbeMessage:
+      type: object
+      required: [id, sender, recipient, sector, body, status, readAt, createdAt, updatedAt]
+      properties:
+        id:
+          type: integer
+        sender:
+          $ref: '#/components/schemas/ProbeMessageEndpoint'
+        recipient:
+          $ref: '#/components/schemas/ProbeMessageEndpoint'
+        sector:
+          type: object
+          required: [relative]
+          properties:
+            relative:
+              $ref: '#/components/schemas/Vector'
+        body:
+          type: string
+        status:
+          type: string
+          enum: [unread, read]
+        readAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ProbeSentMessage:
+      type: object
+      required: [id, sender, recipient, sector, body, createdAt]
+      properties:
+        id:
+          type: integer
+        sender:
+          $ref: '#/components/schemas/ProbeMessageEndpoint'
+        recipient:
+          $ref: '#/components/schemas/ProbeMessageEndpoint'
+        sector:
+          type: object
+          required: [relative]
+          properties:
+            relative:
+              $ref: '#/components/schemas/Vector'
+        body:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    ProbeMessageEndpoint:
+      type: object
+      required: [probeId, name]
+      properties:
+        probeId:
+          type: integer
+        name:
+          type: string
+    ProbeInventory:
+      type: object
+      required: [capacity, capacityUnit, usedCapacity, freeCapacity, items, resourceStocks, containers, externalTanks]
+      properties:
+        capacity:
+          type: number
+          description: Maximum transport capacity in equivalent earth containers.
+          example: 1
+        capacityUnit:
+          type: string
+          enum: [earth_container_equivalent]
+        usedCapacity:
+          type: number
+          example: 0.5
+        freeCapacity:
+          type: number
+          example: 0.5
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProbeInventoryItem'
+        resourceStocks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProbeResourceStock'
+        containers:
+          type: array
+          description: Probe core and additional storage containers, including their routing rules.
+          items:
+            $ref: '#/components/schemas/StorageContainer'
+        externalTanks:
+          type: array
+          description: Special external tanks that do not consume cargo capacity.
+          items:
+            $ref: '#/components/schemas/ProbeExternalTank'
+    ProbeResourceStock:
+      type: object
+      required: [id, type, name, amount, containerSpace, capacityUnit, containers]
+      properties:
+        id:
+          type: string
+          description: Stable inventory id used for jettison orders.
+          example: probe-1-stock-metals
+        type:
+          type: string
+          enum: [metals, ice, carbon_compounds]
+        name:
+          type: string
+        amount:
+          type: number
+          description: Stored amount in equivalent earth containers.
+        containerSpace:
+          type: number
+        capacityUnit:
+          type: string
+          enum: [earth_container_equivalent]
+        containers:
+          type: array
+          description: Per-container placement lines for this resource stock.
+          items:
+            type: object
+            required: [container, amount, containerSpace, capacityUnit]
+            properties:
+              container:
+                $ref: '#/components/schemas/StorageContainerSummary'
+              amount:
+                type: number
+              containerSpace:
+                type: number
+              capacityUnit:
+                type: string
+                enum: [earth_container_equivalent]
+    ProbeExternalTank:
+      type: object
+      required: [id, type, name, fillPercent, external, usesCargoCapacity]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [deuterium]
+        name:
+          type: string
+        fillPercent:
+          type: number
+          minimum: 0
+          maximum: 100
+        external:
+          type: boolean
+          enum: [true]
+        usesCargoCapacity:
+          type: boolean
+          enum: [false]
+    ProbeInventoryJettisonRequest:
+      type: object
+      properties:
+        amount:
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+          description: >
+            Amount to discard. For stored metals/non-metal materials this uses
+            equivalent earth containers; for the deuterium tank this uses tank
+            percentage points. Omit it to discard the full selected stock.
+        containerId:
+          type: string
+          description: Optional source container id for stored resource jettison.
+    ProbeInventoryJettisonResponse:
+      type: object
+      required: [inventory]
+      properties:
+        inventory:
+          $ref: '#/components/schemas/ProbeInventory'
+        jettisoned:
+          type: object
+          nullable: true
+          properties:
+            type:
+              type: string
+              enum: [deuterium, metals, ice, carbon_compounds, waypoint_bookmark, steel_bar, steel_plate, micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+            amount:
+              type: number
+              description: Present for discarded resources and deuterium.
+            quantity:
+              type: integer
+              description: Present for crafted items added to a drifting sector stack.
+            driftingQuantity:
+              type: integer
+              description: Total quantity of this crafted item type now drifting in the current sector.
+            objectId:
+              type: string
+              description: Current-sector drifting item object id for crafted item jettison.
+            containerSpace:
+              type: number
+        manny:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/Manny'
+    MannyWaypointBookmarkInstallRequest:
+      type: object
+      required: [objectId, name]
+      properties:
+        objectId:
+          type: string
+          description: Celestial object id in the probe current sector. Solar-system orbital bodies can be targeted by their object id.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 80
+          description: Player-facing name to assign to the target object.
+    ProbeInventoryItem:
+      type: object
+      required: [id, type, name, containerSpace, currentTask, taskProgressPercent]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [atomic_3d_printer, manny, waypoint_bookmark, steel_bar, steel_plate, additional_container, micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+        name:
+          type: string
+        containerSpace:
+          type: number
+          description: Space occupied in equivalent earth containers.
+        currentTask:
+          type: string
+          nullable: true
+        taskProgressPercent:
+          type: number
+          minimum: 0
+          maximum: 100
+        location:
+          $ref: '#/components/schemas/MannyLocation'
+        cargo:
+          $ref: '#/components/schemas/MannyCargo'
+        container:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/StorageContainerSummary'
+        metadata:
+          type: object
+          additionalProperties: true
+    ProbeInventoryItemTask:
+      type: object
+      required: [id, type, name, currentTask, taskProgressPercent]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [atomic_3d_printer, manny, waypoint_bookmark, steel_bar, steel_plate, additional_container, micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+        name:
+          type: string
+        currentTask:
+          type: string
+          nullable: true
+        taskProgressPercent:
+          type: number
+          minimum: 0
+          maximum: 100
+        location:
+          $ref: '#/components/schemas/MannyLocation'
+        cargo:
+          $ref: '#/components/schemas/MannyCargo'
+        container:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/StorageContainerSummary'
+        metadata:
+          type: object
+          additionalProperties: true
+    MannyRenameRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 40
+    MannyRepairRequest:
+      type: object
+      required: [integrityPercent]
+      properties:
+        integrityPercent:
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+          maximum: 100
+          description: Integrity percentage to restore. Each percent takes 10 real minutes and consumes 0.01 containers of metals.
+        percent:
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+          maximum: 100
+          deprecated: true
+          description: Legacy alias for integrityPercent.
+    MannyMineRequest:
+      type: object
+      required: [objectId, targetAmount]
+      oneOf:
+        - required: [objectId, resources, targetAmount]
+        - required: [objectId, resource, targetAmount]
+      properties:
+        objectId:
+          type: string
+        resources:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            enum: [deuterium, metals, ice, carbon_compounds]
+          description: Resource categories to mine. The extracted amount is split according to the target object's composition, normalized over the selected categories.
+        resource:
+          type: string
+          enum: [deuterium, metals, ice, carbon_compounds]
+          deprecated: true
+          description: Legacy single resource selector. Prefer resources.
+        targetAmount:
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+          description: Amount to mine in equivalent earth containers. Manny cargo capacity is 0.05 per trip.
+    MannyCraftRequest:
+      type: object
+      required: [recipe]
+      properties:
+        recipe:
+          type: string
+          enum: [waypoint_bookmark, steel_bar, steel_plate, additional_container]
+          description: >
+            Crafting recipe to start. Manny craftable items can be jettisoned
+            later, except additional containers whose jettison mechanic is
+            reserved for a later rule.
+    AtomicPrinterCraftRequest:
+      type: object
+      required: [recipe]
+      properties:
+        recipe:
+          type: string
+          enum: [micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+          description: Atomic-printer recipe to start. An available Manny aboard the probe is automatically reserved as assistant.
+    MannySalvageRequest:
+      type: object
+      required: [objectId]
+      properties:
+        objectId:
+          type: string
+          description: >
+            Current-sector object id to recover. Abandoned Manny objects and
+            drifting crafted-item stacks are recoverable. Visible detached
+            storage containers are also recoverable and keep their hidden
+            contents out of sector observations. For item stacks, a Manny
+            reserves at most one cargo trip of items.
+    MannyDetachStorageContainerRequest:
+      type: object
+      required: [containerId, mode]
+      properties:
+        containerId:
+          type: string
+          description: Additional storage container id. probe-core is not detachable.
+          example: container-itm_extra
+        mode:
+          type: string
+          enum: [drifting, hidden_on_asteroid]
+        objectId:
+          type: string
+          description: Required when mode is hidden_on_asteroid; must be an asteroid id in the current sector.
+    MannyInspectAsteroidRequest:
+      type: object
+      required: [objectId]
+      properties:
+        objectId:
+          type: string
+          description: Current-sector asteroid id to inspect.
+    MannyRecoverStorageContainerRequest:
+      type: object
+      required: [objectId]
+      properties:
+        objectId:
+          type: string
+          description: Detached container object id returned by observation or hidden-object detection.
+        source:
+          type: string
+          enum: [drifting, asteroid]
+          description: Optional hint for clients; recovery is resolved by objectId.
+    ArtificialObjectDetection:
+      type: object
+      required: [type, detection]
+      properties:
+        type:
+          type: string
+          enum: [detached_storage_container]
+        detection:
+          type: string
+          enum: [hidden_on_asteroid]
+        objectId:
+          type: string
+          description: Recoverable detached container id when detection yields one.
+    Manny:
+      type: object
+      required: [id, name, location, currentTask, taskProgressPercent, taskEstimatedEndTime, task, cargo, canReceiveOrders]
+      properties:
+        id:
+          type: string
+          description: Stable generated Manny uid used by API calls.
+          example: mny_8d4a2c1f5a91b334
+        name:
+          type: string
+          example: manny-1
+        location:
+          $ref: '#/components/schemas/MannyLocation'
+        currentTask:
+          type: string
+          nullable: true
+          enum: [repair, mining, crafting, assisting_atomic_printer, salvage, installing_waypoint_bookmark, detaching_storage_container, inspecting_asteroid, returning, waiting_for_space, moving_stockage]
+        taskProgressPercent:
+          type: number
+          minimum: 0
+          maximum: 100
+        taskEstimatedEndTime:
+          type: string
+          format: date-time
+          nullable: true
+          description: Estimated ISO-8601 completion time for the current task, or null when idle.
+        task:
+          type: object
+          additionalProperties: true
+        cargo:
+          $ref: '#/components/schemas/MannyCargo'
+        canReceiveOrders:
+          type: boolean
+    MannyLocation:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum: [probe, sector]
+        sector:
+          type: object
+          nullable: true
+          properties:
+            relative:
+              $ref: '#/components/schemas/Vector'
+    MannyCargo:
+      type: object
+      required: [capacity, deuterium, metals, ice, organicCompounds, capacityUnit]
+      properties:
+        capacity:
+          type: number
+          example: 0.05
+        deuterium:
+          type: number
+        metals:
+          type: number
+        ice:
+          type: number
+        organicCompounds:
+          type: number
+        capacityUnit:
+          type: string
+          enum: [earth_container_equivalent]
+    SectorSummary:
+      type: object
+      required: [coordinates, objects]
+      properties:
+        coordinates:
+          type: object
+          properties:
+            relative:
+              $ref: '#/components/schemas/Vector'
+        objects:
+          type: array
+          description: Detailed current or visited sector objects. Abandoned or forgotten Manny objects are included only when the observed sector is the probe current sector.
+          items:
+            $ref: '#/components/schemas/SectorObject'
+    SectorObservation:
+      type: object
+      required: [relativeCoordinates, distance, knowledgeLevel, confidence, scan]
+      properties:
+        relativeCoordinates:
+          $ref: '#/components/schemas/Vector'
+        distance:
+          type: integer
+        knowledgeLevel:
+          type: string
+          enum: [detailed, neighbor_scan, distant_scan, long_range_estimation]
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        objects:
+          type: array
+          description: Detailed current or visited sector objects. Abandoned or forgotten Manny objects are included only when the observed sector is the probe current sector.
+          items:
+            $ref: '#/components/schemas/SectorObject'
+        probes:
+          type: array
+          description: Other probes detected in the current sector. Present only on current-sector observations when at least one other probe is detected.
+          items:
+            $ref: '#/components/schemas/SectorProbePresence'
+        estimatedObjects:
+          type: object
+          additionalProperties: true
+        possibleObjects:
+          type: array
+          items:
+            type: string
+        navigationalRisk:
+          type: string
+        message:
+          type: string
+        sensorMode:
+          type: string
+          enum: [normal, degraded, blind]
+        dataFreshness:
+          type: string
+          enum: [live, degraded_live, historical, unavailable]
+        scan:
+          type: object
+          required: [currentSectorResidenceSeconds, requiredResidenceSeconds, scanQuality]
+          properties:
+            currentSectorResidenceSeconds:
+              type: integer
+            requiredResidenceSeconds:
+              type: integer
+            scanQuality:
+              type: number
+              minimum: 0
+              maximum: 1
+    SectorProbePresence:
+      type: object
+      required: [id, name, moving]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        moving:
+          type: boolean
+    SectorObject:
+      type: object
+      required: [type, name, summary]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [star, planet, asteroid, dust_cloud, black_hole, solar_system, manny, drifting_item, detached_container]
+        name:
+          type: string
+          nullable: true
+        estimated:
+          type: boolean
+        summary:
+          type: string
+        mass:
+          type: number
+        massUnit:
+          type: string
+          enum: [solar_mass, earth_mass]
+          description: Unit used by mass when present. Stars, black holes and dust clouds use solar_mass; planets and asteroids use earth_mass.
+        radius:
+          type: number
+        radiusUnit:
+          type: string
+          enum: [solar_radius, earth_radius, kilometer, astronomical_unit]
+          description: Unit used by radius when present. Stars use solar_radius; planets and asteroids use earth_radius; black holes use kilometer; solar systems and dust clouds use astronomical_unit.
+        dangerLevel:
+          type: string
+          enum: [low, moderate, extreme]
+        salvageable:
+          type: boolean
+          description: True when the object can be recovered with POST /api/probe/mannies/{mannyId}/salvage.
+        waypointBookmarks:
+          type: array
+          items:
+            $ref: '#/components/schemas/WaypointBookmarkHistory'
+        bookmarkTargets:
+          type: array
+          description: Present on solar systems; lists nested stars and orbital bodies that can receive a waypoint bookmark.
+          items:
+            $ref: '#/components/schemas/WaypointBookmarkTarget'
+        mannyState:
+          type: string
+          enum: [abandoned, forgotten]
+          description: Present only for detected Manny objects in the current sector.
+        mannyUid:
+          type: string
+          description: Present only for detected Manny objects.
+        cargo:
+          $ref: '#/components/schemas/MannyCargo'
+        itemType:
+          type: string
+          enum: [waypoint_bookmark, steel_bar, steel_plate, micro_conductor, ceramic_insulator, crystal_substrate, dopant_matrix, integrated_circuit]
+          description: Present only for drifting item stacks.
+        quantity:
+          type: integer
+          description: Present only for drifting item stacks.
+        containerSpace:
+          type: number
+          description: Per-item storage space for drifting item stacks.
+        mode:
+          type: string
+          enum: [drifting, hidden_on_asteroid]
+          description: Present only for detached containers. Hidden containers are not included in normal observations.
+        targetObjectId:
+          type: string
+          description: Present only for detached containers that are attached to another sector object.
+        capacity:
+          type: number
+          description: Storage capacity for detached container objects.
+        capacityUnit:
+          type: string
+          enum: [earth_container_equivalent]
+    WaypointBookmarkTarget:
+      type: object
+      required: [id, type, name]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [star, planet, asteroid, dust_cloud, black_hole, solar_system]
+        name:
+          type: string
+          nullable: true
+        mass:
+          type: number
+        massUnit:
+          type: string
+          enum: [solar_mass, earth_mass]
+        radius:
+          type: number
+        radiusUnit:
+          type: string
+          enum: [solar_radius, earth_radius, kilometer, astronomical_unit]
+        waypointBookmarks:
+          type: array
+          items:
+            $ref: '#/components/schemas/WaypointBookmarkHistory'
+    WaypointBookmarkHistory:
+      type: object
+      required: [name, playerId, playerName, createdAt]
+      properties:
+        name:
+          type: string
+        playerId:
+          type: integer
+        playerName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,4 +1,4 @@
-use super::types::{Manny, Probe, ProbeInventory, ProbeMovement, SectorObservation};
+use super::types::{CraftingRecipe, Manny, Probe, ProbeInventory, ProbeMovement, SectorObservation};
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
 use serde::{Deserialize, Serialize};
@@ -239,6 +239,12 @@ impl ApiClient {
         struct Body<'a> { recipe: &'a str }
         self.post::<serde_json::Value, _>("/api/probe/atomic-printer/craft", &Body { recipe }).await?;
         Ok(())
+    }
+
+    pub async fn get_crafting_recipes(&self) -> Result<Vec<CraftingRecipe>> {
+        #[derive(Deserialize)]
+        struct Resp { recipes: Vec<CraftingRecipe> }
+        Ok(self.get::<Resp>("/api/crafting-recipes").await?.recipes)
     }
 
     pub async fn install_bookmark_manny(&self, manny_id: &str, object_id: &str, name: &str) -> Result<Manny> {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -234,6 +234,13 @@ impl ApiClient {
         Ok(self.patch::<Resp, _>(&path, &Body { name }).await?.manny)
     }
 
+    pub async fn craft_atomic_printer(&self, recipe: &str) -> Result<()> {
+        #[derive(Serialize)]
+        struct Body<'a> { recipe: &'a str }
+        self.post::<serde_json::Value, _>("/api/probe/atomic-printer/craft", &Body { recipe }).await?;
+        Ok(())
+    }
+
     pub async fn install_bookmark_manny(&self, manny_id: &str, object_id: &str, name: &str) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -241,6 +241,47 @@ impl ApiClient {
         Ok(())
     }
 
+    pub async fn detach_storage_container(
+        &self,
+        manny_id: &str,
+        container_id: &str,
+        mode: &str,
+        object_id: Option<&str>,
+    ) -> Result<Manny> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body<'a> {
+            container_id: &'a str,
+            mode: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            object_id: Option<&'a str>,
+        }
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/detach-storage-container");
+        Ok(self.post::<Resp, _>(&path, &Body { container_id, mode, object_id }).await?.manny)
+    }
+
+    pub async fn inspect_asteroid(&self, manny_id: &str, object_id: &str) -> Result<Manny> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body<'a> { object_id: &'a str }
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/inspect-asteroid");
+        Ok(self.post::<Resp, _>(&path, &Body { object_id }).await?.manny)
+    }
+
+    pub async fn recover_storage_container(&self, manny_id: &str, object_id: &str) -> Result<Manny> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body<'a> { object_id: &'a str }
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/recover-storage-container");
+        Ok(self.post::<Resp, _>(&path, &Body { object_id }).await?.manny)
+    }
+
     pub async fn get_crafting_recipes(&self) -> Result<Vec<CraftingRecipe>> {
         #[derive(Deserialize)]
         struct Resp { recipes: Vec<CraftingRecipe> }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -234,13 +234,13 @@ impl ApiClient {
         Ok(self.patch::<Resp, _>(&path, &Body { name }).await?.manny)
     }
 
-    pub async fn deploy_waypoint(&self, item_id: &str, object_id: &str, name: &str) -> Result<ProbeInventory> {
+    pub async fn install_bookmark_manny(&self, manny_id: &str, object_id: &str, name: &str) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct Body<'a> { object_id: &'a str, name: &'a str }
         #[derive(Deserialize)]
-        struct Resp { inventory: ProbeInventory }
-        let path = format!("/api/probe/waypoint-bookmarks/{item_id}/deploy");
-        Ok(self.post::<Resp, _>(&path, &Body { object_id, name }).await?.inventory)
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/install-bookmark");
+        Ok(self.post::<Resp, _>(&path, &Body { object_id, name }).await?.manny)
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -99,6 +99,49 @@ pub struct ProbeMovement {
     pub estimated_velocity_c: Option<f64>,
 }
 
+// ── Storage containers ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageContainerSummary {
+    pub id: String,
+    pub kind: String,
+    pub label: String,
+    pub sort_order: i32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageContainerRules {
+    #[serde(default)]
+    pub priority: Vec<String>,
+    #[serde(default)]
+    pub exclusion: Vec<String>,
+    #[serde(default)]
+    pub strict_exclusion: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageContainer {
+    pub id: String,
+    pub kind: String,
+    pub label: String,
+    pub sort_order: i32,
+    pub capacity: f64,
+    pub used_capacity: f64,
+    pub free_capacity: f64,
+    pub rules: StorageContainerRules,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceStockContainerLine {
+    pub container: StorageContainerSummary,
+    pub amount: f64,
+    pub container_space: f64,
+}
+
 // ── Inventory ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]
@@ -144,6 +187,7 @@ pub struct ProbeInventoryItem {
     pub task_progress_percent: f64,
     pub location: Option<MannyLocation>,
     pub cargo: Option<MannyCargo>,
+    pub container: Option<StorageContainerSummary>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -155,6 +199,8 @@ pub struct ProbeResourceStock {
     pub name: String,
     pub amount: f64,
     pub container_space: f64,
+    #[serde(default)]
+    pub containers: Vec<ResourceStockContainerLine>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -176,6 +222,8 @@ pub struct ProbeInventory {
     pub items: Vec<ProbeInventoryItem>,
     pub resource_stocks: Vec<ProbeResourceStock>,
     pub external_tanks: Vec<ProbeExternalTank>,
+    #[serde(default)]
+    pub containers: Vec<StorageContainer>,
 }
 
 // ── Systems ───────────────────────────────────────────────────────────────────

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -273,6 +273,40 @@ pub struct ManniesResponse {
     pub mannies: Vec<Manny>,
 }
 
+// ── Crafting recipes ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CraftingRecipeIngredient {
+    #[serde(rename = "type")]
+    pub ingredient_type: String,
+    pub quantity: f64,
+    pub unit: String,
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CraftingRecipeOutput {
+    #[serde(rename = "type")]
+    pub output_type: String,
+    pub name: String,
+    pub container_space: f64,
+    pub container_space_unit: String,
+    pub capacity_bonus: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CraftingRecipe {
+    pub id: String,
+    pub name: String,
+    pub craftable_by: Vec<String>,
+    pub ingredients: Vec<CraftingRecipeIngredient>,
+    pub duration_seconds: i64,
+    pub output: CraftingRecipeOutput,
+}
+
 // ── Sector ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -144,7 +144,7 @@ pub struct ResourceStockContainerLine {
 
 // ── Inventory ─────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MannyCargo {
     pub capacity: f64,
@@ -378,6 +378,15 @@ pub struct SectorScan {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct WaypointBookmarkHistory {
+    pub name: String,
+    pub player_id: i64,
+    pub player_name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WaypointBookmarkTarget {
     pub id: String,
     #[serde(rename = "type")]
@@ -387,6 +396,16 @@ pub struct WaypointBookmarkTarget {
     pub mass_unit: Option<String>,
     pub radius: Option<f64>,
     pub radius_unit: Option<String>,
+    #[serde(default)]
+    pub waypoint_bookmarks: Vec<WaypointBookmarkHistory>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SectorProbePresence {
+    pub id: i64,
+    pub name: String,
+    pub moving: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -399,11 +418,24 @@ pub struct SectorObject {
     pub estimated: Option<bool>,
     pub summary: Option<String>,
     pub mass: Option<f64>,
+    pub mass_unit: Option<String>,
     pub radius: Option<f64>,
+    pub radius_unit: Option<String>,
     pub danger_level: Option<DangerLevel>,
+    pub salvageable: Option<bool>,
     pub manny_state: Option<String>,
     pub manny_uid: Option<String>,
+    pub cargo: Option<MannyCargo>,
+    pub item_type: Option<String>,
+    pub quantity: Option<i64>,
+    pub container_space: Option<f64>,
+    pub mode: Option<String>,
+    pub target_object_id: Option<String>,
+    pub capacity: Option<f64>,
+    pub capacity_unit: Option<String>,
     pub minable_targets: Option<Vec<MinableTarget>>,
+    #[serde(default)]
+    pub waypoint_bookmarks: Vec<WaypointBookmarkHistory>,
     #[serde(default)]
     pub bookmark_targets: Vec<WaypointBookmarkTarget>,
 }
@@ -427,6 +459,7 @@ pub struct SectorObservation {
     pub knowledge_level: KnowledgeLevel,
     pub confidence: f64,
     pub objects: Option<Vec<SectorObject>>,
+    pub probes: Option<Vec<SectorProbePresence>>,
     pub possible_objects: Option<Vec<String>>,
     pub estimated_objects: Option<EstimatedObjects>,
     pub navigational_risk: Option<String>,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -59,10 +59,15 @@ pub enum MovementPhase {
 pub enum MannyTask {
     Repair,
     Mining,
+    Crafting,
+    AssistingAtomicPrinter,
+    Salvage,
+    InstallingWaypointBookmark,
+    DetachingStorageContainer,
+    InspectingAsteroid,
     Returning,
     WaitingForSpace,
-    Crafting,
-    Salvage,
+    MovingStockage,
     #[serde(other)]
     Unknown,
 }
@@ -265,6 +270,8 @@ pub enum SectorObjectType {
     BlackHole,
     SolarSystem,
     Manny,
+    DriftingItem,
+    DetachedContainer,
     #[serde(other)]
     Unknown,
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -378,6 +378,19 @@ pub struct SectorScan {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct WaypointBookmarkTarget {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub object_type: SectorObjectType,
+    pub name: Option<String>,
+    pub mass: Option<f64>,
+    pub mass_unit: Option<String>,
+    pub radius: Option<f64>,
+    pub radius_unit: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SectorObject {
     pub id: Option<String>,
     #[serde(rename = "type")]
@@ -391,6 +404,8 @@ pub struct SectorObject {
     pub manny_state: Option<String>,
     pub manny_uid: Option<String>,
     pub minable_targets: Option<Vec<MinableTarget>>,
+    #[serde(default)]
+    pub bookmark_targets: Vec<WaypointBookmarkTarget>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::api::types::{Manny, Probe, ProbeInventory, ProbeMovement, SectorObject, SectorObjectType, SectorObservation};
+use crate::api::types::{CraftingRecipe, Manny, Probe, ProbeInventory, ProbeMovement, SectorObject, SectorObjectType, SectorObservation};
 use chrono::{DateTime, Local, Utc};
 use std::path::Path;
 use tokio::time::Instant;
@@ -50,14 +50,6 @@ pub enum Panel {
 pub const RESOURCE_TYPES: [&str; 4] = ["deuterium", "metals", "ice", "carbon_compounds"];
 pub const RESOURCE_LABELS: [&str; 4] = ["deuterium", "metals", "ice", "carbon"];
 
-pub const ATOMIC_RECIPES: &[(&str, &str)] = &[
-    ("micro_conductor",    "Micro-conductor"),
-    ("ceramic_insulator",  "Ceramic insulator"),
-    ("crystal_substrate",  "Crystal substrate"),
-    ("dopant_matrix",      "Dopant matrix"),
-    ("integrated_circuit", "Integrated circuit"),
-];
-
 #[derive(Default)]
 pub enum AtomicPrinterCraftInput {
     #[default]
@@ -102,9 +94,10 @@ pub enum MineInput {
 pub enum CraftInput {
     #[default]
     Inactive,
-    Confirm {
+    PickRecipe {
         manny_id: String,
         manny_name: String,
+        selection: usize,
         error: Option<String>,
     },
 }
@@ -219,6 +212,7 @@ pub enum ApiMessage {
     DeployError(String),
     AtomicPrinterCraftStarted,
     AtomicPrinterCraftError(String),
+    RecipesFetched(Vec<CraftingRecipe>),
     RenameMannyDone(Manny),
     RenameMannyError(String),
     Error(String),
@@ -253,6 +247,7 @@ pub struct AppState {
     pub rename_manny: RenameMannyInput,
     pub map: MapView,
     pub api_version: Option<u32>,
+    pub recipes: Vec<CraftingRecipe>,
 }
 
 impl AppState {
@@ -628,7 +623,7 @@ impl AppState {
     }
 
     pub fn set_craft_error(&mut self, msg: String) {
-        if let CraftInput::Confirm { ref mut error, .. } = self.craft {
+        if let CraftInput::PickRecipe { ref mut error, .. } = self.craft {
             *error = Some(msg);
         }
     }
@@ -775,6 +770,18 @@ impl AppState {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    pub fn atomic_printer_recipes(&self) -> Vec<&CraftingRecipe> {
+        self.recipes.iter()
+            .filter(|r| r.craftable_by.iter().any(|c| c == "atomic_3d_printer"))
+            .collect()
+    }
+
+    pub fn manny_craft_recipes(&self) -> Vec<&CraftingRecipe> {
+        self.recipes.iter()
+            .filter(|r| r.craftable_by.iter().any(|c| c == "manny"))
+            .collect()
     }
 
     pub fn inventory_waypoint_bookmark_id(&self) -> Option<String> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -235,6 +235,7 @@ pub struct AppState {
     pub scan_mode: ScanMode,
     pub scan_error: Option<String>,
     pub scan_batch: Option<usize>,
+    pub scan_detail_scroll: usize,
     pub travel: TravelInput,
     pub repair: RepairInput,
     pub mine: MineInput,
@@ -328,6 +329,7 @@ impl AppState {
         });
         self.scan_history.insert(0, sector);
         self.scan_history_idx = 0;
+        self.scan_detail_scroll = 0;
         self.scan_loading = false;
         self.scan_error = None;
         self.scan_mode = ScanMode::Current;
@@ -339,14 +341,18 @@ impl AppState {
 
     pub fn scan_hist_next(&mut self) {
         if !self.scan_history.is_empty() {
-            self.scan_history_idx =
-                (self.scan_history_idx + 1).min(self.scan_history.len() - 1);
+            let new = (self.scan_history_idx + 1).min(self.scan_history.len() - 1);
+            if new != self.scan_history_idx {
+                self.scan_history_idx = new;
+                self.scan_detail_scroll = 0;
+            }
         }
     }
 
     pub fn scan_hist_prev(&mut self) {
         if self.scan_history_idx > 0 {
             self.scan_history_idx -= 1;
+            self.scan_detail_scroll = 0;
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -188,6 +188,59 @@ pub enum JettisonInput {
     },
 }
 
+#[derive(Default)]
+pub enum InspectInput {
+    #[default]
+    Inactive,
+    PickAsteroid {
+        manny_id: String,
+        manny_name: String,
+        candidates: Vec<(String, String)>,
+        selection: usize,
+    },
+}
+
+#[derive(Default)]
+pub enum RecoverInput {
+    #[default]
+    Inactive,
+    PickContainer {
+        manny_id: String,
+        manny_name: String,
+        candidates: Vec<(String, String)>,
+        selection: usize,
+    },
+}
+
+#[derive(Default)]
+pub enum DetachInput {
+    #[default]
+    Inactive,
+    PickContainer {
+        manny_id: String,
+        manny_name: String,
+        containers: Vec<(String, String)>,
+        selection: usize,
+    },
+    PickMode {
+        manny_id: String,
+        manny_name: String,
+        container_id: String,
+        container_name: String,
+        selection: usize,
+        error: Option<String>,
+    },
+    PickAsteroid {
+        manny_id: String,
+        manny_name: String,
+        container_id: String,
+        container_name: String,
+        asteroids: Vec<(String, String)>,
+        selection: usize,
+        error: Option<String>,
+    },
+}
+
 pub enum ApiMessage {
     ProbeUpdated(Probe),
     ManniesUpdated(Vec<Manny>),
@@ -215,6 +268,12 @@ pub enum ApiMessage {
     RecipesFetched(Vec<CraftingRecipe>),
     RenameMannyDone(Manny),
     RenameMannyError(String),
+    InspectStarted,
+    InspectError(String),
+    RecoverStarted,
+    RecoverError(String),
+    DetachStarted,
+    DetachError(String),
     Error(String),
 }
 
@@ -246,6 +305,9 @@ pub struct AppState {
     pub recall: RecallInput,
     pub deploy: DeployInput,
     pub rename_manny: RenameMannyInput,
+    pub inspect: InspectInput,
+    pub recover: RecoverInput,
+    pub detach: DetachInput,
     pub map: MapView,
     pub api_version: Option<u32>,
     pub recipes: Vec<CraftingRecipe>,
@@ -771,6 +833,63 @@ impl AppState {
                     .map(|o: &SectorObject| {
                         let id = o.id.clone().unwrap();
                         let name = o.name.clone().unwrap_or_else(|| format!("{:?}", o.object_type).to_lowercase());
+                        (id, name)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn set_inspect_error(&mut self, msg: String) {
+        if let InspectInput::PickAsteroid { ref mut candidates, .. } = self.inspect {
+            let _ = candidates;
+        }
+        let _ = msg;
+    }
+
+    pub fn set_recover_error(&mut self, msg: String) {
+        let _ = msg;
+    }
+
+    pub fn set_detach_error(&mut self, msg: String) {
+        match self.detach {
+            DetachInput::PickMode { ref mut error, .. } => *error = Some(msg),
+            DetachInput::PickAsteroid { ref mut error, .. } => *error = Some(msg),
+            _ => {}
+        }
+    }
+
+    pub fn collect_detachable_containers(&self) -> Vec<(String, String)> {
+        self.probe.as_ref()
+            .map(|p| {
+                p.inventory.containers.iter()
+                    .filter(|c| c.kind != "probe")
+                    .map(|c| (c.id.clone(), c.label.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn collect_detached_containers(&self) -> Vec<(String, String)> {
+        let current_pos = self.probe.as_ref()
+            .and_then(|p| p.sector.as_ref())
+            .and_then(|s| s.relative.as_ref())
+            .map(|r| (r.x as i64, r.y as i64, r.z as i64));
+        let sector = if let Some(pos) = current_pos {
+            self.scan_history.iter().find(|s| {
+                (s.relative_coordinates.x as i64, s.relative_coordinates.y as i64, s.relative_coordinates.z as i64) == pos
+            })
+        } else {
+            self.scan_history.first()
+        };
+        sector
+            .and_then(|s| s.objects.as_ref())
+            .map(|objects| {
+                objects.iter()
+                    .filter(|o| matches!(o.object_type, SectorObjectType::DetachedContainer))
+                    .map(|o| {
+                        let id = o.id.clone().unwrap_or_default();
+                        let name = o.name.clone().unwrap_or_else(|| "unnamed container".into());
                         (id, name)
                     })
                     .collect()

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,13 +137,17 @@ pub enum RenameMannyInput {
 pub enum DeployInput {
     #[default]
     Inactive,
+    PickManny {
+        mannies: Vec<(String, String)>,
+        selection: usize,
+    },
     PickObject {
-        item_id: String,
+        manny_id: String,
         candidates: Vec<(String, String)>,
         selection: usize,
     },
     EnterName {
-        item_id: String,
+        manny_id: String,
         object_id: String,
         object_name: String,
         name_buf: String,
@@ -193,7 +197,7 @@ pub enum ApiMessage {
     SalvageError(String),
     RecallStarted,
     RecallError(String),
-    DeployDone(ProbeInventory),
+    DeployStarted,
     DeployError(String),
     RenameMannyDone(Manny),
     RenameMannyError(String),
@@ -695,6 +699,20 @@ impl AppState {
         if let DeployInput::EnterName { ref mut name_buf, .. } = self.deploy {
             name_buf.pop();
         }
+    }
+
+    pub fn collect_idle_onboard_mannies(&self) -> Vec<(String, String)> {
+        self.mannies.as_ref()
+            .map(|ms| {
+                ms.iter()
+                    .filter(|m| {
+                        m.location.location_type == crate::api::types::MannyLocationType::Probe
+                            && m.can_receive_orders
+                    })
+                    .map(|m| (m.id.clone(), m.name.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     pub fn collect_deploy_candidates(&self) -> Vec<(String, String)> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,6 +50,24 @@ pub enum Panel {
 pub const RESOURCE_TYPES: [&str; 4] = ["deuterium", "metals", "ice", "carbon_compounds"];
 pub const RESOURCE_LABELS: [&str; 4] = ["deuterium", "metals", "ice", "carbon"];
 
+pub const ATOMIC_RECIPES: &[(&str, &str)] = &[
+    ("micro_conductor",    "Micro-conductor"),
+    ("ceramic_insulator",  "Ceramic insulator"),
+    ("crystal_substrate",  "Crystal substrate"),
+    ("dopant_matrix",      "Dopant matrix"),
+    ("integrated_circuit", "Integrated circuit"),
+];
+
+#[derive(Default)]
+pub enum AtomicPrinterCraftInput {
+    #[default]
+    Inactive,
+    PickRecipe {
+        selection: usize,
+        error: Option<String>,
+    },
+}
+
 #[derive(Default)]
 pub struct MapView {
     pub open: bool,
@@ -199,6 +217,8 @@ pub enum ApiMessage {
     RecallError(String),
     DeployStarted,
     DeployError(String),
+    AtomicPrinterCraftStarted,
+    AtomicPrinterCraftError(String),
     RenameMannyDone(Manny),
     RenameMannyError(String),
     Error(String),
@@ -226,6 +246,7 @@ pub struct AppState {
     pub mine: MineInput,
     pub jettison: JettisonInput,
     pub craft: CraftInput,
+    pub atomic_printer_craft: AtomicPrinterCraftInput,
     pub salvage: SalvageInput,
     pub recall: RecallInput,
     pub deploy: DeployInput,
@@ -610,6 +631,18 @@ impl AppState {
         if let CraftInput::Confirm { ref mut error, .. } = self.craft {
             *error = Some(msg);
         }
+    }
+
+    pub fn set_atomic_printer_craft_error(&mut self, msg: String) {
+        if let AtomicPrinterCraftInput::PickRecipe { ref mut error, .. } = self.atomic_printer_craft {
+            *error = Some(msg);
+        }
+    }
+
+    pub fn has_atomic_printer(&self) -> bool {
+        self.probe.as_ref()
+            .map(|p| p.inventory.items.iter().any(|i| i.item_type == "atomic_3d_printer"))
+            .unwrap_or(false)
     }
 
     pub fn set_salvage_error(&mut self, msg: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod ui;
 
 use api::client::ApiClient;
 use api::types::SectorObjectType;
-use app::{ApiMessage, AppState, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_TYPES};
+use app::{ApiMessage, AppState, AtomicPrinterCraftInput, ATOMIC_RECIPES, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_TYPES};
 
 fn neighbors_d1() -> Vec<(i32, i32, i32)> {
     let mut out = Vec::new();
@@ -161,6 +161,11 @@ async fn run(
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::DeployError(e) => state.set_deploy_error(e),
+                    ApiMessage::AtomicPrinterCraftStarted => {
+                        state.atomic_printer_craft = AtomicPrinterCraftInput::Inactive;
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::AtomicPrinterCraftError(e) => state.set_atomic_printer_craft_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -205,6 +210,7 @@ fn handle_event(
     let in_repair = !matches!(state.repair, RepairInput::Inactive);
     let in_jettison = !matches!(state.jettison, JettisonInput::Inactive);
     let in_craft = !matches!(state.craft, CraftInput::Inactive);
+    let in_atomic_craft = !matches!(state.atomic_printer_craft, AtomicPrinterCraftInput::Inactive);
     let in_salvage = !matches!(state.salvage, SalvageInput::Inactive);
     let in_recall = !matches!(state.recall, RecallInput::Inactive);
     let in_rename_manny = !matches!(state.rename_manny, RenameMannyInput::Inactive);
@@ -227,6 +233,11 @@ fn handle_event(
 
     if in_craft {
         handle_craft_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_atomic_craft {
+        handle_atomic_printer_craft_event(k.code, state, client, tx);
         return;
     }
 
@@ -361,6 +372,16 @@ fn handle_event(
                         state.deploy = DeployInput::PickManny { mannies, selection: 0 };
                     }
                 }
+            }
+        }
+        KeyCode::Char('a') if state.focused == Some(Panel::Inventory) => {
+            if state.has_atomic_printer() {
+                state.atomic_printer_craft = AtomicPrinterCraftInput::PickRecipe {
+                    selection: 0,
+                    error: None,
+                };
+            } else {
+                state.error = Some("no atomic printer in inventory".into());
             }
         }
         KeyCode::Down | KeyCode::Char('j') if state.focused == Some(Panel::Mannies) => {
@@ -915,6 +936,44 @@ fn fetch_craft(manny_id: String, recipe: &'static str, client: ApiClient, tx: mp
         let msg = match client.craft_manny(&manny_id, recipe).await {
             Ok(_) => ApiMessage::CraftStarted,
             Err(e) => ApiMessage::CraftError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
+fn handle_atomic_printer_craft_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let AtomicPrinterCraftInput::PickRecipe { selection, .. } = state.atomic_printer_craft else { return };
+    let count = ATOMIC_RECIPES.len();
+    match code {
+        KeyCode::Esc => state.atomic_printer_craft = AtomicPrinterCraftInput::Inactive,
+        KeyCode::Up | KeyCode::Char('k') => {
+            if let AtomicPrinterCraftInput::PickRecipe { ref mut selection, .. } = state.atomic_printer_craft {
+                *selection = selection.checked_sub(1).unwrap_or(count - 1);
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if let AtomicPrinterCraftInput::PickRecipe { ref mut selection, .. } = state.atomic_printer_craft {
+                *selection = (*selection + 1) % count;
+            }
+        }
+        KeyCode::Enter => {
+            let recipe = ATOMIC_RECIPES[selection].0;
+            fetch_atomic_printer_craft(recipe, client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}
+
+fn fetch_atomic_printer_craft(recipe: &'static str, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.craft_atomic_printer(recipe).await {
+            Ok(()) => ApiMessage::AtomicPrinterCraftStarted,
+            Err(e) => ApiMessage::AtomicPrinterCraftError(e.to_string()),
         };
         let _ = tx.send(msg).await;
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod ui;
 
 use api::client::ApiClient;
 use api::types::SectorObjectType;
-use app::{ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_TYPES};
+use app::{ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_TYPES};
 
 fn neighbors_d1() -> Vec<(i32, i32, i32)> {
     let mut out = Vec::new();
@@ -168,6 +168,21 @@ async fn run(
                     }
                     ApiMessage::AtomicPrinterCraftError(e) => state.set_atomic_printer_craft_error(e),
                     ApiMessage::RecipesFetched(recipes) => state.recipes = recipes,
+                    ApiMessage::InspectStarted => {
+                        state.inspect = InspectInput::Inactive;
+                        fetch_mannies(client.clone(), tx.clone());
+                    }
+                    ApiMessage::InspectError(e) => state.set_inspect_error(e),
+                    ApiMessage::RecoverStarted => {
+                        state.recover = RecoverInput::Inactive;
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::RecoverError(e) => state.set_recover_error(e),
+                    ApiMessage::DetachStarted => {
+                        state.detach = DetachInput::Inactive;
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::DetachError(e) => state.set_detach_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -217,6 +232,9 @@ fn handle_event(
     let in_recall = !matches!(state.recall, RecallInput::Inactive);
     let in_rename_manny = !matches!(state.rename_manny, RenameMannyInput::Inactive);
     let in_deploy = !matches!(state.deploy, DeployInput::Inactive);
+    let in_inspect = !matches!(state.inspect, InspectInput::Inactive);
+    let in_recover = !matches!(state.recover, RecoverInput::Inactive);
+    let in_detach = !matches!(state.detach, DetachInput::Inactive);
 
     if ctrl && k.code == KeyCode::Char('c') {
         state.set_quit();
@@ -260,6 +278,21 @@ fn handle_event(
 
     if in_deploy {
         handle_deploy_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_inspect {
+        handle_inspect_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_recover {
+        handle_recover_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_detach {
+        handle_detach_event(k.code, state, client, tx);
         return;
     }
 
@@ -514,6 +547,83 @@ fn handle_event(
                         buf: manny.name.clone(),
                         error: None,
                     };
+                }
+            }
+        }
+        KeyCode::Char('x') if state.focused == Some(Panel::Mannies) => {
+            if let Some(mannies) = &state.mannies {
+                if let Some(manny) = mannies.get(state.mannies_selection) {
+                    if manny.can_receive_orders {
+                        let candidates = collect_asteroid_candidates(state);
+                        match candidates.len() {
+                            0 => state.error = Some("no asteroids in current sector — scan first".into()),
+                            1 => {
+                                let (object_id, _) = candidates.into_iter().next().unwrap();
+                                fetch_inspect(manny.id.clone(), object_id, client.clone(), tx.clone());
+                            }
+                            _ => {
+                                state.inspect = InspectInput::PickAsteroid {
+                                    manny_id: manny.id.clone(),
+                                    manny_name: manny.name.clone(),
+                                    candidates,
+                                    selection: 0,
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        KeyCode::Char('v') if state.focused == Some(Panel::Mannies) => {
+            if let Some(mannies) = &state.mannies {
+                if let Some(manny) = mannies.get(state.mannies_selection) {
+                    if manny.can_receive_orders {
+                        let candidates = state.collect_detached_containers();
+                        match candidates.len() {
+                            0 => state.error = Some("no detached containers in current sector — scan first".into()),
+                            1 => {
+                                let (object_id, _) = candidates.into_iter().next().unwrap();
+                                fetch_recover(manny.id.clone(), object_id, client.clone(), tx.clone());
+                            }
+                            _ => {
+                                state.recover = RecoverInput::PickContainer {
+                                    manny_id: manny.id.clone(),
+                                    manny_name: manny.name.clone(),
+                                    candidates,
+                                    selection: 0,
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        KeyCode::Char('D') if state.focused == Some(Panel::Mannies) => {
+            if let Some(mannies) = &state.mannies {
+                if let Some(manny) = mannies.get(state.mannies_selection) {
+                    if manny.can_receive_orders {
+                        let containers = state.collect_detachable_containers();
+                        if containers.is_empty() {
+                            state.error = Some("no detachable containers in inventory".into());
+                        } else if containers.len() == 1 {
+                            let (container_id, container_name) = containers.into_iter().next().unwrap();
+                            state.detach = DetachInput::PickMode {
+                                manny_id: manny.id.clone(),
+                                manny_name: manny.name.clone(),
+                                container_id,
+                                container_name,
+                                selection: 0,
+                                error: None,
+                            };
+                        } else {
+                            state.detach = DetachInput::PickContainer {
+                                manny_id: manny.id.clone(),
+                                manny_name: manny.name.clone(),
+                                containers,
+                                selection: 0,
+                            };
+                        }
+                    }
                 }
             }
         }
@@ -1245,6 +1355,232 @@ fn handle_rename_manny_event(
         }
         _ => {}
     }
+}
+
+fn collect_asteroid_candidates(state: &AppState) -> Vec<(String, String)> {
+    let current_pos = state.probe.as_ref()
+        .and_then(|p| p.sector.as_ref())
+        .and_then(|s| s.relative.as_ref())
+        .map(|r| (r.x as i64, r.y as i64, r.z as i64));
+    let sector = if let Some(pos) = current_pos {
+        state.scan_history.iter().find(|s| {
+            (s.relative_coordinates.x as i64, s.relative_coordinates.y as i64, s.relative_coordinates.z as i64) == pos
+        })
+    } else {
+        state.scan_history.first()
+    };
+    sector
+        .and_then(|s| s.objects.as_ref())
+        .map(|objects| {
+            objects.iter()
+                .flat_map(|o| {
+                    let direct = if matches!(o.object_type, SectorObjectType::Asteroid) {
+                        o.id.as_ref().map(|id| vec![(id.clone(), o.name.clone().unwrap_or_else(|| "unnamed".into()))])
+                            .unwrap_or_default()
+                    } else { vec![] };
+                    let nested: Vec<(String, String)> = o.bookmark_targets.iter()
+                        .filter(|t| matches!(t.object_type, SectorObjectType::Asteroid))
+                        .map(|t| (t.id.clone(), t.name.clone().unwrap_or_else(|| "unnamed".into())))
+                        .collect();
+                    [direct, nested].concat()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn handle_inspect_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let InspectInput::PickAsteroid { selection: _, ref candidates, .. } = state.inspect else { return };
+    let count = candidates.len();
+    match code {
+        KeyCode::Esc => state.inspect = InspectInput::Inactive,
+        KeyCode::Up | KeyCode::Char('k') => {
+            if let InspectInput::PickAsteroid { ref mut selection, .. } = state.inspect {
+                *selection = selection.checked_sub(1).unwrap_or(count - 1);
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if let InspectInput::PickAsteroid { ref mut selection, .. } = state.inspect {
+                *selection = (*selection + 1) % count;
+            }
+        }
+        KeyCode::Enter => {
+            let (manny_id, object_id) = {
+                let InspectInput::PickAsteroid { ref manny_id, ref candidates, selection, .. } = state.inspect else { return };
+                (manny_id.clone(), candidates[selection].0.clone())
+            };
+            fetch_inspect(manny_id, object_id, client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}
+
+fn fetch_inspect(manny_id: String, object_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.inspect_asteroid(&manny_id, &object_id).await {
+            Ok(_) => ApiMessage::InspectStarted,
+            Err(e) => ApiMessage::InspectError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
+fn handle_recover_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let RecoverInput::PickContainer { selection: _, ref candidates, .. } = state.recover else { return };
+    let count = candidates.len();
+    match code {
+        KeyCode::Esc => state.recover = RecoverInput::Inactive,
+        KeyCode::Up | KeyCode::Char('k') => {
+            if let RecoverInput::PickContainer { ref mut selection, .. } = state.recover {
+                *selection = selection.checked_sub(1).unwrap_or(count - 1);
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if let RecoverInput::PickContainer { ref mut selection, .. } = state.recover {
+                *selection = (*selection + 1) % count;
+            }
+        }
+        KeyCode::Enter => {
+            let (manny_id, object_id) = {
+                let RecoverInput::PickContainer { ref manny_id, ref candidates, selection, .. } = state.recover else { return };
+                (manny_id.clone(), candidates[selection].0.clone())
+            };
+            fetch_recover(manny_id, object_id, client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}
+
+fn fetch_recover(manny_id: String, object_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.recover_storage_container(&manny_id, &object_id).await {
+            Ok(_) => ApiMessage::RecoverStarted,
+            Err(e) => ApiMessage::RecoverError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
+pub const DETACH_MODES: [(&str, &str); 2] = [
+    ("drifting", "drifting — leave in sector"),
+    ("hidden_on_asteroid", "hidden — attach to asteroid"),
+];
+
+fn handle_detach_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match &state.detach {
+        DetachInput::PickContainer { selection, containers, .. } => {
+            let sel = *selection;
+            let count = containers.len();
+            match code {
+                KeyCode::Esc => state.detach = DetachInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    if let DetachInput::PickContainer { ref mut selection, .. } = state.detach {
+                        *selection = sel.checked_sub(1).unwrap_or(count - 1);
+                    }
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if let DetachInput::PickContainer { ref mut selection, .. } = state.detach {
+                        *selection = (sel + 1) % count;
+                    }
+                }
+                KeyCode::Enter => {
+                    let (manny_id, manny_name, container_id, container_name) = {
+                        let DetachInput::PickContainer { ref manny_id, ref manny_name, ref containers, selection } = state.detach else { return };
+                        let (id, name) = containers[selection].clone();
+                        (manny_id.clone(), manny_name.clone(), id, name)
+                    };
+                    state.detach = DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection: 0, error: None };
+                }
+                _ => {}
+            }
+        }
+        DetachInput::PickMode { selection, .. } => {
+            let sel = *selection;
+            let count = DETACH_MODES.len();
+            match code {
+                KeyCode::Esc => state.detach = DetachInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    if let DetachInput::PickMode { ref mut selection, .. } = state.detach {
+                        *selection = sel.checked_sub(1).unwrap_or(count - 1);
+                    }
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if let DetachInput::PickMode { ref mut selection, .. } = state.detach {
+                        *selection = (sel + 1) % count;
+                    }
+                }
+                KeyCode::Enter => {
+                    let (manny_id, manny_name, container_id, container_name, sel) = {
+                        let DetachInput::PickMode { ref manny_id, ref manny_name, ref container_id, ref container_name, selection, .. } = state.detach else { return };
+                        (manny_id.clone(), manny_name.clone(), container_id.clone(), container_name.clone(), selection)
+                    };
+                    let mode = DETACH_MODES[sel].0;
+                    if mode == "hidden_on_asteroid" {
+                        let asteroids = collect_asteroid_candidates(state);
+                        if asteroids.is_empty() {
+                            state.set_detach_error("no asteroids in current sector — scan first".into());
+                        } else {
+                            state.detach = DetachInput::PickAsteroid { manny_id, manny_name, container_id, container_name, asteroids, selection: 0, error: None };
+                        }
+                    } else {
+                        fetch_detach(manny_id, container_id, "drifting".into(), None, client.clone(), tx.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+        DetachInput::PickAsteroid { selection, asteroids, .. } => {
+            let sel = *selection;
+            let count = asteroids.len();
+            match code {
+                KeyCode::Esc => state.detach = DetachInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    if let DetachInput::PickAsteroid { ref mut selection, .. } = state.detach {
+                        *selection = sel.checked_sub(1).unwrap_or(count - 1);
+                    }
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if let DetachInput::PickAsteroid { ref mut selection, .. } = state.detach {
+                        *selection = (sel + 1) % count;
+                    }
+                }
+                KeyCode::Enter => {
+                    let (manny_id, container_id, object_id) = {
+                        let DetachInput::PickAsteroid { ref manny_id, ref container_id, ref asteroids, selection, .. } = state.detach else { return };
+                        (manny_id.clone(), container_id.clone(), asteroids[selection].0.clone())
+                    };
+                    fetch_detach(manny_id, container_id, "hidden_on_asteroid".into(), Some(object_id), client.clone(), tx.clone());
+                }
+                _ => {}
+            }
+        }
+        DetachInput::Inactive => {}
+    }
+}
+
+fn fetch_detach(manny_id: String, container_id: String, mode: String, object_id: Option<String>, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.detach_storage_container(&manny_id, &container_id, &mode, object_id.as_deref()).await {
+            Ok(_) => ApiMessage::DetachStarted,
+            Err(e) => ApiMessage::DetachError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
 }
 
 fn fetch_rename_manny(manny_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,9 +156,9 @@ async fn run(
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::RecallError(e) => state.set_recall_error(e),
-                    ApiMessage::DeployDone(inv) => {
-                        state.update_inventory(inv);
+                    ApiMessage::DeployStarted => {
                         state.deploy = DeployInput::Inactive;
+                        fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::DeployError(e) => state.set_deploy_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
@@ -333,29 +333,32 @@ fn handle_event(
             }
         }
         KeyCode::Char('d') if state.focused == Some(Panel::Inventory) => {
-            match state.inventory_waypoint_bookmark_id() {
-                None => state.error = Some("no waypoint bookmark in inventory — craft one first".into()),
-                Some(item_id) => {
+            if state.inventory_waypoint_bookmark_id().is_none() {
+                state.error = Some("no waypoint bookmark in inventory — craft one first".into());
+            } else {
+                let mannies = state.collect_idle_onboard_mannies();
+                if mannies.is_empty() {
+                    state.error = Some("no idle Manny on board".into());
+                } else {
                     let candidates = state.collect_deploy_candidates();
-                    match candidates.len() {
-                        0 => state.error = Some("no targets in current sector — scan first".into()),
-                        1 => {
+                    if candidates.is_empty() {
+                        state.error = Some("no targets in current sector — scan first".into());
+                    } else if mannies.len() == 1 {
+                        let (manny_id, _) = mannies.into_iter().next().unwrap();
+                        if candidates.len() == 1 {
                             let (object_id, object_name) = candidates.into_iter().next().unwrap();
                             state.deploy = DeployInput::EnterName {
-                                item_id,
+                                manny_id,
                                 object_id,
                                 object_name,
                                 name_buf: String::new(),
                                 error: None,
                             };
+                        } else {
+                            state.deploy = DeployInput::PickObject { manny_id, candidates, selection: 0 };
                         }
-                        _ => {
-                            state.deploy = DeployInput::PickObject {
-                                item_id,
-                                candidates,
-                                selection: 0,
-                            };
-                        }
+                    } else {
+                        state.deploy = DeployInput::PickManny { mannies, selection: 0 };
                     }
                 }
             }
@@ -1029,6 +1032,40 @@ fn handle_deploy_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match &state.deploy {
+        DeployInput::PickManny { selection, mannies } => {
+            let sel = *selection;
+            let count = mannies.len();
+            match code {
+                KeyCode::Esc => state.deploy = DeployInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    if let DeployInput::PickManny { ref mut selection, .. } = state.deploy {
+                        *selection = sel.checked_sub(1).unwrap_or(count - 1);
+                    }
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if let DeployInput::PickManny { ref mut selection, .. } = state.deploy {
+                        *selection = (sel + 1) % count;
+                    }
+                }
+                KeyCode::Enter => {
+                    let manny_id = {
+                        let DeployInput::PickManny { ref mannies, selection } = state.deploy else { return };
+                        mannies[selection].0.clone()
+                    };
+                    let candidates = state.collect_deploy_candidates();
+                    if candidates.is_empty() {
+                        state.deploy = DeployInput::Inactive;
+                        state.error = Some("no targets in current sector".into());
+                    } else if candidates.len() == 1 {
+                        let (object_id, object_name) = candidates.into_iter().next().unwrap();
+                        state.deploy = DeployInput::EnterName { manny_id, object_id, object_name, name_buf: String::new(), error: None };
+                    } else {
+                        state.deploy = DeployInput::PickObject { manny_id, candidates, selection: 0 };
+                    }
+                }
+                _ => {}
+            }
+        }
         DeployInput::PickObject { selection, candidates, .. } => {
             let sel = *selection;
             let count = candidates.len();
@@ -1045,13 +1082,13 @@ fn handle_deploy_event(
                     }
                 }
                 KeyCode::Enter => {
-                    let (item_id, object_id, object_name) = {
-                        let DeployInput::PickObject { ref item_id, ref candidates, selection } = state.deploy else { return };
+                    let (manny_id, object_id, object_name) = {
+                        let DeployInput::PickObject { ref manny_id, ref candidates, selection } = state.deploy else { return };
                         let (id, name) = candidates[selection].clone();
-                        (item_id.clone(), id, name)
+                        (manny_id.clone(), id, name)
                     };
                     state.deploy = DeployInput::EnterName {
-                        item_id,
+                        manny_id,
                         object_id,
                         object_name,
                         name_buf: String::new(),
@@ -1067,12 +1104,12 @@ fn handle_deploy_event(
                 KeyCode::Backspace => state.deploy_backspace(),
                 KeyCode::Char(c) => state.deploy_type_char(c),
                 KeyCode::Enter => {
-                    let (item_id, object_id, name) = {
-                        let DeployInput::EnterName { ref item_id, ref object_id, ref name_buf, .. } = state.deploy else { return };
+                    let (manny_id, object_id, name) = {
+                        let DeployInput::EnterName { ref manny_id, ref object_id, ref name_buf, .. } = state.deploy else { return };
                         if name_buf.is_empty() { return }
-                        (item_id.clone(), object_id.clone(), name_buf.clone())
+                        (manny_id.clone(), object_id.clone(), name_buf.clone())
                     };
-                    fetch_deploy(item_id, object_id, name, client.clone(), tx.clone());
+                    fetch_deploy(manny_id, object_id, name, client.clone(), tx.clone());
                 }
                 _ => {}
             }
@@ -1081,10 +1118,10 @@ fn handle_deploy_event(
     }
 }
 
-fn fetch_deploy(item_id: String, object_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+fn fetch_deploy(manny_id: String, object_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        let msg = match client.deploy_waypoint(&item_id, &object_id, &name).await {
-            Ok(inv) => ApiMessage::DeployDone(inv),
+        let msg = match client.install_bookmark_manny(&manny_id, &object_id, &name).await {
+            Ok(_) => ApiMessage::DeployStarted,
             Err(e) => ApiMessage::DeployError(e.to_string()),
         };
         let _ = tx.send(msg).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod ui;
 
 use api::client::ApiClient;
 use api::types::SectorObjectType;
-use app::{ApiMessage, AppState, AtomicPrinterCraftInput, ATOMIC_RECIPES, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_TYPES};
+use app::{ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_TYPES};
 
 fn neighbors_d1() -> Vec<(i32, i32, i32)> {
     let mut out = Vec::new();
@@ -88,6 +88,7 @@ async fn run(
     // Initial data fetch
     fetch_all(client.clone(), tx.clone());
     fetch_api_version(client.clone(), tx.clone());
+    fetch_crafting_recipes(client.clone(), tx.clone());
     state.loading = true;
 
     loop {
@@ -166,6 +167,7 @@ async fn run(
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::AtomicPrinterCraftError(e) => state.set_atomic_printer_craft_error(e),
+                    ApiMessage::RecipesFetched(recipes) => state.recipes = recipes,
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -375,13 +377,15 @@ fn handle_event(
             }
         }
         KeyCode::Char('a') if state.focused == Some(Panel::Inventory) => {
-            if state.has_atomic_printer() {
+            if !state.has_atomic_printer() {
+                state.error = Some("no atomic printer in inventory".into());
+            } else if state.atomic_printer_recipes().is_empty() {
+                state.error = Some("recipes not loaded yet — press r to refresh".into());
+            } else {
                 state.atomic_printer_craft = AtomicPrinterCraftInput::PickRecipe {
                     selection: 0,
                     error: None,
                 };
-            } else {
-                state.error = Some("no atomic printer in inventory".into());
             }
         }
         KeyCode::Down | KeyCode::Char('j') if state.focused == Some(Panel::Mannies) => {
@@ -443,11 +447,16 @@ fn handle_event(
             if let Some(mannies) = &state.mannies {
                 if let Some(manny) = mannies.get(state.mannies_selection) {
                     if manny.can_receive_orders {
-                        state.craft = CraftInput::Confirm {
-                            manny_id: manny.id.clone(),
-                            manny_name: manny.name.clone(),
-                            error: None,
-                        };
+                        if state.manny_craft_recipes().is_empty() {
+                            state.error = Some("recipes not loaded yet — press r to refresh".into());
+                        } else {
+                            state.craft = CraftInput::PickRecipe {
+                                manny_id: manny.id.clone(),
+                                manny_name: manny.name.clone(),
+                                selection: 0,
+                                error: None,
+                            };
+                        }
                     }
                 }
             }
@@ -918,22 +927,36 @@ fn handle_craft_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
+    let CraftInput::PickRecipe { selection: _, .. } = state.craft else { return };
+    let count = state.manny_craft_recipes().len();
+    if count == 0 { return; }
     match code {
         KeyCode::Esc => state.craft = CraftInput::Inactive,
+        KeyCode::Up | KeyCode::Char('k') => {
+            if let CraftInput::PickRecipe { ref mut selection, .. } = state.craft {
+                *selection = selection.checked_sub(1).unwrap_or(count - 1);
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if let CraftInput::PickRecipe { ref mut selection, .. } = state.craft {
+                *selection = (*selection + 1) % count;
+            }
+        }
         KeyCode::Enter => {
-            let manny_id = {
-                let CraftInput::Confirm { ref manny_id, .. } = state.craft else { return };
-                manny_id.clone()
+            let (manny_id, recipe_id) = {
+                let CraftInput::PickRecipe { ref manny_id, selection, .. } = state.craft else { return };
+                let recipe_id = state.manny_craft_recipes()[selection].id.clone();
+                (manny_id.clone(), recipe_id)
             };
-            fetch_craft(manny_id, "waypoint_bookmark", client.clone(), tx.clone());
+            fetch_craft(manny_id, recipe_id, client.clone(), tx.clone());
         }
         _ => {}
     }
 }
 
-fn fetch_craft(manny_id: String, recipe: &'static str, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+fn fetch_craft(manny_id: String, recipe: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        let msg = match client.craft_manny(&manny_id, recipe).await {
+        let msg = match client.craft_manny(&manny_id, &recipe).await {
             Ok(_) => ApiMessage::CraftStarted,
             Err(e) => ApiMessage::CraftError(e.to_string()),
         };
@@ -948,7 +971,8 @@ fn handle_atomic_printer_craft_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     let AtomicPrinterCraftInput::PickRecipe { selection, .. } = state.atomic_printer_craft else { return };
-    let count = ATOMIC_RECIPES.len();
+    let count = state.atomic_printer_recipes().len();
+    if count == 0 { return; }
     match code {
         KeyCode::Esc => state.atomic_printer_craft = AtomicPrinterCraftInput::Inactive,
         KeyCode::Up | KeyCode::Char('k') => {
@@ -962,16 +986,24 @@ fn handle_atomic_printer_craft_event(
             }
         }
         KeyCode::Enter => {
-            let recipe = ATOMIC_RECIPES[selection].0;
-            fetch_atomic_printer_craft(recipe, client.clone(), tx.clone());
+            let recipe_id = state.atomic_printer_recipes()[selection].id.clone();
+            fetch_atomic_printer_craft(recipe_id, client.clone(), tx.clone());
         }
         _ => {}
     }
 }
 
-fn fetch_atomic_printer_craft(recipe: &'static str, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+fn fetch_crafting_recipes(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        let msg = match client.craft_atomic_printer(recipe).await {
+        if let Ok(recipes) = client.get_crafting_recipes().await {
+            let _ = tx.send(ApiMessage::RecipesFetched(recipes)).await;
+        }
+    });
+}
+
+fn fetch_atomic_printer_craft(recipe: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.craft_atomic_printer(&recipe).await {
             Ok(()) => ApiMessage::AtomicPrinterCraftStarted,
             Err(e) => ApiMessage::AtomicPrinterCraftError(e.to_string()),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,6 +400,12 @@ fn handle_event(
         KeyCode::Up | KeyCode::Char('k') if state.focused == Some(Panel::Scanner) => {
             state.scan_hist_prev();
         }
+        KeyCode::Char('J') if state.focused == Some(Panel::Scanner) => {
+            state.scan_detail_scroll = state.scan_detail_scroll.saturating_add(3);
+        }
+        KeyCode::Char('K') if state.focused == Some(Panel::Scanner) => {
+            state.scan_detail_scroll = state.scan_detail_scroll.saturating_sub(3);
+        }
         KeyCode::Enter if state.focused == Some(Panel::Mannies) => {
             if let Some(mannies) = &state.mannies {
                 if let Some(manny) = mannies.get(state.mannies_selection) {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -514,12 +514,15 @@ fn manny_list_item(m: &Manny) -> ListItem<'_> {
         None => Span::styled("idle", Style::default().fg(Color::DarkGray)),
         Some(MannyTask::Repair) => Span::styled("repair", Style::default().fg(Color::Cyan)),
         Some(MannyTask::Mining) => Span::styled("mining", Style::default().fg(Color::Yellow)),
-        Some(MannyTask::Returning) => Span::styled("returning", Style::default().fg(Color::Blue)),
-        Some(MannyTask::WaitingForSpace) => {
-            Span::styled("waiting", Style::default().fg(Color::Magenta))
-        }
         Some(MannyTask::Crafting) => Span::styled("crafting", Style::default().fg(Color::Cyan)),
+        Some(MannyTask::AssistingAtomicPrinter) => Span::styled("assisting printer", Style::default().fg(Color::Cyan)),
         Some(MannyTask::Salvage) => Span::styled("salvage", Style::default().fg(Color::Yellow)),
+        Some(MannyTask::InstallingWaypointBookmark) => Span::styled("installing waypoint", Style::default().fg(Color::Green)),
+        Some(MannyTask::DetachingStorageContainer) => Span::styled("detaching container", Style::default().fg(Color::Yellow)),
+        Some(MannyTask::InspectingAsteroid) => Span::styled("inspecting", Style::default().fg(Color::Yellow)),
+        Some(MannyTask::Returning) => Span::styled("returning", Style::default().fg(Color::Blue)),
+        Some(MannyTask::WaitingForSpace) => Span::styled("waiting", Style::default().fg(Color::Magenta)),
+        Some(MannyTask::MovingStockage) => Span::styled("moving cargo", Style::default().fg(Color::Blue)),
         Some(MannyTask::Unknown) => Span::styled("?", Style::default().fg(Color::DarkGray)),
     };
 
@@ -1686,6 +1689,52 @@ fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: &AppState) 
 
 fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     match &state.deploy {
+        DeployInput::PickManny { mannies, selection } => {
+            let height = (mannies.len() as u16 + 6).min(18);
+            let popup = centered_rect(52, height, area);
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(" DEPLOY WAYPOINT — SELECT MANNY ")
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(inner);
+
+            let mut lines: Vec<Line> = Vec::new();
+            for (i, (_, name)) in mannies.iter().enumerate() {
+                let selected = i == *selection;
+                if selected {
+                    lines.push(Line::from(vec![
+                        Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                        Span::styled(name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                    ]));
+                } else {
+                    lines.push(Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(name.as_str(), Style::default().fg(Color::DarkGray)),
+                    ]));
+                }
+            }
+            frame.render_widget(Paragraph::new(lines), rows[0]);
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" select  "),
+                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::raw(" confirm  "),
+                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" cancel"),
+                ])),
+                rows[1],
+            );
+        }
+
         DeployInput::PickObject { candidates, selection, .. } => {
             let height = (candidates.len() as u16 + 6).min(18);
             let popup = centered_rect(52, height, area);
@@ -2200,6 +2249,8 @@ fn object_icon(t: &SectorObjectType) -> (&'static str, Color) {
         SectorObjectType::BlackHole => ("◉", Color::Magenta),
         SectorObjectType::SolarSystem => ("⊙", Color::Yellow),
         SectorObjectType::Manny => ("♟", Color::Green),
+        SectorObjectType::DriftingItem => ("◌", Color::White),
+        SectorObjectType::DetachedContainer => ("□", Color::Cyan),
         SectorObjectType::Unknown => ("?", Color::DarkGray),
     }
 }

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -656,6 +656,9 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
                         s.push(Span::styled("[g]", Style::default().fg(Color::Yellow)));
                         s.push(Span::raw(" go"));
                     }
+                    s.push(Span::raw("  "));
+                    s.push(Span::styled("[J/K]", Style::default().fg(Color::Cyan)));
+                    s.push(Span::raw(" scroll"));
                     s
                 };
                 frame.render_widget(Paragraph::new(Line::from(spans)), hint_area);
@@ -899,7 +902,10 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
         }
     }
 
-    frame.render_widget(Paragraph::new(lines), detail_area);
+    frame.render_widget(
+        Paragraph::new(lines).scroll((state.scan_detail_scroll as u16, 0)),
+        detail_area,
+    );
 }
 
 // ── Travel overlay ────────────────────────────────────────────────────────────
@@ -2049,8 +2055,9 @@ fn sector_object_lines(obj: &SectorObject) -> Vec<Line<'_>> {
 
     let mut lines = vec![Line::from(main_spans)];
 
-    let has_mass = obj.mass.is_some();
-    let has_radius = obj.radius.is_some();
+    let skip_dimensions = matches!(obj.object_type, SectorObjectType::SolarSystem);
+    let has_mass = obj.mass.is_some() && !skip_dimensions;
+    let has_radius = obj.radius.is_some() && !skip_dimensions;
     let has_uid = obj.manny_uid.is_some();
     if has_mass || has_radius || has_uid {
         let mut detail_spans = vec![Span::raw("  ")];
@@ -2075,6 +2082,32 @@ fn sector_object_lines(obj: &SectorObject) -> Vec<Line<'_>> {
             detail_spans.push(Span::styled(uid.as_str(), Style::default().fg(Color::White)));
         }
         lines.push(Line::from(detail_spans));
+    }
+
+    // Nested bodies of a solar system
+    for target in &obj.bookmark_targets {
+        let (icon, color) = object_icon(&target.object_type);
+        let name = target.name.as_deref().unwrap_or("unnamed");
+        let mut spans = vec![
+            Span::styled("  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(icon, Style::default().fg(color)),
+            Span::raw(" "),
+            Span::raw(name.to_string()),
+        ];
+        let mut extras: Vec<String> = Vec::new();
+        if let Some(m) = target.mass {
+            extras.push(format!("{m:.3e} {}", target.mass_unit.as_deref().unwrap_or("")));
+        }
+        if let Some(r) = target.radius {
+            extras.push(format!("r {r:.3e} {}", target.radius_unit.as_deref().unwrap_or("")));
+        }
+        if !extras.is_empty() {
+            spans.push(Span::styled(
+                format!("  {}", extras.join("  ")),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        lines.push(Line::from(spans));
     }
 
     lines

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -809,6 +809,15 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
     }
 
     let has_objects = sector.objects.as_ref().is_some_and(|o| !o.is_empty());
+    let confirmed_empty = sector.objects.as_ref().is_some_and(|o| o.is_empty())
+        && sector.possible_objects.as_ref().is_none_or(|p| p.is_empty())
+        && sector.estimated_objects.is_none();
+    if confirmed_empty {
+        lines.push(Line::from(Span::styled(
+            "empty sector",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
     if !has_objects {
         if let Some(possible) = &sector.possible_objects {
             if !possible.is_empty() {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2,7 +2,7 @@ use crate::api::types::{
     DangerLevel, DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask,
     MovementPhase, ProbeStatus, SectorObject, SectorObjectType, SectorObservation, SensorMode,
 };
-use crate::app::{AppState, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{AppState, AtomicPrinterCraftInput, ATOMIC_RECIPES, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use chrono::Utc;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -72,6 +72,9 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     }
     if !matches!(state.craft, CraftInput::Inactive) {
         render_craft_overlay(frame, area, state);
+    }
+    if !matches!(state.atomic_printer_craft, AtomicPrinterCraftInput::Inactive) {
+        render_atomic_printer_craft_overlay(frame, area, state);
     }
     if !matches!(state.salvage, SalvageInput::Inactive) {
         render_salvage_overlay(frame, area, state);
@@ -283,6 +286,11 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
             hint_spans.push(Span::raw("  "));
             hint_spans.push(Span::styled("[d]", Style::default().fg(Color::Cyan)));
             hint_spans.push(Span::raw(" deploy"));
+        }
+        if state.has_atomic_printer() {
+            hint_spans.push(Span::raw("  "));
+            hint_spans.push(Span::styled("[a]", Style::default().fg(Color::Cyan)));
+            hint_spans.push(Span::raw(" atomic craft"));
         }
         frame.render_widget(
             Paragraph::new(Line::from(hint_spans)),
@@ -1495,6 +1503,62 @@ fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
         Paragraph::new(Line::from(vec![
             Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
             Span::raw(" CRAFT  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
+}
+
+fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let AtomicPrinterCraftInput::PickRecipe { selection, ref error } = state.atomic_printer_craft else { return };
+
+    let height = (ATOMIC_RECIPES.len() as u16 + 6).min(16);
+    let popup = centered_rect(52, height, area);
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(" ATOMIC PRINTER — SELECT RECIPE ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, (_, label)) in ATOMIC_RECIPES.iter().enumerate() {
+        let selected = i == selection;
+        if selected {
+            lines.push(Line::from(vec![
+                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                Span::styled(*label, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(*label, Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+    }
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(Color::Red),
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" start  "),
             Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
             Span::raw(" cancel"),
         ])),

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2,7 +2,7 @@ use crate::api::types::{
     DangerLevel, DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask,
     MovementPhase, ProbeStatus, SectorObject, SectorObjectType, SectorObservation, SensorMode,
 };
-use crate::app::{AppState, AtomicPrinterCraftInput, ATOMIC_RECIPES, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use chrono::Utc;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -1488,9 +1488,11 @@ fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
 }
 
 fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let CraftInput::Confirm { ref manny_name, ref error, .. } = state.craft else { return };
+    let CraftInput::PickRecipe { ref manny_name, selection, ref error, .. } = state.craft else { return };
 
-    let popup = centered_rect(48, 10, area);
+    let recipes = state.manny_craft_recipes();
+    let height = (recipes.len() as u16 + 6).min(16);
+    let popup = centered_rect(58, height, area);
     frame.render_widget(Clear, popup);
 
     let title = format!(" CRAFT — {manny_name} ");
@@ -1508,13 +1510,38 @@ fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
         .split(inner);
 
     let mut lines: Vec<Line> = Vec::new();
-    lines.push(Line::from(vec![
-        Span::styled("waypoint_bookmark", Style::default().fg(Color::White)),
-        Span::styled("  —  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("0.01 ECE metals, 10 min", Style::default().fg(Color::DarkGray)),
-    ]));
-    lines.push(Line::default());
+    if recipes.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "loading recipes…",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    for (i, recipe) in recipes.iter().enumerate() {
+        let selected = i == selection;
+        let duration_min = recipe.duration_seconds / 60;
+        let ingredients: String = recipe.ingredients.iter().map(|ing| {
+            if ing.unit == "item" {
+                format!("{} × {}", ing.quantity as u32, ing.ingredient_type)
+            } else {
+                format!("{:.2} ECE {}", ing.quantity, ing.ingredient_type)
+            }
+        }).collect::<Vec<_>>().join(", ");
+        let detail = format!("  {}m  {}", duration_min, ingredients);
+        if selected {
+            lines.push(Line::from(vec![
+                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                Span::styled(recipe.name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled(detail, Style::default().fg(Color::DarkGray)),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(recipe.name.as_str(), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+    }
     if let Some(err) = error {
+        lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
             Style::default().fg(Color::Red),
@@ -1524,8 +1551,10 @@ fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
+            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
             Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-            Span::raw(" CRAFT  "),
+            Span::raw(" start  "),
             Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
             Span::raw(" cancel"),
         ])),
@@ -1536,8 +1565,9 @@ fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
 fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let AtomicPrinterCraftInput::PickRecipe { selection, ref error } = state.atomic_printer_craft else { return };
 
-    let height = (ATOMIC_RECIPES.len() as u16 + 6).min(16);
-    let popup = centered_rect(52, height, area);
+    let recipes = state.atomic_printer_recipes();
+    let height = (recipes.len() as u16 + 6).min(16);
+    let popup = centered_rect(58, height, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()
@@ -1554,17 +1584,33 @@ fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect, state: &Ap
         .split(inner);
 
     let mut lines: Vec<Line> = Vec::new();
-    for (i, (_, label)) in ATOMIC_RECIPES.iter().enumerate() {
+    if recipes.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "loading recipes…",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    for (i, recipe) in recipes.iter().enumerate() {
         let selected = i == selection;
+        let duration_min = recipe.duration_seconds / 60;
+        let ingredients: String = recipe.ingredients.iter().map(|ing| {
+            if ing.unit == "item" {
+                format!("{} × {}", ing.quantity as u32, ing.ingredient_type)
+            } else {
+                format!("{:.2} ECE {}", ing.quantity, ing.ingredient_type)
+            }
+        }).collect::<Vec<_>>().join(", ");
+        let detail = format!("  {}m  {}", duration_min, ingredients);
         if selected {
             lines.push(Line::from(vec![
                 Span::styled("▶ ", Style::default().fg(Color::Yellow)),
-                Span::styled(*label, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled(recipe.name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled(detail, Style::default().fg(Color::DarkGray)),
             ]));
         } else {
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(*label, Style::default().fg(Color::DarkGray)),
+                Span::styled(recipe.name.as_str(), Style::default().fg(Color::DarkGray)),
             ]));
         }
     }

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2,7 +2,7 @@ use crate::api::types::{
     DangerLevel, DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask,
     MovementPhase, ProbeStatus, SectorObject, SectorObjectType, SectorObservation, SensorMode,
 };
-use crate::app::{AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, JettisonInput, MineInput, Panel, RecallInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use chrono::Utc;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -87,6 +87,15 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     }
     if !matches!(state.rename_manny, RenameMannyInput::Inactive) {
         render_rename_manny_overlay(frame, area, state);
+    }
+    if !matches!(state.inspect, InspectInput::Inactive) {
+        render_inspect_overlay(frame, area, state);
+    }
+    if !matches!(state.recover, RecoverInput::Inactive) {
+        render_recover_overlay(frame, area, state);
+    }
+    if !matches!(state.detach, DetachInput::Inactive) {
+        render_detach_overlay(frame, area, state);
     }
 }
 
@@ -448,6 +457,8 @@ fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
         let can_order = selected_manny.map(|m| m.can_receive_orders).unwrap_or(false);
         let is_busy = selected_manny.map(|m| !m.can_receive_orders && m.current_task.is_some()).unwrap_or(false);
         if can_order {
+            let has_detachable = !state.collect_detachable_containers().is_empty();
+            let has_detached = !state.collect_detached_containers().is_empty();
             let mut spans = vec![
                 Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
                 Span::raw(" repair  "),
@@ -457,9 +468,22 @@ fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
                 Span::raw(" craft  "),
                 Span::styled("[s]", Style::default().fg(Color::Cyan)),
                 Span::raw(" salvage  "),
-                Span::styled("[n]", Style::default().fg(Color::Cyan)),
-                Span::raw(" rename"),
+                Span::styled("[x]", Style::default().fg(Color::Cyan)),
+                Span::raw(" inspect"),
             ];
+            if has_detachable {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled("[D]", Style::default().fg(Color::Cyan)));
+                spans.push(Span::raw(" detach"));
+            }
+            if has_detached {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled("[v]", Style::default().fg(Color::Cyan)));
+                spans.push(Span::raw(" recover"));
+            }
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled("[n]", Style::default().fg(Color::Cyan)));
+            spans.push(Span::raw(" rename"));
             if is_busy {
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled("[R]", Style::default().fg(Color::Yellow)));
@@ -1980,6 +2004,232 @@ fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
         }
 
         DeployInput::Inactive => {}
+    }
+}
+
+fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let InspectInput::PickAsteroid { ref manny_name, ref candidates, selection, .. } = state.inspect else { return };
+
+    let height = (candidates.len() as u16 + 6).min(16);
+    let popup = centered_rect(52, height, area);
+    frame.render_widget(Clear, popup);
+
+    let title = format!(" INSPECT — {manny_name} ");
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled("Select asteroid to inspect:", Style::default().fg(Color::Cyan))),
+        Line::default(),
+    ];
+    for (i, (_, name)) in candidates.iter().enumerate() {
+        let selected = i == selection;
+        if selected {
+            lines.push(Line::from(vec![
+                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                Span::styled(name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(name.as_str(), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+    }
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" inspect  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
+}
+
+fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let RecoverInput::PickContainer { ref manny_name, ref candidates, selection, .. } = state.recover else { return };
+
+    let height = (candidates.len() as u16 + 6).min(16);
+    let popup = centered_rect(52, height, area);
+    frame.render_widget(Clear, popup);
+
+    let title = format!(" RECOVER — {manny_name} ");
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled("Select container to recover:", Style::default().fg(Color::Cyan))),
+        Line::default(),
+    ];
+    for (i, (_, name)) in candidates.iter().enumerate() {
+        let selected = i == selection;
+        if selected {
+            lines.push(Line::from(vec![
+                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                Span::styled(name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(name.as_str(), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+    }
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" recover  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
+}
+
+fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match &state.detach {
+        DetachInput::PickContainer { manny_name, containers, selection, .. } => {
+            let height = (containers.len() as u16 + 6).min(16);
+            let popup = centered_rect(52, height, area);
+            frame.render_widget(Clear, popup);
+            let title = format!(" DETACH — {manny_name} ");
+            let block = Block::default()
+                .title(title).title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+            let rows = Layout::default().direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+            let mut lines: Vec<Line> = vec![
+                Line::from(Span::styled("Select container to detach:", Style::default().fg(Color::Cyan))),
+                Line::default(),
+            ];
+            for (i, (_, name)) in containers.iter().enumerate() {
+                if i == *selection {
+                    lines.push(Line::from(vec![
+                        Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                        Span::styled(name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                    ]));
+                } else {
+                    lines.push(Line::from(vec![Span::raw("  "), Span::styled(name.as_str(), Style::default().fg(Color::DarkGray))]));
+                }
+            }
+            frame.render_widget(Paragraph::new(lines), rows[0]);
+            frame.render_widget(Paragraph::new(Line::from(vec![
+                Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)), Span::raw(" select  "),
+                Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)), Span::raw(" next  "),
+                Span::styled("[Esc]", Style::default().fg(Color::Cyan)), Span::raw(" cancel"),
+            ])), rows[1]);
+        }
+
+        DetachInput::PickMode { manny_name, container_name, selection, error, .. } => {
+            let popup = centered_rect(52, 10, area);
+            frame.render_widget(Clear, popup);
+            let title = format!(" DETACH — {container_name} ");
+            let block = Block::default()
+                .title(title).title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+            let rows = Layout::default().direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+
+            let mut lines: Vec<Line> = vec![
+                Line::from(Span::styled(format!("Detach mode  (manny: {manny_name})"), Style::default().fg(Color::Cyan))),
+                Line::default(),
+            ];
+            for (i, (_, label)) in crate::DETACH_MODES.iter().enumerate() {
+                if i == *selection {
+                    lines.push(Line::from(vec![
+                        Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                        Span::styled(*label, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                    ]));
+                } else {
+                    lines.push(Line::from(vec![Span::raw("  "), Span::styled(*label, Style::default().fg(Color::DarkGray))]));
+                }
+            }
+            if let Some(err) = error {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+            }
+            frame.render_widget(Paragraph::new(lines), rows[0]);
+            frame.render_widget(Paragraph::new(Line::from(vec![
+                Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)), Span::raw(" select  "),
+                Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)), Span::raw(" confirm  "),
+                Span::styled("[Esc]", Style::default().fg(Color::Cyan)), Span::raw(" cancel"),
+            ])), rows[1]);
+        }
+
+        DetachInput::PickAsteroid { manny_name, container_name, asteroids, selection, error, .. } => {
+            let height = (asteroids.len() as u16 + 8).min(18);
+            let popup = centered_rect(52, height, area);
+            frame.render_widget(Clear, popup);
+            let title = format!(" DETACH — hide {container_name} ");
+            let block = Block::default()
+                .title(title).title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+            let rows = Layout::default().direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+
+            let mut lines: Vec<Line> = vec![
+                Line::from(Span::styled(format!("Attach to asteroid  (manny: {manny_name})"), Style::default().fg(Color::Cyan))),
+                Line::default(),
+            ];
+            for (i, (_, name)) in asteroids.iter().enumerate() {
+                if i == *selection {
+                    lines.push(Line::from(vec![
+                        Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+                        Span::styled(name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                    ]));
+                } else {
+                    lines.push(Line::from(vec![Span::raw("  "), Span::styled(name.as_str(), Style::default().fg(Color::DarkGray))]));
+                }
+            }
+            if let Some(err) = error {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+            }
+            frame.render_widget(Paragraph::new(lines), rows[0]);
+            frame.render_widget(Paragraph::new(Line::from(vec![
+                Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)), Span::raw(" select  "),
+                Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)), Span::raw(" hide here  "),
+                Span::styled("[Esc]", Style::default().fg(Color::Cyan)), Span::raw(" cancel"),
+            ])), rows[1]);
+        }
+
+        DetachInput::Inactive => {}
     }
 }
 

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -825,6 +825,23 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
         }
     }
 
+    if let Some(probes) = &sector.probes {
+        if !probes.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "── other probes ──",
+                Style::default().fg(Color::DarkGray),
+            )));
+            for p in probes {
+                let moving = if p.moving { " moving" } else { " idle" };
+                lines.push(Line::from(vec![
+                    Span::styled("⊕ ", Style::default().fg(Color::Cyan)),
+                    Span::raw(p.name.as_str()),
+                    Span::styled(moving, Style::default().fg(Color::DarkGray)),
+                ]));
+            }
+        }
+    }
+
     let has_objects = sector.objects.as_ref().is_some_and(|o| !o.is_empty());
     let confirmed_empty = sector.objects.as_ref().is_some_and(|o| o.is_empty())
         && sector.possible_objects.as_ref().is_none_or(|p| p.is_empty())
@@ -2034,23 +2051,46 @@ fn sector_object_lines(obj: &SectorObject) -> Vec<Line<'_>> {
 
     let manny_state = obj.manny_state.as_deref().unwrap_or("");
 
+    let salvageable = obj.salvageable.unwrap_or(false);
+
     let mut main_spans = vec![
         Span::styled(icon, Style::default().fg(color)),
         Span::raw(" "),
         Span::styled(estimated, Style::default().fg(Color::DarkGray)),
         Span::raw(format!("{name}{danger}")),
     ];
+    if salvageable {
+        main_spans.push(Span::styled("  ⬡ salvageable", Style::default().fg(Color::Yellow)));
+    }
     if !manny_state.is_empty() {
         main_spans.push(Span::styled(
             format!("  [{manny_state}]"),
             Style::default().fg(Color::DarkGray),
         ));
     }
-    if let Some(summary) = &obj.summary {
-        main_spans.push(Span::styled(
-            format!("  {summary}"),
-            Style::default().fg(Color::DarkGray),
-        ));
+    // drifting item: show type + quantity instead of summary
+    if obj.object_type == SectorObjectType::DriftingItem {
+        if let (Some(itype), Some(qty)) = (&obj.item_type, obj.quantity) {
+            main_spans.push(Span::styled(
+                format!("  {itype} × {qty}"),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+    } else if obj.object_type == SectorObjectType::DetachedContainer {
+        if let Some(cap) = obj.capacity {
+            let mode = obj.mode.as_deref().unwrap_or("drifting");
+            main_spans.push(Span::styled(
+                format!("  {mode}  {cap:.2} ECE"),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+    } else if let Some(summary) = &obj.summary {
+        if !matches!(obj.object_type, SectorObjectType::SolarSystem) || obj.bookmark_targets.is_empty() {
+            main_spans.push(Span::styled(
+                format!("  {summary}"),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
     }
 
     let mut lines = vec![Line::from(main_spans)];

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -315,13 +315,7 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
     };
 
     let items_expanded = focused && !inv.items.is_empty();
-    let items_rows: usize = if items_expanded {
-        1 + inv.items.len()
-    } else if !inv.items.is_empty() {
-        1
-    } else {
-        0
-    };
+    let items_rows: usize = items_row_count(&inv.items, items_expanded);
     let n_rows = 1 + inv.resource_stocks.len() + items_rows;
 
     let mut sections: Vec<Constraint> = (0..n_rows).map(|_| Constraint::Length(1)).collect();
@@ -373,19 +367,19 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
             rows[row],
         );
         row += 1;
-        for item in &inv.items {
-            let (icon, icon_color) = match item.item_type.as_str() {
-                "manny" => ("♟", Color::Green),
-                _ => ("◈", Color::White),
-            };
-            let task_span = match item.current_task.as_deref() {
-                None => Span::styled("idle", Style::default().fg(Color::DarkGray)),
-                Some(t) => Span::styled(t.to_string(), Style::default().fg(Color::Yellow)),
-            };
-            let progress = if item.current_task.is_some() {
-                format!(" {:3.0}%", item.task_progress_percent)
-            } else {
-                String::new()
+
+        // Active items: manny and atomic_3d_printer — show individually with task state
+        for item in inv.items.iter().filter(|i| is_active_item(&i.item_type)) {
+            let (icon, icon_color) = item_icon(&item.item_type);
+            let (task_span, progress) = match item.current_task.as_deref() {
+                None => (
+                    Span::styled("idle", Style::default().fg(Color::DarkGray)),
+                    String::new(),
+                ),
+                Some(t) => (
+                    Span::styled(t.to_string(), Style::default().fg(Color::Yellow)),
+                    format!(" {:3.0}%", item.task_progress_percent),
+                ),
             };
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
@@ -393,6 +387,26 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
                     Span::raw(format!("{:<14}", item.name)),
                     task_span,
                     Span::styled(progress, Style::default().fg(Color::DarkGray)),
+                ])),
+                rows[row],
+            );
+            row += 1;
+        }
+
+        // Passive items: group by type, show count
+        let mut seen_types: Vec<&str> = Vec::new();
+        for item in inv.items.iter().filter(|i| !is_active_item(&i.item_type)) {
+            if seen_types.contains(&item.item_type.as_str()) {
+                continue;
+            }
+            seen_types.push(&item.item_type);
+            let count = inv.items.iter().filter(|i| i.item_type == item.item_type).count();
+            let (icon, icon_color) = item_icon(&item.item_type);
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(format!("  {icon} "), Style::default().fg(icon_color)),
+                    Span::raw(format!("{:<14}", item.name)),
+                    Span::styled(format!("× {count}"), Style::default().fg(Color::White)),
                 ])),
                 rows[row],
             );
@@ -2257,13 +2271,8 @@ fn inventory_panel_height(state: &AppState) -> u16 {
     let inv = &probe.inventory;
     let focused = state.focused == Some(Panel::Inventory);
     let n_stocks = inv.resource_stocks.len() as u16;
-    let items_rows: u16 = if focused && !inv.items.is_empty() {
-        1 + inv.items.len() as u16
-    } else if !inv.items.is_empty() {
-        1
-    } else {
-        0
-    };
+    let expanded = focused && !inv.items.is_empty();
+    let items_rows = items_row_count(&inv.items, expanded) as u16;
     1 + n_stocks + items_rows + 2
 }
 
@@ -2272,6 +2281,35 @@ fn top_row_height(state: &AppState) -> u16 {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn is_active_item(item_type: &str) -> bool {
+    matches!(item_type, "manny" | "atomic_3d_printer")
+}
+
+fn item_icon(item_type: &str) -> (&'static str, Color) {
+    match item_type {
+        "manny" => ("♟", Color::Green),
+        "atomic_3d_printer" => ("⚙", Color::Magenta),
+        "additional_container" => ("□", Color::Cyan),
+        "waypoint_bookmark" => ("◎", Color::Cyan),
+        "micro_conductor" | "ceramic_insulator" | "crystal_substrate"
+        | "dopant_matrix" | "integrated_circuit" => ("◈", Color::Yellow),
+        _ => ("◈", Color::White),
+    }
+}
+
+fn items_row_count(items: &[crate::api::types::ProbeInventoryItem], expanded: bool) -> usize {
+    if items.is_empty() { return 0; }
+    if !expanded { return 1; }
+    let n_active = items.iter().filter(|i| is_active_item(&i.item_type)).count();
+    let mut seen: Vec<&str> = Vec::new();
+    for item in items.iter().filter(|i| !is_active_item(&i.item_type)) {
+        if !seen.contains(&item.item_type.as_str()) {
+            seen.push(&item.item_type);
+        }
+    }
+    1 + n_active + seen.len()
+}
 
 fn knowledge_label(k: &KnowledgeLevel) -> &'static str {
     match k {


### PR DESCRIPTION
## Summary

- **fix(api)**: replace removed waypoint-deploy endpoint, complete `MannyTask`/`SectorObject` enums
- **feat(ui)**: atomic printer craft via `POST /api/probe/atomic-printer/craft`
- **fix(ui)**: show "empty sector" in scanner when sector has no objects
- **feat(ui)**: enrich storage types, split active/passive items in inventory
- **feat(craft)**: load crafting recipes from `GET /api/crafting-recipes`, dynamic pickers for manny craft and atomic printer
- **feat(scanner)**: list solar system bodies from `bookmarkTargets`, add detail scroll `[J/K]`
- **feat(types)**: complete `SectorObject` fields, add `SectorProbePresence`, display other probes in scanner
- **feat(mannies)**: implement v23 endpoints — `inspect-asteroid` `[x]`, `recover-storage-container` `[v]`, `detach-storage-container` `[D]` (3-step flow: container → mode → asteroid)

## Test plan

- [ ] Craft via manny picker (dynamic recipes filtré par `craftable_by`)
- [ ] Craft via atomic printer picker
- [ ] Scanner : secteur avec système solaire → vérifier les corps imbriqués listés
- [ ] Scanner : scroll `[J/K]` sur un secteur dense
- [ ] Mannies : `[x]` inspect asteroid (manny idle requis)
- [ ] Mannies : `[D]` detach container → mode drifting
- [ ] Mannies : `[D]` detach container → mode hidden → pick asteroid
- [ ] Mannies : `[v]` recover container depuis le secteur