### PR TITLE
fix(app): propagate inspect/recover errors to overlay + update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ base_url = "https://neumann-probe.net"
 api_key  = "vng_..."
 ```
 
-Copy `config.example.toml` to that path and fill in the API key (generated once via the web UI, shown only at creation time).
+Copy `config.example.toml` to that path and fill in the API key (generated once via the web UI).
+
+Scan history is persisted across runs to `~/.config/neumann-cockpit/scan_history.json`.
 
 ## Architecture
 
@@ -31,41 +33,102 @@ Copy `config.example.toml` to that path and fill in the API key (generated once 
 
 Single `tokio::select!` loop over three sources:
 
-- **crossterm `EventStream`** — keyboard / mouse / resize
+- **crossterm `EventStream`** — keyboard / mouse / resize events
 - **`mpsc::Receiver<ApiMessage>`** — results from spawned API tasks
 - **`tokio::time::sleep_until(deadline)`** — auto-refresh timer
 
-The timer deadline is set to `movement.arrival_at` (ISO 8601 from the API) converted to a `tokio::time::Instant`. When no movement is in progress the deadline is 24 h away — no polling, no tick loop.
+The timer deadline is set to `movement.arrival_at` (ISO 8601) converted to a `tokio::time::Instant`. When no movement is in progress the deadline is 24 h away — no polling, no tick loop.
 
-`fetch_all()` spawns two independent `tokio::spawn` tasks (probe + mannies); mannies failure is non-fatal.
+`fetch_all()` spawns **three** independent `tokio::spawn` tasks: probe, mannies, and sector. Mannies and sector failures are non-fatal.
+
+All other API calls (move, repair, mine, craft, etc.) are also spawned tasks that send results back via the `mpsc::Sender<ApiMessage>`.
+
+`main.rs` is currently large (~1600 lines) and mixes three concerns: the `tokio::select!` loop, all keyboard handlers (`handle_*_event`), and all `fetch_*` spawner functions. Planned refactor: extract handlers to `src/input.rs` and fetchers to `src/api/tasks.rs`.
 
 ### State (`src/app.rs`)
 
-`AppState` is the single source of truth passed to the renderer. `update_probe()` extracts `movement_arrival` from the response and stores it separately so the event loop can compute the next deadline without re-reading the full probe struct.
+`AppState` is the single source of truth passed to the renderer. Key design choices:
+
+- Each interactive action (travel, repair, mine, craft, jettison, salvage, recall, rename, deploy, inspect, recover, detach, atomic printer craft) has its own input state enum (`TravelInput`, `RepairInput`, etc.) with variants for each wizard step. All start as `Inactive`.
+- `update_probe()` extracts `movement_arrival` from the response and stores it separately so the event loop can compute the next deadline without re-reading the full probe struct.
+- Scan history is cached in `AppState::scan_history` (a `Vec<SectorObservation>`) and persisted to disk asynchronously after each sector fetch.
+- `RESOURCE_TYPES` and `DETACH_MODES` constants live here (not in `main.rs` or `cockpit.rs`).
 
 ### API layer (`src/api/`)
 
 - `types.rs` — all OpenAPI types. Structs use `#[serde(rename_all = "camelCase")]`; enums use `#[serde(rename_all = "snake_case")]` with `#[serde(other)] Unknown` fallbacks. `#![allow(dead_code)]` suppresses warnings on fields not yet consumed by the UI.
-- `client.rs` — `ApiClient` (cloneable, wraps `reqwest::Client`). Each endpoint has a typed wrapper that deserializes the envelope and returns the inner value.
+- `client.rs` — `ApiClient` (cloneable, wraps `reqwest::Client`). Each endpoint has a typed wrapper with an inline `struct Resp` that deserializes the envelope and returns the inner value. HTTP errors extract `error.message` from the JSON body; 401 produces a specific "check your api_key" message.
 
 ### UI (`src/ui/cockpit.rs`)
 
-`render(frame, state)` is the single render entry point called every loop iteration. Layout:
+`render(frame, state)` is the single render entry point called every loop iteration. Layout — two rows, each split into two columns:
 
 ```
-┌─ NEUMANN COCKPIT ──────────────────────────────────────────┐
-│  ┌─ PROBE (45%) ──────────┐  ┌─ MANNIES (55%) ───────────┐ │
-│  │ name + status          │  │ ● manny-1  idle           │ │
-│  │ sensor mode dot        │  │ ◌ manny-2  mining   42%   │ │
-│  │ movement + ETA gauge   │  │                           │ │
-│  │ fuel gauge             │  │                           │ │
-│  │ integrity gauge        │  │                           │ │
-│  │ cargo gauge            │  │                           │ │
-│  └────────────────────────┘  └───────────────────────────┘ │
-│ [r] refresh  [q] quit          ⟳ HH:MM:SS   next: Xm Ys   │
-└────────────────────────────────────────────────────────────┘
+┌─ NEUMANN COCKPIT ─────────────────────────────────────────────┐
+│  ┌─ PROBE ─────────────────┐  ┌─ INVENTORY ─────────────────┐ │
+│  │ name · status · sector  │  │ capacity gauge              │ │
+│  │ movement phase + ETA    │  │ resource stocks             │ │
+│  │ progress gauge          │  │ items list (expandable)     │ │
+│  │ speed gauge             │  │ [j] jettison  [d] deploy    │ │
+│  │ fuel gauge              │  │ [a] atomic craft            │ │
+│  │ integrity gauge         │  └─────────────────────────────┘ │
+│  └─────────────────────────┘                                  │
+│  ┌─ SCANNER ───────────────┐  ┌─ MANNIES ───────────────────┐ │
+│  │ sector detail / history │  │ ● manny-1  idle             │ │
+│  │ [↑/↓] scroll history   │  │ ◌ manny-2  mining   42%     │ │
+│  │ [enter] drill-down      │  │ [c] craft  [n] mine         │ │
+│  │ [f] batch scan          │  │ [x] repair [l] recall       │ │
+│  └─────────────────────────┘  │ [v] salvage [e] rename      │ │
+│                               └─────────────────────────────┘ │
+│ [r] refresh [p][i][m][s] focus [t] travel [b] map [q] quit    │
+│                                    v23.0.0  API v23  ⟳ HH:MM  │
+└───────────────────────────────────────────────────────────────┘
 ```
 
-Gauge colors: green > 50 %, yellow 25–50 %, red < 25 %. Sensor mode and probe status are colour-coded. Movement progress is derived from `started_at` / `arrival_at` timestamps client-side (more accurate than the API's `secondsRemaining` snapshot).
+Top row height is dynamic: `max(probe_panel_height, inventory_panel_height)`. The focused panel gets a white border; others are dimmed.
 
-The layout is designed to be extended: the right column is a single `Rect` today and will be split vertically to add a SECTOR panel above MANNIES.
+Gauge colors: green > 50 %, yellow 25–50 %, red < 25 %. Probe status and sensor mode are colour-coded.
+
+Movement progress is derived from `started_at` / `arrival_at` timestamps client-side (more accurate than the API's `secondsRemaining` snapshot).
+
+**Overlays** (rendered on top of the 4-panel layout):
+- Travel — coordinate input + fuel cost preview + confirmation
+- Repair / Mine / Craft / Atomic printer craft — manny/target/recipe pickers
+- Jettison / Salvage / Recall / Rename / Inspect / Recover / Detach — inventory/sector object pickers
+- Deploy waypoint — 3-step wizard: pick manny → pick object → enter bookmark name
+- Map (`[b]`) — isometric sector overview with pan (`[↑↓←→]`) and layer selection
+
+### Known issues / planned refactors
+
+- `set_inspect_error` and `set_recover_error` in `app.rs` are no-ops: errors from the API on inspect/recover are silently dropped. Fix: add `error: Option<String>` to `InspectInput::PickAsteroid` and `RecoverInput::PickContainer`.
+- `collect_mineable_candidates` and `collect_asteroid_candidates` are free functions in `main.rs`; the other `collect_*` functions are methods on `AppState`. Consolidate all into `AppState` methods.
+- List navigation (Up/Down/Esc/Enter) is copy-pasted ~9× across handlers. Extract a `list_nav(code, sel, count) -> NavResult` helper.
+- Selection overlays (mine, salvage, deploy, inspect, recover, detach) are structurally identical. Extract a `render_selection_overlay(...)` helper to remove ~300 lines of duplication.
+- `ManniesResponse` in `types.rs` is unused — delete it.
+- `travel_go_sector` has an unused `_dist_hint` parameter — remove it and the call-site calculation.
+
+## Implemented API endpoints (v23)
+
+| Endpoint | Method | Status |
+|---|---|---|
+| `/api/version` | GET | ✓ |
+| `/api/probe` | GET | ✓ |
+| `/api/probe/mannies` | GET | ✓ |
+| `/api/probe/sector` | GET | ✓ |
+| `/api/probe/move` | POST | ✓ |
+| `/api/probe/mannies/{id}/repair` | POST | ✓ |
+| `/api/probe/mannies/{id}/mine` | POST | ✓ |
+| `/api/probe/mannies/{id}/craft` | POST | ✓ |
+| `/api/probe/mannies/{id}/salvage` | POST | ✓ |
+| `/api/probe/mannies/{id}/recall` | POST | ✓ |
+| `/api/probe/mannies/{id}` | PATCH | ✓ (rename) |
+| `/api/probe/mannies/{id}/install-bookmark` | POST | ✓ |
+| `/api/probe/mannies/{id}/inspect-asteroid` | POST | ✓ |
+| `/api/probe/mannies/{id}/recover-storage-container` | POST | ✓ |
+| `/api/probe/mannies/{id}/detach-storage-container` | POST | ✓ |
+| `/api/probe/inventory/{id}/jettison` | POST | ✓ |
+| `/api/probe/atomic-printer/craft` | POST | ✓ |
+| `/api/crafting-recipes` | GET | ✓ |
+| `/api/sector` | GET | ✓ |
+| `/api/probe/visited-sectors` | GET | ✗ (not implemented) |
+| `/api/probe/messages` | GET/POST | ✗ (not implemented) |

--- a/src/app.rs
+++ b/src/app.rs
@@ -197,6 +197,7 @@ pub enum InspectInput {
         manny_name: String,
         candidates: Vec<(String, String)>,
         selection: usize,
+        error: Option<String>,
     },
 }
 
@@ -209,6 +210,7 @@ pub enum RecoverInput {
         manny_name: String,
         candidates: Vec<(String, String)>,
         selection: usize,
+        error: Option<String>,
     },
 }
 
@@ -841,14 +843,15 @@ impl AppState {
     }
 
     pub fn set_inspect_error(&mut self, msg: String) {
-        if let InspectInput::PickAsteroid { ref mut candidates, .. } = self.inspect {
-            let _ = candidates;
+        if let InspectInput::PickAsteroid { ref mut error, .. } = self.inspect {
+            *error = Some(msg);
         }
-        let _ = msg;
     }
 
     pub fn set_recover_error(&mut self, msg: String) {
-        let _ = msg;
+        if let RecoverInput::PickContainer { ref mut error, .. } = self.recover {
+            *error = Some(msg);
+        }
     }
 
     pub fn set_detach_error(&mut self, msg: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -567,6 +567,7 @@ fn handle_event(
                                     manny_name: manny.name.clone(),
                                     candidates,
                                     selection: 0,
+                                    error: None,
                                 };
                             }
                         }
@@ -591,6 +592,7 @@ fn handle_event(
                                     manny_name: manny.name.clone(),
                                     candidates,
                                     selection: 0,
+                                    error: None,
                                 };
                             }
                         }

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2008,9 +2008,10 @@ fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
 }
 
 fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let InspectInput::PickAsteroid { ref manny_name, ref candidates, selection, .. } = state.inspect else { return };
+    let InspectInput::PickAsteroid { ref manny_name, ref candidates, selection, ref error, .. } = state.inspect else { return };
 
-    let height = (candidates.len() as u16 + 6).min(16);
+    let error_lines = if error.is_some() { 2u16 } else { 0 };
+    let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     let popup = centered_rect(52, height, area);
     frame.render_widget(Clear, popup);
 
@@ -2046,6 +2047,10 @@ fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
             ]));
         }
     }
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+    }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
@@ -2061,9 +2066,10 @@ fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
 }
 
 fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let RecoverInput::PickContainer { ref manny_name, ref candidates, selection, .. } = state.recover else { return };
+    let RecoverInput::PickContainer { ref manny_name, ref candidates, selection, ref error, .. } = state.recover else { return };
 
-    let height = (candidates.len() as u16 + 6).min(16);
+    let error_lines = if error.is_some() { 2u16 } else { 0 };
+    let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     let popup = centered_rect(52, height, area);
     frame.render_widget(Clear, popup);
 
@@ -2098,6 +2104,10 @@ fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
                 Span::styled(name.as_str(), Style::default().fg(Color::DarkGray)),
             ]));
         }
+    }
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(


### PR DESCRIPTION
## Summary

- **Bug fix**: `set_inspect_error` et `set_recover_error` étaient des no-ops — les erreurs API retournées lors des actions inspect/recover étaient silencieusement ignorées
- Ajout du champ `error: Option<String>` aux variants `InspectInput::PickAsteroid` et `RecoverInput::PickContainer`
- Affichage de l'erreur en rouge dans les deux overlays (même pattern que `DetachInput::PickMode`)
- **CLAUDE.md** réécrit pour refléter l'état réel du code : layout 2×2, `fetch_all()` spawn 3 tâches, tous les raccourcis clavier, overlays, historique de scan, table des endpoints API v23

## Changes

- `src/app.rs`: champ `error` ajouté aux deux enums, setters corrigés
- `src/main.rs`: `error: None` aux deux sites de construction
- `src/ui/cockpit.rs`: overlays inspect et recover affichent l'erreur
- `CLAUDE.md`: réécriture complète (layout, architecture, raccourcis, endpoints)