### PR TITLE
chore: remove .claude/scheduled_tasks.lock from git tracking

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d3f4f98f-450c-44c0-8f59-98691c6926f6","pid":188473,"procStart":"536309","acquiredAt":1780950078226}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.claude/*.lock


### PR DESCRIPTION
## Summary

- Removes `.claude/scheduled_tasks.lock` from git tracking — this is an internal Claude Code lock file that has no place in the repository
- Adds `/.claude/*.lock` to `.gitignore` to prevent future commits of such files

## Test plan

- [ ] Verify `.claude/scheduled_tasks.lock` is no longer tracked after merge
- [ ] Verify the file still exists locally (only removed from tracking, not deleted)