### PR TITLE
feat(inventory): selectable rows, direct jettison, containers and tanks display

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -174,10 +174,6 @@ pub enum DeployInput {
 pub enum JettisonInput {
     #[default]
     Inactive,
-    PickItem {
-        items: Vec<(String, String, bool)>,
-        selection: usize,
-    },
     ConfirmManny {
         item_id: String,
         manny_name: String,
@@ -283,6 +279,20 @@ pub enum ApiMessage {
     Error(String),
 }
 
+/// Active items (manny, atomic printer) are listed individually in the
+/// inventory panel; passive items are grouped by type.
+pub fn is_active_item(item_type: &str) -> bool {
+    matches!(item_type, "manny" | "atomic_3d_printer")
+}
+
+/// One navigable row of the inventory panel, in display order.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InventoryRow {
+    Stock { id: String },
+    ActiveItem { id: String },
+    PassiveGroup { item_type: String },
+}
+
 #[derive(Default)]
 pub struct AppState {
     pub probe: Option<Probe>,
@@ -294,6 +304,7 @@ pub struct AppState {
     pub quit: bool,
     pub focused: Option<Panel>,
     pub mannies_selection: usize,
+    pub inventory_selection: usize,
     pub scan_history: Vec<SectorObservation>,
     pub scan_history_idx: usize,
     pub scan_loading: bool,
@@ -329,6 +340,16 @@ impl AppState {
         self.probe = Some(probe);
         self.last_update = Some(Local::now());
         self.error = None;
+        self.clamp_inventory_selection();
+    }
+
+    fn clamp_inventory_selection(&mut self) {
+        let count = self.inventory_rows().len();
+        self.inventory_selection = if count == 0 {
+            0
+        } else {
+            self.inventory_selection.min(count - 1)
+        };
     }
 
     pub fn update_mannies(&mut self, mannies: Vec<Manny>) {
@@ -666,34 +687,102 @@ impl AppState {
         self.map.center_z -= dy;
     }
 
-    pub fn build_jettison_items(&self) -> Vec<(String, String, bool)> {
+    /// Navigable rows of the inventory panel, in display order:
+    /// resource stocks, then active items, then passive groups.
+    pub fn inventory_rows(&self) -> Vec<InventoryRow> {
         let Some(probe) = &self.probe else { return vec![] };
         let inv = &probe.inventory;
-        let mut out: Vec<(String, String, bool)> = Vec::new();
+        let mut out: Vec<InventoryRow> = Vec::new();
         for stock in &inv.resource_stocks {
-            if stock.amount > 0.0 {
-                let label = format!("{} ({:.3} ECE)", stock.name, stock.amount);
-                out.push((stock.id.clone(), label, false));
-            }
+            out.push(InventoryRow::Stock { id: stock.id.clone() });
         }
-        for item in &inv.items {
-            if item.item_type == "manny" {
-                let in_probe = item.location.as_ref()
-                    .map(|l| l.location_type == crate::api::types::MannyLocationType::Probe)
-                    .unwrap_or(false);
-                let idle = item.current_task.is_none();
-                if in_probe && idle {
-                    out.push((item.id.clone(), item.name.clone(), true));
-                }
+        for item in inv.items.iter().filter(|i| is_active_item(&i.item_type)) {
+            out.push(InventoryRow::ActiveItem { id: item.id.clone() });
+        }
+        let mut seen: Vec<&str> = Vec::new();
+        for item in inv.items.iter().filter(|i| !is_active_item(&i.item_type)) {
+            if !seen.contains(&item.item_type.as_str()) {
+                seen.push(&item.item_type);
+                out.push(InventoryRow::PassiveGroup { item_type: item.item_type.clone() });
             }
         }
         out
+    }
+
+    pub fn selected_inventory_row(&self) -> Option<InventoryRow> {
+        self.inventory_rows().into_iter().nth(self.inventory_selection)
+    }
+
+    pub fn inventory_next(&mut self) {
+        let count = self.inventory_rows().len();
+        if count > 0 {
+            self.inventory_selection = (self.inventory_selection + 1) % count;
+        }
+    }
+
+    pub fn inventory_prev(&mut self) {
+        let count = self.inventory_rows().len();
+        if count > 0 {
+            self.inventory_selection = self
+                .inventory_selection
+                .checked_sub(1)
+                .unwrap_or(count - 1);
+        }
+    }
+
+    /// Build the jettison wizard state for the currently selected inventory row.
+    pub fn jettison_for_selected(&self) -> Result<JettisonInput, String> {
+        let Some(probe) = &self.probe else { return Err("no probe data".into()) };
+        match self.selected_inventory_row() {
+            Some(InventoryRow::Stock { id }) => {
+                let stock = probe.inventory.resource_stocks.iter()
+                    .find(|s| s.id == id)
+                    .ok_or_else(|| "stock not found".to_string())?;
+                if stock.amount <= 0.0 {
+                    return Err(format!("{} stock is empty", stock.name));
+                }
+                Ok(JettisonInput::EnterAmount {
+                    item_id: stock.id.clone(),
+                    item_name: stock.name.clone(),
+                    max_amount: stock.amount,
+                    buf: String::new(),
+                    error: None,
+                })
+            }
+            Some(InventoryRow::ActiveItem { id }) => {
+                let item = probe.inventory.items.iter()
+                    .find(|i| i.id == id)
+                    .ok_or_else(|| "item not found".to_string())?;
+                if item.item_type != "manny" {
+                    return Err("only resource stocks and mannies can be jettisoned".into());
+                }
+                let in_probe = item.location.as_ref()
+                    .map(|l| l.location_type == crate::api::types::MannyLocationType::Probe)
+                    .unwrap_or(false);
+                if !in_probe {
+                    return Err(format!("{} is not aboard the probe", item.name));
+                }
+                if item.current_task.is_some() {
+                    return Err(format!("{} is busy", item.name));
+                }
+                Ok(JettisonInput::ConfirmManny {
+                    item_id: item.id.clone(),
+                    manny_name: item.name.clone(),
+                    error: None,
+                })
+            }
+            Some(InventoryRow::PassiveGroup { .. }) => {
+                Err("only resource stocks and mannies can be jettisoned".into())
+            }
+            None => Err("inventory is empty".into()),
+        }
     }
 
     pub fn update_inventory(&mut self, inv: ProbeInventory) {
         if let Some(ref mut probe) = self.probe {
             probe.inventory = inv;
         }
+        self.clamp_inventory_selection();
     }
 
     pub fn jettison_type_char(&mut self, c: char) {
@@ -1154,92 +1243,131 @@ mod tests {
         assert_eq!(state.mine_max_amount(), 0.0);
     }
 
-    // ── build_jettison_items ──────────────────────────────────────────────────
+    // ── inventory_rows / jettison_for_selected ────────────────────────────────
 
-    #[test]
-    fn build_jettison_items_no_probe_is_empty() {
-        let state = AppState::default();
-        assert!(state.build_jettison_items().is_empty());
-    }
-
-    #[test]
-    fn build_jettison_items_resource_stock_included() {
-        let mut state = AppState::default();
-        let probe: Probe = serde_json::from_str(r#"{
+    fn probe_with_inventory(items_json: &str, stocks_json: &str) -> Probe {
+        serde_json::from_str(&format!(r#"{{
             "id": 1, "name": "test", "status": "idle",
-            "fuel": {"deuterium": 100.0}, "sensorMode": "normal",
+            "fuel": {{"deuterium": 100.0}}, "sensorMode": "normal",
             "sector": null, "movement": null, "systems": null,
-            "inventory": {
-                "capacity": 10.0, "usedCapacity": 0.5, "freeCapacity": 9.5,
-                "items": [],
-                "resourceStocks": [{
-                    "id": "stock-metals", "type": "metals", "name": "Metals",
-                    "amount": 0.5, "containerSpace": 0.5, "containers": []
-                }],
+            "inventory": {{
+                "capacity": 10.0, "usedCapacity": 1.0, "freeCapacity": 9.0,
+                "items": {items_json},
+                "resourceStocks": {stocks_json},
                 "externalTanks": [], "containers": []
-            }
-        }"#).unwrap();
-        state.probe = Some(probe);
-        let items = state.build_jettison_items();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].0, "stock-metals");
-        assert!(!items[0].2, "resource stock should not be is_manny");
-        assert!(items[0].1.contains("Metals"));
-        assert!(items[0].1.contains("0.500"));
+            }}
+        }}"#)).unwrap()
+    }
+
+    const STOCK_METALS: &str = r#"[{
+        "id": "stock-metals", "type": "metals", "name": "Metals",
+        "amount": 0.5, "containerSpace": 0.5, "containers": []
+    }]"#;
+
+    fn manny_item(task: Option<&str>) -> String {
+        let task_json = task.map(|t| format!("\"{t}\"")).unwrap_or("null".into());
+        format!(r#"{{
+            "id": "manny-1", "type": "manny", "name": "Manny-1",
+            "containerSpace": 1.0,
+            "currentTask": {task_json},
+            "taskProgressPercent": 0.0,
+            "location": {{"type": "probe", "sector": null}},
+            "cargo": null,
+            "container": null
+        }}"#)
     }
 
     #[test]
-    fn build_jettison_items_idle_probe_manny_included() {
-        let mut state = AppState::default();
-        let probe: Probe = serde_json::from_str(r#"{
-            "id": 1, "name": "test", "status": "idle",
-            "fuel": {"deuterium": 100.0}, "sensorMode": "normal",
-            "sector": null, "movement": null, "systems": null,
-            "inventory": {
-                "capacity": 10.0, "usedCapacity": 1.0, "freeCapacity": 9.0,
-                "items": [{
-                    "id": "manny-1", "type": "manny", "name": "Manny-1",
-                    "containerSpace": 1.0,
-                    "currentTask": null,
-                    "taskProgressPercent": 0.0,
-                    "location": {"type": "probe", "sector": null},
-                    "cargo": null,
-                    "container": null
-                }],
-                "resourceStocks": [], "externalTanks": [], "containers": []
-            }
-        }"#).unwrap();
-        state.probe = Some(probe);
-        let items = state.build_jettison_items();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].0, "manny-1");
-        assert!(items[0].2, "manny item should have is_manny=true");
+    fn inventory_rows_no_probe_is_empty() {
+        let state = AppState::default();
+        assert!(state.inventory_rows().is_empty());
+        assert_eq!(state.selected_inventory_row(), None);
     }
 
     #[test]
-    fn build_jettison_items_busy_manny_excluded() {
+    fn inventory_rows_order_stocks_active_passive() {
         let mut state = AppState::default();
-        let probe: Probe = serde_json::from_str(r#"{
-            "id": 1, "name": "test", "status": "idle",
-            "fuel": {"deuterium": 100.0}, "sensorMode": "normal",
-            "sector": null, "movement": null, "systems": null,
-            "inventory": {
-                "capacity": 10.0, "usedCapacity": 1.0, "freeCapacity": 9.0,
-                "items": [{
-                    "id": "manny-1", "type": "manny", "name": "Manny-1",
-                    "containerSpace": 1.0,
-                    "currentTask": "mining",
-                    "taskProgressPercent": 50.0,
-                    "location": {"type": "probe", "sector": null},
-                    "cargo": null,
-                    "container": null
-                }],
-                "resourceStocks": [], "externalTanks": [], "containers": []
+        let items = format!(r#"[
+            {{"id": "wb-1", "type": "waypoint_bookmark", "name": "Bookmark",
+              "containerSpace": 0.1, "currentTask": null, "taskProgressPercent": 0.0,
+              "location": null, "cargo": null, "container": null}},
+            {{"id": "wb-2", "type": "waypoint_bookmark", "name": "Bookmark",
+              "containerSpace": 0.1, "currentTask": null, "taskProgressPercent": 0.0,
+              "location": null, "cargo": null, "container": null}},
+            {}
+        ]"#, manny_item(None));
+        state.probe = Some(probe_with_inventory(&items, STOCK_METALS));
+        let rows = state.inventory_rows();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0], InventoryRow::Stock { id: "stock-metals".into() });
+        assert_eq!(rows[1], InventoryRow::ActiveItem { id: "manny-1".into() });
+        assert_eq!(rows[2], InventoryRow::PassiveGroup { item_type: "waypoint_bookmark".into() });
+    }
+
+    #[test]
+    fn inventory_nav_wraps() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_with_inventory(&format!("[{}]", manny_item(None)), STOCK_METALS));
+        assert_eq!(state.inventory_rows().len(), 2);
+        state.inventory_next();
+        assert_eq!(state.inventory_selection, 1);
+        state.inventory_next();
+        assert_eq!(state.inventory_selection, 0);
+        state.inventory_prev();
+        assert_eq!(state.inventory_selection, 1);
+    }
+
+    #[test]
+    fn jettison_for_selected_stock_enters_amount() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_with_inventory("[]", STOCK_METALS));
+        match state.jettison_for_selected() {
+            Ok(JettisonInput::EnterAmount { item_id, item_name, max_amount, .. }) => {
+                assert_eq!(item_id, "stock-metals");
+                assert_eq!(item_name, "Metals");
+                assert_eq!(max_amount, 0.5);
             }
-        }"#).unwrap();
-        state.probe = Some(probe);
-        let items = state.build_jettison_items();
-        assert!(items.is_empty(), "busy manny should not be jettison candidate");
+            other => panic!("expected EnterAmount, got {:?}", std::mem::discriminant(&other.unwrap_or_default())),
+        }
+    }
+
+    #[test]
+    fn jettison_for_selected_idle_manny_confirms() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_with_inventory(&format!("[{}]", manny_item(None)), "[]"));
+        match state.jettison_for_selected() {
+            Ok(JettisonInput::ConfirmManny { item_id, manny_name, .. }) => {
+                assert_eq!(item_id, "manny-1");
+                assert_eq!(manny_name, "Manny-1");
+            }
+            _ => panic!("expected ConfirmManny"),
+        }
+    }
+
+    #[test]
+    fn jettison_for_selected_busy_manny_errors() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_with_inventory(&format!("[{}]", manny_item(Some("mining"))), "[]"));
+        let err = state.jettison_for_selected().err().expect("busy manny should error");
+        assert!(err.contains("busy"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn jettison_for_selected_passive_group_errors() {
+        let mut state = AppState::default();
+        let items = r#"[{"id": "wb-1", "type": "waypoint_bookmark", "name": "Bookmark",
+            "containerSpace": 0.1, "currentTask": null, "taskProgressPercent": 0.0,
+            "location": null, "cargo": null, "container": null}]"#;
+        state.probe = Some(probe_with_inventory(items, "[]"));
+        assert!(state.jettison_for_selected().is_err());
+    }
+
+    #[test]
+    fn update_probe_clamps_inventory_selection() {
+        let mut state = AppState::default();
+        state.inventory_selection = 5;
+        state.update_probe(probe_with_inventory("[]", STOCK_METALS));
+        assert_eq!(state.inventory_selection, 0);
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/src/input.rs
+++ b/src/input.rs
@@ -213,10 +213,16 @@ pub fn handle_event(
         KeyCode::Char('i') => state.toggle_focus(Panel::Inventory),
         KeyCode::Char('m') => state.toggle_focus(Panel::Mannies),
         KeyCode::Char('j') if state.focused == Some(Panel::Inventory) => {
-            let items = state.build_jettison_items();
-            if !items.is_empty() {
-                state.jettison = JettisonInput::PickItem { items, selection: 0 };
+            match state.jettison_for_selected() {
+                Ok(input) => state.jettison = input,
+                Err(msg) => state.error = Some(msg),
             }
+        }
+        KeyCode::Down if state.focused == Some(Panel::Inventory) => {
+            state.inventory_next();
+        }
+        KeyCode::Up if state.focused == Some(Panel::Inventory) => {
+            state.inventory_prev();
         }
         KeyCode::Char('d') if state.focused == Some(Panel::Inventory) => {
             if state.inventory_waypoint_bookmark_id().is_none() {
@@ -648,47 +654,6 @@ fn handle_jettison_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match &state.jettison {
-        JettisonInput::PickItem { selection, items, .. } => {
-            let sel = *selection;
-            let count = items.len();
-            match code {
-                KeyCode::Esc => state.jettison = JettisonInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let JettisonInput::PickItem { ref mut selection, .. } = state.jettison {
-                            *selection = new_sel;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (item_id, is_manny) = {
-                        let JettisonInput::PickItem { ref items, selection, .. } = state.jettison else { return };
-                        let (id, _, manny) = &items[selection];
-                        (id.clone(), *manny)
-                    };
-                    if is_manny {
-                        let manny_name = state.probe.as_ref()
-                            .and_then(|p| p.inventory.items.iter().find(|i| i.id == item_id))
-                            .map(|i| i.name.clone())
-                            .unwrap_or_else(|| item_id.clone());
-                        state.jettison = JettisonInput::ConfirmManny { item_id, manny_name, error: None };
-                    } else {
-                        let (item_name, max_amount) = state.probe.as_ref()
-                            .and_then(|p| p.inventory.resource_stocks.iter().find(|s| s.id == item_id))
-                            .map(|s| (s.name.clone(), s.amount))
-                            .unwrap_or_else(|| (item_id.clone(), 0.0));
-                        state.jettison = JettisonInput::EnterAmount {
-                            item_id,
-                            item_name,
-                            max_amount,
-                            buf: String::new(),
-                            error: None,
-                        };
-                    }
-                }
-                _ => {}
-            }
-        }
         JettisonInput::ConfirmManny { .. } => {
             match code {
                 KeyCode::Esc => state.jettison = JettisonInput::Inactive,

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2,7 +2,7 @@ use crate::api::types::{
     DangerLevel, DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask,
     MovementPhase, ProbeStatus, SectorObject, SectorObjectType, SectorObservation, SensorMode,
 };
-use crate::app::{AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{is_active_item, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use chrono::Utc;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -288,6 +288,8 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
 
     if let Some(hint_area) = hint_area_opt {
         let mut hint_spans = vec![
+            Span::styled("[↑↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
             Span::styled("[j]", Style::default().fg(Color::Cyan)),
             Span::raw(" jettison"),
         ];
@@ -325,7 +327,9 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
 
     let items_expanded = focused && !inv.items.is_empty();
     let items_rows: usize = items_row_count(&inv.items, items_expanded);
-    let n_rows = 1 + inv.resource_stocks.len() + items_rows;
+    let containers_rows = containers_row_count(inv, focused);
+    let tanks_rows = tanks_row_count(inv, focused);
+    let n_rows = 1 + inv.resource_stocks.len() + items_rows + containers_rows + tanks_rows;
 
     let mut sections: Vec<Constraint> = (0..n_rows).map(|_| Constraint::Length(1)).collect();
     sections.push(Constraint::Min(0));
@@ -336,6 +340,25 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
         .split(inner);
 
     let mut row = 0;
+    // Index into the navigable rows (stocks, active items, passive groups),
+    // must advance in the same order as AppState::inventory_rows().
+    let mut nav_idx: usize = 0;
+    let sel_prefix = |selected: bool| {
+        if selected {
+            Span::styled("▶ ", Style::default().fg(Color::Yellow))
+        } else {
+            Span::raw("  ")
+        }
+    };
+    let name_style = |selected: bool, dim: bool| {
+        if selected {
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+        } else if dim {
+            Style::default().fg(Color::DarkGray)
+        } else {
+            Style::default()
+        }
+    };
 
     frame.render_widget(
         make_line_gauge(
@@ -348,6 +371,8 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
     row += 1;
 
     for stock in &inv.resource_stocks {
+        let selected = focused && nav_idx == state.inventory_selection;
+        nav_idx += 1;
         let (icon, color, label) = match stock.stock_type.as_str() {
             "metals" => ("◆", Color::White, "Metals"),
             "ice" => ("❄", Color::Cyan, "Ice"),
@@ -356,8 +381,9 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
         };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled(format!("  {icon} "), Style::default().fg(color)),
-                Span::raw(format!("{:<11}", label)),
+                sel_prefix(selected),
+                Span::styled(format!("{icon} "), Style::default().fg(color)),
+                Span::styled(format!("{:<11}", label), name_style(selected, false)),
                 Span::styled(format!("{:.3}", stock.amount), Style::default().fg(Color::White)),
                 Span::styled(" ECE", Style::default().fg(Color::DarkGray)),
             ])),
@@ -379,6 +405,8 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
 
         // Active items: manny and atomic_3d_printer — show individually with task state
         for item in inv.items.iter().filter(|i| is_active_item(&i.item_type)) {
+            let selected = focused && nav_idx == state.inventory_selection;
+            nav_idx += 1;
             let (icon, icon_color) = item_icon(&item.item_type);
             let (task_span, progress) = match item.current_task.as_deref() {
                 None => (
@@ -392,8 +420,9 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
             };
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled(format!("  {icon} "), Style::default().fg(icon_color)),
-                    Span::raw(format!("{:<14}", item.name)),
+                    sel_prefix(selected),
+                    Span::styled(format!("{icon} "), Style::default().fg(icon_color)),
+                    Span::styled(format!("{:<14}", item.name), name_style(selected, false)),
                     task_span,
                     Span::styled(progress, Style::default().fg(Color::DarkGray)),
                 ])),
@@ -409,12 +438,15 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
                 continue;
             }
             seen_types.push(&item.item_type);
+            let selected = focused && nav_idx == state.inventory_selection;
+            nav_idx += 1;
             let count = inv.items.iter().filter(|i| i.item_type == item.item_type).count();
             let (icon, icon_color) = item_icon(&item.item_type);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled(format!("  {icon} "), Style::default().fg(icon_color)),
-                    Span::raw(format!("{:<14}", item.name)),
+                    sel_prefix(selected),
+                    Span::styled(format!("{icon} "), Style::default().fg(icon_color)),
+                    Span::styled(format!("{:<14}", item.name), name_style(selected, false)),
                     Span::styled(format!("× {count}"), Style::default().fg(Color::White)),
                 ])),
                 rows[row],
@@ -433,7 +465,69 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
         row += 1;
     }
 
+    // ── Containers ── (display only, expanded view)
+    if containers_rows > 0 {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "── containers ──",
+                Style::default().fg(Color::DarkGray),
+            ))),
+            rows[row],
+        );
+        row += 1;
+
+        let mut containers: Vec<_> = inv.containers.iter().collect();
+        containers.sort_by_key(|c| c.sort_order);
+        for c in containers {
+            let name = if c.kind == "probe" {
+                c.label.clone()
+            } else {
+                format!("{} ({})", c.label, c.kind)
+            };
+            let ratio = if c.capacity > 0.0 {
+                (c.used_capacity / c.capacity).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            frame.render_widget(
+                make_line_gauge(
+                    &format!("  {:<18}{:.2} / {:.2}", name, c.used_capacity, c.capacity),
+                    ratio,
+                    Color::Blue,
+                ),
+                rows[row],
+            );
+            row += 1;
+        }
+    }
+
+    // ── External tanks ── (display only, expanded view)
+    if tanks_rows > 0 {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "── tanks ──",
+                Style::default().fg(Color::DarkGray),
+            ))),
+            rows[row],
+        );
+        row += 1;
+
+        for tank in &inv.external_tanks {
+            let ratio = (tank.fill_percent / 100.0).clamp(0.0, 1.0);
+            frame.render_widget(
+                make_line_gauge(
+                    &format!("  {:<18}{:.1}%", tank.name, tank.fill_percent),
+                    ratio,
+                    gauge_color(ratio),
+                ),
+                rows[row],
+            );
+            row += 1;
+        }
+    }
+
     let _ = row;
+    let _ = nav_idx;
 }
 
 // ── Mannies panel ─────────────────────────────────────────────────────────────
@@ -1404,67 +1498,6 @@ fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
 
 fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     match &state.jettison {
-        JettisonInput::PickItem { items, selection } => {
-            let height = (items.len() as u16 + 6).min(20);
-            let popup = centered_rect(50, height, area);
-            frame.render_widget(Clear, popup);
-            let block = Block::default()
-                .title(" JETTISON ")
-                .title_alignment(Alignment::Center)
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow));
-            let inner = block.inner(popup);
-            frame.render_widget(block, popup);
-
-            let rows = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(1), Constraint::Length(1)])
-                .split(inner);
-
-            let mut lines: Vec<Line> = Vec::new();
-            for (i, (id, label, is_manny)) in items.iter().enumerate() {
-                let selected = i == *selection;
-                let (icon, icon_color) = if *is_manny {
-                    ("♟", Color::Green)
-                } else if id.contains("metals") {
-                    ("◆", Color::White)
-                } else if id.contains("ice") {
-                    ("❄", Color::Cyan)
-                } else if id.contains("carbon") {
-                    ("◇", Color::Green)
-                } else {
-                    ("◆", Color::White)
-                };
-                if selected {
-                    lines.push(Line::from(vec![
-                        Span::styled("▶ ", Style::default().fg(Color::Yellow)),
-                        Span::styled(icon, Style::default().fg(icon_color)),
-                        Span::raw(" "),
-                        Span::styled(label.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
-                    ]));
-                } else {
-                    lines.push(Line::from(vec![
-                        Span::raw("  "),
-                        Span::styled(icon, Style::default().fg(icon_color)),
-                        Span::raw(" "),
-                        Span::styled(label.as_str(), Style::default().fg(Color::DarkGray)),
-                    ]));
-                }
-            }
-            frame.render_widget(Paragraph::new(lines), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
-                    Span::raw(" select  "),
-                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-                    Span::raw(" confirm  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
-        }
-
         JettisonInput::ConfirmManny { manny_name, error, .. } => {
             let popup = centered_rect(48, 8, area);
             frame.render_widget(Clear, popup);
@@ -2392,7 +2425,10 @@ fn inventory_panel_height(state: &AppState) -> u16 {
     let n_stocks = inv.resource_stocks.len() as u16;
     let expanded = focused && !inv.items.is_empty();
     let items_rows = items_row_count(&inv.items, expanded) as u16;
-    1 + n_stocks + items_rows + 2
+    let containers_rows = containers_row_count(inv, focused) as u16;
+    let tanks_rows = tanks_row_count(inv, focused) as u16;
+    let hint_row = if focused { 1 } else { 0 };
+    1 + n_stocks + items_rows + containers_rows + tanks_rows + hint_row + 2
 }
 
 fn top_row_height(state: &AppState) -> u16 {
@@ -2401,8 +2437,20 @@ fn top_row_height(state: &AppState) -> u16 {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn is_active_item(item_type: &str) -> bool {
-    matches!(item_type, "manny" | "atomic_3d_printer")
+fn containers_row_count(inv: &crate::api::types::ProbeInventory, focused: bool) -> usize {
+    if focused && !inv.containers.is_empty() {
+        1 + inv.containers.len()
+    } else {
+        0
+    }
+}
+
+fn tanks_row_count(inv: &crate::api::types::ProbeInventory, focused: bool) -> usize {
+    if focused && !inv.external_tanks.is_empty() {
+        1 + inv.external_tanks.len()
+    } else {
+        0
+    }
 }
 
 fn item_icon(item_type: &str) -> (&'static str, Color) {


### PR DESCRIPTION
## I1 — Curseur dans le panneau INVENTORY

- `inventory_selection` dans `AppState`, navigation `↑/↓` quand le panneau est focalisé (wrap, comme MANNIES). Lignes navigables : stocks de ressources, items actifs (manny, printer), groupes d'items passifs — ordre garanti identique entre `inventory_rows()` et le rendu.
- `[j]` jettison agit directement sur la ligne sélectionnée : l'étape `JettisonInput::PickItem` (picker redondant) est supprimée. Les lignes non éligibles (manny occupé, stock vide, item passif) produisent une erreur explicite dans la status bar via `jettison_for_selected()`.
- Note : la navigation utilise uniquement `↑/↓` (pas `j/k`) car `[j]` est déjà le raccourci jettison.

## I2 — Containers + external tanks

- Section `── containers ──` en vue dépliée : gauge `used/capacity` par container, triés par `sortOrder`, kind affiché si ≠ probe. Ces champs étaient désérialisés mais jamais rendus.
- Section `── tanks ──` : gauge `fillPercent` par external tank.
- `inventory_panel_height` compte désormais la hint bar (la dernière ligne de contenu était écrasée quand le panneau était focalisé).

## Tests

- 8 nouveaux tests (`inventory_rows`, navigation wrap, `jettison_for_selected` stock/manny idle/manny busy/passif, clamp de sélection) remplaçant les 4 tests de `build_jettison_items` (supprimé).
- `cargo check`, `cargo clippy` clean ; `cargo test` : 95 passed.

_PR 2/15 de la série d'améliorations TUI._

🤖 Generated with [Claude Code](https://claude.com/claude-code)