### PR TITLE
feat(scanner): object-first actions on sector objects

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -54,6 +54,64 @@ pub const DETACH_MODES: [(&str, &str); 2] = [
     ("hidden_on_asteroid", "hidden — attach to asteroid"),
 ];
 
+/// Action applicable to a sector object from the scanner panel.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ObjectAction {
+    Mine,
+    Inspect,
+    Salvage,
+    Recover,
+    DeployWaypoint,
+}
+
+impl ObjectAction {
+    pub fn label(&self) -> &'static str {
+        match self {
+            ObjectAction::Mine => "mine",
+            ObjectAction::Inspect => "inspect",
+            ObjectAction::Salvage => "salvage",
+            ObjectAction::Recover => "recover",
+            ObjectAction::DeployWaypoint => "deploy waypoint",
+        }
+    }
+}
+
+/// Where a scanner object entry comes from; determines which actions apply
+/// (mirrors the candidate sets of the manny-first flows).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ObjectProvenance {
+    TopLevel,
+    MinableTarget,
+    BookmarkTarget,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScannerObjectEntry {
+    pub id: String,
+    pub name: String,
+    pub object_type: SectorObjectType,
+    pub provenance: ObjectProvenance,
+}
+
+#[derive(Default)]
+pub enum ObjectActionInput {
+    #[default]
+    Inactive,
+    PickAction {
+        object_id: String,
+        object_name: String,
+        actions: Vec<ObjectAction>,
+        selection: usize,
+    },
+    PickManny {
+        object_id: String,
+        object_name: String,
+        action: ObjectAction,
+        mannies: Vec<(String, String)>,
+        selection: usize,
+    },
+}
+
 #[derive(Default)]
 pub enum AtomicPrinterCraftInput {
     #[default]
@@ -312,6 +370,9 @@ pub struct AppState {
     pub scan_error: Option<String>,
     pub scan_batch: Option<usize>,
     pub scan_detail_scroll: usize,
+    /// Some(idx) when the scanner panel is in object-browsing mode.
+    pub scanner_obj_selection: Option<usize>,
+    pub object_action: ObjectActionInput,
     pub travel: TravelInput,
     pub repair: RepairInput,
     pub mine: MineInput,
@@ -422,6 +483,112 @@ impl AppState {
         self.scan_loading = false;
         self.scan_error = None;
         self.scan_mode = ScanMode::Current;
+        // Object list may have changed — leave browsing mode.
+        self.scanner_obj_selection = None;
+    }
+
+    /// True when the displayed history entry is the sector the probe is in.
+    pub fn viewing_probe_sector(&self) -> bool {
+        match (self.current_sector(), self.probe_sector_coords()) {
+            (Some(s), Some(pos)) => {
+                (
+                    s.relative_coordinates.x.round() as i32,
+                    s.relative_coordinates.y.round() as i32,
+                    s.relative_coordinates.z.round() as i32,
+                ) == pos
+            }
+            _ => false,
+        }
+    }
+
+    /// Actionable objects of the probe's current sector, in display order:
+    /// for each top-level object, the object itself (if it has an id), then
+    /// its minable targets, then its bookmark-target asteroids.
+    pub fn scanner_objects(&self) -> Vec<ScannerObjectEntry> {
+        if !self.viewing_probe_sector() {
+            return vec![];
+        }
+        let Some(objects) = self.current_sector().and_then(|s| s.objects.as_ref()) else {
+            return vec![];
+        };
+        let mut out: Vec<ScannerObjectEntry> = Vec::new();
+        let push = |out: &mut Vec<ScannerObjectEntry>, entry: ScannerObjectEntry| {
+            if !out.iter().any(|e| e.id == entry.id) {
+                out.push(entry);
+            }
+        };
+        for o in objects {
+            if let Some(id) = &o.id {
+                push(&mut out, ScannerObjectEntry {
+                    id: id.clone(),
+                    name: o.name.clone().unwrap_or_else(|| format!("{:?}", o.object_type).to_lowercase()),
+                    object_type: o.object_type.clone(),
+                    provenance: ObjectProvenance::TopLevel,
+                });
+            }
+            for t in o.minable_targets.iter().flatten() {
+                push(&mut out, ScannerObjectEntry {
+                    id: t.id.clone(),
+                    name: t.name.clone().unwrap_or_else(|| "unnamed".into()),
+                    object_type: t.object_type.clone(),
+                    provenance: ObjectProvenance::MinableTarget,
+                });
+            }
+            for t in &o.bookmark_targets {
+                if matches!(t.object_type, SectorObjectType::Asteroid) {
+                    push(&mut out, ScannerObjectEntry {
+                        id: t.id.clone(),
+                        name: t.name.clone().unwrap_or_else(|| "unnamed".into()),
+                        object_type: t.object_type.clone(),
+                        provenance: ObjectProvenance::BookmarkTarget,
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    /// Actions available for an entry, mirroring the manny-first candidate
+    /// sets (mine ← minable targets; inspect ← top-level + bookmark-target
+    /// asteroids; salvage ← sector mannies; recover ← detached containers;
+    /// deploy ← any top-level object, when a bookmark is in inventory).
+    pub fn actions_for_object(&self, entry: &ScannerObjectEntry) -> Vec<ObjectAction> {
+        let mut actions: Vec<ObjectAction> = Vec::new();
+        match (entry.provenance, &entry.object_type) {
+            (ObjectProvenance::MinableTarget, SectorObjectType::Asteroid) => {
+                actions.push(ObjectAction::Mine);
+            }
+            (ObjectProvenance::TopLevel | ObjectProvenance::BookmarkTarget, SectorObjectType::Asteroid) => {
+                actions.push(ObjectAction::Inspect);
+            }
+            (ObjectProvenance::TopLevel, SectorObjectType::Manny) => {
+                actions.push(ObjectAction::Salvage);
+            }
+            (ObjectProvenance::TopLevel, SectorObjectType::DetachedContainer) => {
+                actions.push(ObjectAction::Recover);
+            }
+            _ => {}
+        }
+        if entry.provenance == ObjectProvenance::TopLevel
+            && self.inventory_waypoint_bookmark_id().is_some()
+        {
+            actions.push(ObjectAction::DeployWaypoint);
+        }
+        actions
+    }
+
+    pub fn scanner_obj_next(&mut self) {
+        let count = self.scanner_objects().len();
+        if let (Some(sel), true) = (self.scanner_obj_selection, count > 0) {
+            self.scanner_obj_selection = Some((sel + 1) % count);
+        }
+    }
+
+    pub fn scanner_obj_prev(&mut self) {
+        let count = self.scanner_objects().len();
+        if let (Some(sel), true) = (self.scanner_obj_selection, count > 0) {
+            self.scanner_obj_selection = Some(sel.checked_sub(1).unwrap_or(count - 1));
+        }
     }
 
     pub fn current_sector(&self) -> Option<&SectorObservation> {
@@ -962,12 +1129,18 @@ impl AppState {
     pub fn set_inspect_error(&mut self, msg: String) {
         if let InspectInput::PickAsteroid { ref mut error, .. } = self.inspect {
             *error = Some(msg);
+        } else {
+            // Inspect was dispatched without the picker overlay (single
+            // candidate or object-first flow) — surface in the status bar.
+            self.error = Some(format!("inspect: {msg}"));
         }
     }
 
     pub fn set_recover_error(&mut self, msg: String) {
         if let RecoverInput::PickContainer { ref mut error, .. } = self.recover {
             *error = Some(msg);
+        } else {
+            self.error = Some(format!("recover: {msg}"));
         }
     }
 
@@ -1834,5 +2007,109 @@ mod tests {
         ]"#)];
         let result = state.collect_detached_containers();
         assert_eq!(result[0].1, "unnamed container");
+    }
+
+    // ── scanner_objects / actions_for_object ─────────────────────────────────
+
+    const MIXED_OBJECTS: &str = r#"[
+        {
+            "id": "planet-1", "type": "planet", "name": "P1",
+            "estimated": null, "summary": null, "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+            "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+            "capacity": null, "capacityUnit": null,
+            "minableTargets": [
+                {"id": "ast-1", "type": "asteroid", "name": "Rock A", "mass": null, "resourceTypes": ["metals"]}
+            ],
+            "waypointBookmarks": [], "bookmarkTargets": []
+        },
+        {
+            "id": "wreck-1", "type": "manny", "name": "Lost Manny",
+            "estimated": null, "summary": null, "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": true,
+            "mannyState": "wreck", "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+            "capacity": null, "capacityUnit": null, "minableTargets": null,
+            "waypointBookmarks": [], "bookmarkTargets": []
+        },
+        {
+            "id": "dc-1", "type": "detached_container", "name": "Floater",
+            "estimated": null, "summary": null, "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+            "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+            "capacity": null, "capacityUnit": null, "minableTargets": null,
+            "waypointBookmarks": [], "bookmarkTargets": []
+        }
+    ]"#;
+
+    #[test]
+    fn scanner_objects_empty_when_not_in_probe_sector() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_at(4., 0., 0.));
+        state.scan_history = vec![make_sector_with_objects(0., 0., 0., MIXED_OBJECTS)];
+        assert!(!state.viewing_probe_sector());
+        assert!(state.scanner_objects().is_empty());
+    }
+
+    #[test]
+    fn scanner_objects_order_top_level_then_nested() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_at(0., 0., 0.));
+        state.scan_history = vec![make_sector_with_objects(0., 0., 0., MIXED_OBJECTS)];
+        assert!(state.viewing_probe_sector());
+        let entries = state.scanner_objects();
+        let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, vec!["planet-1", "ast-1", "wreck-1", "dc-1"]);
+        assert_eq!(entries[1].provenance, ObjectProvenance::MinableTarget);
+        assert_eq!(entries[2].provenance, ObjectProvenance::TopLevel);
+    }
+
+    #[test]
+    fn actions_for_object_by_kind() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_at(0., 0., 0.));
+        state.scan_history = vec![make_sector_with_objects(0., 0., 0., MIXED_OBJECTS)];
+        let entries = state.scanner_objects();
+
+        // planet (top-level, no bookmark in inventory): no actions
+        assert!(state.actions_for_object(&entries[0]).is_empty());
+        // minable asteroid: mine
+        assert_eq!(state.actions_for_object(&entries[1]), vec![ObjectAction::Mine]);
+        // manny wreck: salvage
+        assert_eq!(state.actions_for_object(&entries[2]), vec![ObjectAction::Salvage]);
+        // detached container: recover
+        assert_eq!(state.actions_for_object(&entries[3]), vec![ObjectAction::Recover]);
+    }
+
+    #[test]
+    fn actions_include_deploy_when_bookmark_in_inventory() {
+        let mut state = AppState::default();
+        let items = r#"[{"id": "wb-1", "type": "waypoint_bookmark", "name": "Bookmark",
+            "containerSpace": 0.1, "currentTask": null, "taskProgressPercent": 0.0,
+            "location": null, "cargo": null, "container": null}]"#;
+        state.probe = Some(probe_with_inventory(items, "[]"));
+        // probe_with_inventory has no sector — give it one at origin
+        if let Some(ref mut p) = state.probe {
+            p.sector = Some(serde_json::from_str(r#"{"relative": {"x": 0.0, "y": 0.0, "z": 0.0}}"#).unwrap());
+        }
+        state.scan_history = vec![make_sector_with_objects(0., 0., 0., MIXED_OBJECTS)];
+        let entries = state.scanner_objects();
+        // top-level planet gains deploy; nested minable target does not
+        assert_eq!(state.actions_for_object(&entries[0]), vec![ObjectAction::DeployWaypoint]);
+        assert_eq!(state.actions_for_object(&entries[1]), vec![ObjectAction::Mine]);
+    }
+
+    #[test]
+    fn scanner_obj_nav_wraps() {
+        let mut state = AppState::default();
+        state.probe = Some(probe_at(0., 0., 0.));
+        state.scan_history = vec![make_sector_with_objects(0., 0., 0., MIXED_OBJECTS)];
+        state.scanner_obj_selection = Some(0);
+        state.scanner_obj_prev();
+        assert_eq!(state.scanner_obj_selection, Some(3));
+        state.scanner_obj_next();
+        assert_eq!(state.scanner_obj_selection, Some(0));
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,8 +9,9 @@ use crate::api::tasks::{
 };
 use crate::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput,
-    InspectInput, JettisonInput, MineInput, Panel, RecallInput, RecoverInput, RenameMannyInput,
-    RepairInput, SalvageInput, ScanMode, TravelInput, DETACH_MODES, RESOURCE_TYPES,
+    InspectInput, JettisonInput, MineInput, ObjectAction, ObjectActionInput, Panel, RecallInput,
+    RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput,
+    DETACH_MODES, RESOURCE_TYPES,
 };
 
 fn neighbors_d1() -> Vec<(i32, i32, i32)> {
@@ -137,6 +138,11 @@ pub fn handle_event(
         return;
     }
 
+    if !matches!(state.object_action, ObjectActionInput::Inactive) {
+        handle_object_action_event(k.code, state, client, tx);
+        return;
+    }
+
     if in_travel {
         handle_travel_event(k.code, state, client, tx);
         return;
@@ -189,10 +195,43 @@ pub fn handle_event(
         return;
     }
 
+    let in_object_mode =
+        state.focused == Some(Panel::Scanner) && state.scanner_obj_selection.is_some();
+
     match k.code {
         KeyCode::Char('q') => state.set_quit(),
         KeyCode::Char('b') => state.open_map(),
+        KeyCode::Esc if in_object_mode => state.scanner_obj_selection = None,
         KeyCode::Esc => state.focused = None,
+        KeyCode::Char('o') if state.focused == Some(Panel::Scanner) => {
+            if state.scanner_obj_selection.is_some() {
+                state.scanner_obj_selection = None;
+            } else if !state.scanner_objects().is_empty() {
+                state.scanner_obj_selection = Some(0);
+            } else if state.viewing_probe_sector() {
+                state.error = Some("no actionable objects in current sector".into());
+            } else {
+                state.error = Some("object actions only available in the probe's sector".into());
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') if in_object_mode => state.scanner_obj_next(),
+        KeyCode::Up | KeyCode::Char('k') if in_object_mode => state.scanner_obj_prev(),
+        KeyCode::Enter if in_object_mode => {
+            let entries = state.scanner_objects();
+            if let Some(entry) = state.scanner_obj_selection.and_then(|i| entries.get(i)) {
+                let actions = state.actions_for_object(entry);
+                if actions.is_empty() {
+                    state.error = Some(format!("no actions available for {}", entry.name));
+                } else {
+                    state.object_action = ObjectActionInput::PickAction {
+                        object_id: entry.id.clone(),
+                        object_name: entry.name.clone(),
+                        actions,
+                        selection: 0,
+                    };
+                }
+            }
+        }
         KeyCode::Char('t') => {
             state.travel = TravelInput::Typing(String::new());
         }
@@ -1089,6 +1128,133 @@ fn handle_detach_event(
             }
         }
         DetachInput::Inactive => {}
+    }
+}
+
+/// Send the chosen object action, reusing the existing wizards/endpoints.
+fn dispatch_object_action(
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+    action: ObjectAction,
+    object: (String, String),
+    manny: (String, String),
+) {
+    let (object_id, object_name) = object;
+    let (manny_id, manny_name) = manny;
+    state.object_action = ObjectActionInput::Inactive;
+    state.scanner_obj_selection = None;
+    match action {
+        ObjectAction::Mine => {
+            state.mine = MineInput::Configure {
+                manny_id,
+                manny_name,
+                object_id,
+                object_name,
+                resources: [false, true, false, false],
+                amount_buf: "0.30".into(),
+                amount_mode: false,
+                error: None,
+            };
+        }
+        ObjectAction::Inspect => {
+            fetch_inspect(manny_id, object_id, client.clone(), tx.clone());
+        }
+        ObjectAction::Salvage => {
+            state.salvage = SalvageInput::Confirm {
+                manny_id,
+                manny_name,
+                object_id,
+                object_name,
+                error: None,
+            };
+        }
+        ObjectAction::Recover => {
+            fetch_recover(manny_id, object_id, client.clone(), tx.clone());
+        }
+        ObjectAction::DeployWaypoint => {
+            state.deploy = DeployInput::EnterName {
+                manny_id,
+                object_id,
+                object_name,
+                name_buf: String::new(),
+                error: None,
+            };
+        }
+    }
+}
+
+fn handle_object_action_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match &state.object_action {
+        ObjectActionInput::PickAction { selection, actions, .. } => {
+            let sel = *selection;
+            let count = actions.len();
+            match code {
+                KeyCode::Esc => state.object_action = ObjectActionInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, sel, count) {
+                        if let ObjectActionInput::PickAction { ref mut selection, .. } = state.object_action {
+                            *selection = new_sel;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let (object_id, object_name, action) = {
+                        let ObjectActionInput::PickAction { ref object_id, ref object_name, ref actions, selection } = state.object_action else { return };
+                        (object_id.clone(), object_name.clone(), actions[selection])
+                    };
+                    let mannies = state.collect_idle_onboard_mannies();
+                    match mannies.len() {
+                        0 => {
+                            state.object_action = ObjectActionInput::Inactive;
+                            state.error = Some("no idle Manny on board".into());
+                        }
+                        1 => {
+                            let manny = mannies.into_iter().next().unwrap();
+                            dispatch_object_action(state, client, tx, action, (object_id, object_name), manny);
+                        }
+                        _ => {
+                            state.object_action = ObjectActionInput::PickManny {
+                                object_id,
+                                object_name,
+                                action,
+                                mannies,
+                                selection: 0,
+                            };
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        ObjectActionInput::PickManny { selection, mannies, .. } => {
+            let sel = *selection;
+            let count = mannies.len();
+            match code {
+                KeyCode::Esc => state.object_action = ObjectActionInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, sel, count) {
+                        if let ObjectActionInput::PickManny { ref mut selection, .. } = state.object_action {
+                            *selection = new_sel;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let (object, action, manny) = {
+                        let ObjectActionInput::PickManny { ref object_id, ref object_name, action, ref mannies, selection } = state.object_action else { return };
+                        ((object_id.clone(), object_name.clone()), action, mannies[selection].clone())
+                    };
+                    dispatch_object_action(state, client, tx, action, object, manny);
+                }
+                _ => {}
+            }
+        }
+        ObjectActionInput::Inactive => {}
     }
 }
 

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2,7 +2,7 @@ use crate::api::types::{
     DangerLevel, DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask,
     MovementPhase, ProbeStatus, SectorObject, SectorObjectType, SectorObservation, SensorMode,
 };
-use crate::app::{is_active_item, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{is_active_item, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use chrono::Utc;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -96,6 +96,9 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     }
     if !matches!(state.detach, DetachInput::Inactive) {
         render_detach_overlay(frame, area, state);
+    }
+    if !matches!(state.object_action, ObjectActionInput::Inactive) {
+        render_object_action_overlay(frame, area, state);
     }
 }
 
@@ -749,7 +752,16 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
                     hint_area,
                 );
             } else if focused {
-                let spans = if is_blind {
+                let spans = if state.scanner_obj_selection.is_some() {
+                    vec![
+                        Span::styled("[↑↓/jk]", Style::default().fg(Color::Cyan)),
+                        Span::raw(" object  "),
+                        Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                        Span::raw(" actions  "),
+                        Span::styled("[Esc/o]", Style::default().fg(Color::Cyan)),
+                        Span::raw(" back"),
+                    ]
+                } else if is_blind {
                     vec![
                         Span::styled("● SENSORS BLIND", Style::default().fg(Color::Red)),
                         Span::raw("  "),
@@ -773,6 +785,11 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
                         Span::styled("[JK]", Style::default().fg(Color::Cyan)),
                         Span::raw(" scroll"),
                     ];
+                    if !state.scanner_objects().is_empty() {
+                        s.push(Span::raw("  "));
+                        s.push(Span::styled("[o]", Style::default().fg(Color::Yellow)));
+                        s.push(Span::raw(" objects"));
+                    }
                     if state.current_sector().is_some() {
                         s.push(Span::raw("  "));
                         s.push(Span::styled("[g]", Style::default().fg(Color::Yellow)));
@@ -927,6 +944,16 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
         }
     }
 
+    let browsing = focused && state.scanner_obj_selection.is_some() && state.viewing_probe_sector();
+    let selected_obj_id: Option<String> = if browsing {
+        state
+            .scanner_obj_selection
+            .and_then(|i| state.scanner_objects().into_iter().nth(i))
+            .map(|e| e.id)
+    } else {
+        None
+    };
+
     if let Some(objects) = &sector.objects {
         if !objects.is_empty() {
             lines.push(Line::from(Span::styled(
@@ -934,7 +961,7 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
                 Style::default().fg(Color::DarkGray),
             )));
             for obj in objects {
-                lines.extend(sector_object_lines(obj));
+                lines.extend(sector_object_lines(obj, browsing, selected_obj_id.as_deref()));
             }
         }
     }
@@ -1987,6 +2014,25 @@ fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     }
 }
 
+fn render_object_action_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match &state.object_action {
+        ObjectActionInput::PickAction { object_name, actions, selection, .. } => {
+            let labels: Vec<&str> = actions.iter().map(|a| a.label()).collect();
+            let height = (actions.len() as u16 + 6).min(14);
+            render_pick_list(frame, area, &format!(" {object_name} "), 46, height,
+                Some("Action:"), &labels, *selection, None, "select");
+        }
+        ObjectActionInput::PickManny { object_name, action, mannies, selection, .. } => {
+            let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
+            let height = (mannies.len() as u16 + 6).min(16);
+            let prompt = format!("{} — select manny:", action.label());
+            render_pick_list(frame, area, &format!(" {object_name} "), 46, height,
+                Some(&prompt), &names, *selection, None, "confirm");
+        }
+        ObjectActionInput::Inactive => {}
+    }
+}
+
 fn sector_interest_color(s: &crate::api::types::SectorObservation) -> Color {
     use crate::api::types::{DangerLevel, KnowledgeLevel, SectorObjectType};
 
@@ -2039,7 +2085,22 @@ fn sector_interest_color(s: &crate::api::types::SectorObservation) -> Color {
     Color::DarkGray
 }
 
-fn sector_object_lines(obj: &SectorObject) -> Vec<Line<'_>> {
+fn obj_sel_prefix(browsing: bool, selected: bool) -> Option<Span<'static>> {
+    if !browsing {
+        return None;
+    }
+    Some(if selected {
+        Span::styled("▶ ", Style::default().fg(Color::Yellow))
+    } else {
+        Span::raw("  ")
+    })
+}
+
+fn sector_object_lines<'a>(
+    obj: &'a SectorObject,
+    browsing: bool,
+    selected_id: Option<&str>,
+) -> Vec<Line<'a>> {
     let (icon, color) = object_icon(&obj.object_type);
     let estimated = if obj.estimated.unwrap_or(false) { "~ " } else { "" };
     let name = obj.name.as_deref().unwrap_or("unnamed");
@@ -2057,12 +2118,22 @@ fn sector_object_lines(obj: &SectorObject) -> Vec<Line<'_>> {
 
     let salvageable = obj.salvageable.unwrap_or(false);
 
-    let mut main_spans = vec![
+    let main_selected = browsing && obj.id.is_some() && obj.id.as_deref() == selected_id;
+    let name_style = if main_selected {
+        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let mut main_spans: Vec<Span> = Vec::new();
+    if let Some(prefix) = obj_sel_prefix(browsing, main_selected) {
+        main_spans.push(prefix);
+    }
+    main_spans.extend([
         Span::styled(icon, Style::default().fg(color)),
         Span::raw(" "),
         Span::styled(estimated, Style::default().fg(Color::DarkGray)),
-        Span::raw(format!("{name}{danger}")),
-    ];
+        Span::styled(format!("{name}{danger}"), name_style),
+    ]);
     if salvageable {
         main_spans.push(Span::styled("  ⬡ salvageable", Style::default().fg(Color::Yellow)));
     }
@@ -2133,12 +2204,22 @@ fn sector_object_lines(obj: &SectorObject) -> Vec<Line<'_>> {
         for target in targets {
             let (icon, color) = object_icon(&target.object_type);
             let name = target.name.as_deref().unwrap_or("unnamed");
-            let mut spans = vec![
+            let selected = browsing && selected_id == Some(target.id.as_str());
+            let target_style = if selected {
+                Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let mut spans: Vec<Span> = Vec::new();
+            if let Some(prefix) = obj_sel_prefix(browsing, selected) {
+                spans.push(prefix);
+            }
+            spans.extend([
                 Span::styled("  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(icon, Style::default().fg(color)),
                 Span::raw(" "),
-                Span::raw(name.to_string()),
-            ];
+                Span::styled(name.to_string(), target_style),
+            ]);
             if let Some(resources) = &target.resource_types {
                 let res_str = resources.iter().map(|r| match r.as_str() {
                     "metals" => "metals",
@@ -2161,12 +2242,22 @@ fn sector_object_lines(obj: &SectorObject) -> Vec<Line<'_>> {
     for target in &obj.bookmark_targets {
         let (icon, color) = object_icon(&target.object_type);
         let name = target.name.as_deref().unwrap_or("unnamed");
-        let mut spans = vec![
+        let selected = browsing && selected_id == Some(target.id.as_str());
+        let target_style = if selected {
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let mut spans: Vec<Span> = Vec::new();
+        if let Some(prefix) = obj_sel_prefix(browsing, selected) {
+            spans.push(prefix);
+        }
+        spans.extend([
             Span::styled("  ", Style::default().fg(Color::DarkGray)),
             Span::styled(icon, Style::default().fg(color)),
             Span::raw(" "),
-            Span::raw(name.to_string()),
-        ];
+            Span::styled(name.to_string(), target_style),
+        ]);
         let mut extras: Vec<String> = Vec::new();
         if let Some(m) = target.mass {
             extras.push(format!("{m:.3e} {}", target.mass_unit.as_deref().unwrap_or("")));


### PR DESCRIPTION
## S3 — Flux objet-first

Le flux actuel est manny-first (focus MANNIES → `[e]` mine → re-choisir l'astéroïde dans un picker) alors que l'objet est sous les yeux dans le SCANNER. Cette PR ajoute un mode curseur objets :

- `[o]` dans le panneau SCANNER (secteur courant de la sonde uniquement) entre en mode objets ; `↑↓/jk` déplace le curseur sur les objets top-level, les `minableTargets` et les astéroïdes de `bookmarkTargets` ; `[Enter]` ouvre un menu d'actions contextuel ; `[Esc]/[o]` ressort.
- Actions par type, en miroir exact des ensembles de candidats des flux manny-first existants :
  - mine ← `minableTargets` ; inspect ← astéroïdes top-level + bookmark targets ; salvage ← mannies du secteur ; recover ← detached containers ; deploy waypoint ← objets top-level (si bookmark en inventaire).
- Le menu réutilise les wizards existants avec l'objet pré-rempli (`MineInput::Configure`, `SalvageInput::Confirm`, `DeployInput::EnterName`, dispatch direct pour inspect/recover). Étape `PickManny` insérée uniquement si plusieurs mannies idle à bord.
- Les flux manny-first restent inchangés et disponibles.
- `set_inspect_error`/`set_recover_error` retombent sur la status bar quand l'overlay picker n'est pas ouvert (chemins de dispatch direct — l'erreur était silencieusement perdue pour le cas candidat unique).

## Tests

5 nouveaux tests (`scanner_objects` ordre/dédup/hors-secteur, `actions_for_object` par type, deploy conditionné au bookmark, wrap de navigation). `cargo clippy` clean ; `cargo test` : 100 passed.

_PR 3/15 — empilée sur #32. Merger #32 d'abord (GitHub reciblera automatiquement sur main)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)