### PR TITLE
feat(nav): waypoints overlay listing known destinations

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -112,6 +112,34 @@ pub enum ObjectActionInput {
     },
 }
 
+/// Category of a known destination shown in the waypoints overlay.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WaypointKind {
+    Bookmark,
+    Star,
+    Minable,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WaypointEntry {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+    pub distance: i64,
+    pub label: String,
+    pub kind: WaypointKind,
+}
+
+#[derive(Default)]
+pub enum WaypointsInput {
+    #[default]
+    Inactive,
+    Browsing {
+        entries: Vec<WaypointEntry>,
+        selection: usize,
+    },
+}
+
 #[derive(Default)]
 pub enum AtomicPrinterCraftInput {
     #[default]
@@ -373,6 +401,7 @@ pub struct AppState {
     /// Some(idx) when the scanner panel is in object-browsing mode.
     pub scanner_obj_selection: Option<usize>,
     pub object_action: ObjectActionInput,
+    pub waypoints: WaypointsInput,
     pub travel: TravelInput,
     pub repair: RepairInput,
     pub mine: MineInput,
@@ -575,6 +604,78 @@ impl AppState {
             actions.push(ObjectAction::DeployWaypoint);
         }
         actions
+    }
+
+    /// Known destinations aggregated from scan history: deployed waypoint
+    /// bookmarks first, then sectors with a star, then sectors with minable
+    /// targets. One entry per (sector, category); bookmarks listed per name.
+    pub fn collect_waypoints(&self) -> Vec<WaypointEntry> {
+        let mut bookmarks: Vec<WaypointEntry> = Vec::new();
+        let mut stars: Vec<WaypointEntry> = Vec::new();
+        let mut minables: Vec<WaypointEntry> = Vec::new();
+
+        for s in &self.scan_history {
+            let (x, y, z) = (
+                s.relative_coordinates.x.round() as i32,
+                s.relative_coordinates.y.round() as i32,
+                s.relative_coordinates.z.round() as i32,
+            );
+            let Some(objects) = &s.objects else { continue };
+
+            for o in objects {
+                let obj_name = o.name.clone().unwrap_or_else(|| "object".into());
+                for wb in &o.waypoint_bookmarks {
+                    bookmarks.push(WaypointEntry {
+                        x, y, z,
+                        distance: s.distance,
+                        label: format!("{} @ {}", wb.name, obj_name),
+                        kind: WaypointKind::Bookmark,
+                    });
+                }
+                for t in &o.bookmark_targets {
+                    let t_name = t.name.clone().unwrap_or_else(|| "object".into());
+                    for wb in &t.waypoint_bookmarks {
+                        bookmarks.push(WaypointEntry {
+                            x, y, z,
+                            distance: s.distance,
+                            label: format!("{} @ {}", wb.name, t_name),
+                            kind: WaypointKind::Bookmark,
+                        });
+                    }
+                }
+            }
+
+            let has_star = objects.iter().any(|o| {
+                matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem)
+            });
+            if has_star {
+                stars.push(WaypointEntry {
+                    x, y, z,
+                    distance: s.distance,
+                    label: "star".into(),
+                    kind: WaypointKind::Star,
+                });
+            }
+
+            let has_minable = objects.iter().any(|o| {
+                o.minable_targets.as_ref().is_some_and(|t| !t.is_empty())
+            });
+            if has_minable {
+                minables.push(WaypointEntry {
+                    x, y, z,
+                    distance: s.distance,
+                    label: "minable resources".into(),
+                    kind: WaypointKind::Minable,
+                });
+            }
+        }
+
+        stars.sort_by_key(|e| e.distance);
+        minables.sort_by_key(|e| e.distance);
+        let mut out = bookmarks;
+        out.extend(stars);
+        out.extend(minables);
+        out
     }
 
     pub fn scanner_obj_next(&mut self) {
@@ -2099,6 +2200,66 @@ mod tests {
         // top-level planet gains deploy; nested minable target does not
         assert_eq!(state.actions_for_object(&entries[0]), vec![ObjectAction::DeployWaypoint]);
         assert_eq!(state.actions_for_object(&entries[1]), vec![ObjectAction::Mine]);
+    }
+
+    // ── collect_waypoints ─────────────────────────────────────────────────────
+
+    #[test]
+    fn collect_waypoints_empty_history() {
+        assert!(AppState::default().collect_waypoints().is_empty());
+    }
+
+    #[test]
+    fn collect_waypoints_bookmarks_first_then_sorted_by_distance() {
+        let mut state = AppState::default();
+        let star_far: SectorObservation = serde_json::from_str(r#"{
+            "relativeCoordinates": {"x": 6.0, "y": 0.0, "z": 0.0},
+            "distance": 6, "knowledgeLevel": "detailed", "confidence": 1.0,
+            "objects": [{
+                "id": "star-1", "type": "star", "name": "Sun",
+                "estimated": null, "summary": null, "mass": null, "massUnit": null,
+                "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+                "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+                "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+                "capacity": null, "capacityUnit": null, "minableTargets": null,
+                "waypointBookmarks": [], "bookmarkTargets": []
+            }],
+            "probes": null, "possibleObjects": null, "estimatedObjects": null,
+            "navigationalRisk": null, "message": null, "sensorMode": null, "dataFreshness": null,
+            "scan": {"currentSectorResidenceSeconds": 0, "requiredResidenceSeconds": 0, "scanQuality": 1.0}
+        }"#).unwrap();
+        let bookmark_near: SectorObservation = serde_json::from_str(r#"{
+            "relativeCoordinates": {"x": 2.0, "y": 0.0, "z": 0.0},
+            "distance": 2, "knowledgeLevel": "detailed", "confidence": 1.0,
+            "objects": [{
+                "id": "planet-1", "type": "planet", "name": "P1",
+                "estimated": null, "summary": null, "mass": null, "massUnit": null,
+                "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+                "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+                "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+                "capacity": null, "capacityUnit": null,
+                "minableTargets": [{"id": "ast-1", "type": "asteroid", "name": "Rock", "mass": null, "resourceTypes": null}],
+                "waypointBookmarks": [{"name": "home", "playerId": 1, "playerName": "me", "createdAt": "2026-01-01T00:00:00Z"}],
+                "bookmarkTargets": []
+            }],
+            "probes": null, "possibleObjects": null, "estimatedObjects": null,
+            "navigationalRisk": null, "message": null, "sensorMode": null, "dataFreshness": null,
+            "scan": {"currentSectorResidenceSeconds": 0, "requiredResidenceSeconds": 0, "scanQuality": 1.0}
+        }"#).unwrap();
+        // far star scanned first (more recent in history)
+        state.scan_history = vec![star_far, bookmark_near];
+
+        let entries = state.collect_waypoints();
+        assert_eq!(entries.len(), 3);
+        // bookmark first regardless of history order
+        assert_eq!(entries[0].kind, WaypointKind::Bookmark);
+        assert!(entries[0].label.contains("home"));
+        assert_eq!((entries[0].x, entries[0].y, entries[0].z), (2, 0, 0));
+        // then star, then minable
+        assert_eq!(entries[1].kind, WaypointKind::Star);
+        assert_eq!(entries[1].distance, 6);
+        assert_eq!(entries[2].kind, WaypointKind::Minable);
+        assert_eq!(entries[2].distance, 2);
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,7 +11,7 @@ use crate::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput,
     InspectInput, JettisonInput, MineInput, ObjectAction, ObjectActionInput, Panel, RecallInput,
     RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput,
-    DETACH_MODES, RESOURCE_TYPES,
+    WaypointsInput, DETACH_MODES, RESOURCE_TYPES,
 };
 
 fn neighbors_d1() -> Vec<(i32, i32, i32)> {
@@ -143,6 +143,11 @@ pub fn handle_event(
         return;
     }
 
+    if !matches!(state.waypoints, WaypointsInput::Inactive) {
+        handle_waypoints_event(k.code, state);
+        return;
+    }
+
     if in_travel {
         handle_travel_event(k.code, state, client, tx);
         return;
@@ -201,6 +206,14 @@ pub fn handle_event(
     match k.code {
         KeyCode::Char('q') => state.set_quit(),
         KeyCode::Char('b') => state.open_map(),
+        KeyCode::Char('w') => {
+            let entries = state.collect_waypoints();
+            if entries.is_empty() {
+                state.error = Some("no known waypoints — scan sectors first".into());
+            } else {
+                state.waypoints = WaypointsInput::Browsing { entries, selection: 0 };
+            }
+        }
         KeyCode::Esc if in_object_mode => state.scanner_obj_selection = None,
         KeyCode::Esc => state.focused = None,
         KeyCode::Char('o') if state.focused == Some(Panel::Scanner) => {
@@ -1181,6 +1194,31 @@ fn dispatch_object_action(
                 error: None,
             };
         }
+    }
+}
+
+fn handle_waypoints_event(code: KeyCode, state: &mut AppState) {
+    let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
+    let count = entries.len();
+    match code {
+        KeyCode::Esc | KeyCode::Char('w') => state.waypoints = WaypointsInput::Inactive,
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+            if let Some(new_sel) = list_nav(code, selection, count) {
+                if let WaypointsInput::Browsing { ref mut selection, .. } = state.waypoints {
+                    *selection = new_sel;
+                }
+            }
+        }
+        KeyCode::Enter => {
+            let (x, y, z) = {
+                let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
+                let e = &entries[selection];
+                (e.x, e.y, e.z)
+            };
+            state.waypoints = WaypointsInput::Inactive;
+            state.travel_go_sector(x, y, z);
+        }
+        _ => {}
     }
 }
 

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2,7 +2,7 @@ use crate::api::types::{
     DangerLevel, DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask,
     MovementPhase, ProbeStatus, SectorObject, SectorObjectType, SectorObservation, SensorMode,
 };
-use crate::app::{is_active_item, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{is_active_item, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, WaypointKind, WaypointsInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use chrono::Utc;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -99,6 +99,9 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     }
     if !matches!(state.object_action, ObjectActionInput::Inactive) {
         render_object_action_overlay(frame, area, state);
+    }
+    if !matches!(state.waypoints, WaypointsInput::Inactive) {
+        render_waypoints_overlay(frame, area, state);
     }
 }
 
@@ -2014,6 +2017,65 @@ fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     }
 }
 
+fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
+
+    let height = (entries.len() as u16 + 5).min(20);
+    let popup = centered_rect(58, height, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" WAYPOINTS ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let items: Vec<ListItem> = entries
+        .iter()
+        .map(|e| {
+            let (icon, color) = match e.kind {
+                WaypointKind::Bookmark => ("◎", Color::Cyan),
+                WaypointKind::Star => ("★", Color::Yellow),
+                WaypointKind::Minable => ("◆", Color::White),
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{icon} "), Style::default().fg(color)),
+                Span::raw(format!("{:<28}", e.label)),
+                Span::styled(
+                    format!("({},{},{})", e.x, e.y, e.z),
+                    Style::default().fg(Color::White),
+                ),
+                Span::styled(format!("  d:{}", e.distance), Style::default().fg(Color::DarkGray)),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+        .highlight_symbol("▶ ");
+    let mut list_state = ListState::default();
+    list_state.select(Some(selection));
+    frame.render_stateful_widget(list, rows[0], &mut list_state);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" travel  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" close"),
+        ])),
+        rows[1],
+    );
+}
+
 fn render_object_action_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     match &state.object_action {
         ObjectActionInput::PickAction { object_name, actions, selection, .. } => {
@@ -2459,6 +2521,8 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
         Span::raw(" travel  "),
         Span::styled("[b]", Style::default().fg(Color::Cyan)),
         Span::raw(" map  "),
+        Span::styled("[w]", Style::default().fg(Color::Cyan)),
+        Span::raw(" waypoints  "),
         Span::styled("[q]", Style::default().fg(Color::Cyan)),
         Span::raw(" quit"),
         Span::styled(error_part, Style::default().fg(Color::Red)),


### PR DESCRIPTION
## N1 — Overlay waypoints `[w]`

Il n'existait aucun moyen de revenir à un point d'intérêt sans retaper ses coordonnées. `[w]` ouvre un overlay agrégé depuis `scan_history` :

- **Bookmarks déployés** (champ `waypointBookmarks` des objets et de leurs `bookmarkTargets` — désérialisé mais jamais rendu jusqu'ici), affichés en premier ;
- **Secteurs avec étoile** puis **secteurs avec ressources minables**, triés par distance.

`[Enter]` envoie le secteur sélectionné dans la confirmation travel existante (preview fuel/ETA via `travel_go_sector`). `[w]` ajouté à la status bar.

## Tests

2 nouveaux tests (historique vide ; ordre bookmarks → star → minable avec tri par distance et coordonnées correctes). `cargo clippy` clean ; `cargo test` : 102 passed.

_PR 4/15 — empilée sur #33._

🤖 Generated with [Claude Code](https://claude.com/claude-code)