### PR TITLE
feat(map): center cell info line, legend, recenter and jump to coords

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -156,6 +156,8 @@ pub struct MapView {
     pub center_x: i32,
     pub center_z: i32,
     pub y_layer: i32,
+    /// Some(buffer) while typing target coordinates ([c] on the map).
+    pub coord_input: Option<String>,
 }
 
 #[derive(Default)]
@@ -941,12 +943,25 @@ impl AppState {
     }
 
     pub fn open_map(&mut self) {
+        self.map_recenter_on_probe();
+        self.map.open = true;
+    }
+
+    pub fn map_recenter_on_probe(&mut self) {
         if let Some((x, y, z)) = self.probe_sector_coords() {
             self.map.center_x = x;
             self.map.center_z = z;
             self.map.y_layer = y;
         }
-        self.map.open = true;
+    }
+
+    /// Chebyshev distance from the probe to the map center, when known.
+    pub fn map_center_distance(&self) -> Option<i64> {
+        let (px, py, pz) = self.probe_sector_coords()?;
+        let dx = (self.map.center_x - px).abs() as i64;
+        let dy = (self.map.y_layer - py).abs() as i64;
+        let dz = (self.map.center_z - pz).abs() as i64;
+        Some(dx.max(dy).max(dz))
     }
 
     // Move to y±1 while preserving cx+y+cz (no drift on round-trips).

--- a/src/input.rs
+++ b/src/input.rs
@@ -746,6 +746,34 @@ fn handle_jettison_event(
 }
 
 fn handle_map_event(code: KeyCode, state: &mut AppState) {
+    // Coordinate-input mode ([c]) captures keys first.
+    if let Some(buf) = state.map.coord_input.as_mut() {
+        match code {
+            KeyCode::Esc => state.map.coord_input = None,
+            KeyCode::Backspace => {
+                buf.pop();
+            }
+            KeyCode::Enter => {
+                let parts: Vec<&str> = buf.split_whitespace().collect();
+                if parts.len() == 3 {
+                    if let (Ok(x), Ok(y), Ok(z)) = (
+                        parts[0].parse::<i32>(),
+                        parts[1].parse::<i32>(),
+                        parts[2].parse::<i32>(),
+                    ) {
+                        state.map.center_x = x;
+                        state.map.y_layer = y;
+                        state.map.center_z = z;
+                        state.map.coord_input = None;
+                    }
+                }
+            }
+            KeyCode::Char(c) if c == '-' || c == ' ' || c.is_ascii_digit() => buf.push(c),
+            _ => {}
+        }
+        return;
+    }
+
     match code {
         KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('b') => state.map.open = false,
         KeyCode::Char('h') | KeyCode::Left  => state.map.center_x -= 2,
@@ -754,6 +782,8 @@ fn handle_map_event(code: KeyCode, state: &mut AppState) {
         KeyCode::Char('j') | KeyCode::Down  => state.map.center_z += 2,
         KeyCode::Char('u') => state.map_move_y(1),
         KeyCode::Char('d') => state.map_move_y(-1),
+        KeyCode::Char('0') => state.map_recenter_on_probe(),
+        KeyCode::Char('c') => state.map.coord_input = Some(String::new()),
         KeyCode::Char('g') => {
             let (cx, y, cz) = (state.map.center_x, state.map.y_layer, state.map.center_z);
             state.map.open = false;

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2365,6 +2365,44 @@ fn map_cell_symbol(s: &SectorObservation) -> (&'static str, Style) {
     ("·", Style::default().fg(Color::White))
 }
 
+/// Short content summary of a scanned sector for the map info line.
+fn sector_brief(s: &SectorObservation) -> String {
+    let Some(objects) = &s.objects else {
+        return "estimated only".into();
+    };
+    if objects.is_empty() {
+        return "empty".into();
+    }
+    let mut parts: Vec<String> = Vec::new();
+    if objects.iter().any(|o| matches!(o.object_type, SectorObjectType::BlackHole)) {
+        parts.push("black hole".into());
+    }
+    if objects.iter().any(|o| {
+        matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem)
+    }) {
+        parts.push("star".into());
+    }
+    let planets = objects.iter().filter(|o| matches!(o.object_type, SectorObjectType::Planet)).count()
+        + objects.iter().flat_map(|o| &o.bookmark_targets)
+            .filter(|t| matches!(t.object_type, SectorObjectType::Planet)).count();
+    if planets > 0 {
+        parts.push(format!("{planets} planet(s)"));
+    }
+    let minables: usize = objects.iter()
+        .map(|o| o.minable_targets.as_ref().map(|t| t.len()).unwrap_or(0))
+        .sum();
+    if minables > 0 {
+        parts.push(format!("{minables} minable"));
+    }
+    if objects.iter().any(|o| matches!(o.danger_level, Some(DangerLevel::Extreme))) {
+        parts.push("extreme danger".into());
+    }
+    if parts.is_empty() {
+        parts.push(format!("{} object(s)", objects.len()));
+    }
+    parts.join("  ")
+}
+
 fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     use std::collections::HashMap;
 
@@ -2388,24 +2426,17 @@ fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
 
     let rows_layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
         .split(map_inner);
     let map_area = rows_layout[0];
-    let hint_area = rows_layout[1];
-
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[hjkl]", Style::default().fg(Color::Cyan)),
-            Span::raw(" pan  "),
-            Span::styled("[u/d]", Style::default().fg(Color::Cyan)),
-            Span::raw(" y±1  "),
-            Span::styled("[g]", Style::default().fg(Color::Yellow)),
-            Span::raw(" travel  "),
-            Span::styled("[b/Esc]", Style::default().fg(Color::Cyan)),
-            Span::raw(" close"),
-        ])),
-        hint_area,
-    );
+    let info_area = rows_layout[1];
+    let legend_area = rows_layout[2];
+    let hint_area = rows_layout[3];
 
     // Fast lookup: (x,y,z) → sector
     let sector_lookup: HashMap<(i32, i32, i32), &SectorObservation> = state
@@ -2433,6 +2464,91 @@ fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let cx = state.map.center_x;
     let cz = state.map.center_z;
     let y = state.map.y_layer;
+
+    // ── Center cell info ──
+    let mut info_spans: Vec<Span> = vec![
+        Span::styled(
+            format!("({cx},{y},{cz})"),
+            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+        ),
+    ];
+    if let Some(d) = state.map_center_distance() {
+        info_spans.push(Span::styled(
+            format!("  d:{d}"),
+            Style::default().fg(Color::DarkGray),
+        ));
+        if d > 0 {
+            info_spans.push(Span::styled(
+                format!("  ETA ~{}", format_duration((5 + 35 * d) * 60)),
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+    }
+    let brief = sector_lookup
+        .get(&(cx, y, cz))
+        .map(|s| sector_brief(s))
+        .unwrap_or_else(|| "unscanned".into());
+    info_spans.push(Span::styled(
+        format!("  {brief}"),
+        Style::default().fg(Color::DarkGray),
+    ));
+    frame.render_widget(Paragraph::new(Line::from(info_spans)), info_area);
+
+    // ── Legend ──
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("⊕", Style::default().fg(Color::Cyan)),
+            Span::styled(" probe  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("★", Style::default().fg(Color::Yellow)),
+            Span::styled(" star  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("●", Style::default().fg(Color::Green)),
+            Span::styled(" objects  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("◉", Style::default().fg(Color::Magenta)),
+            Span::styled(" black hole  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("!", Style::default().fg(Color::Red)),
+            Span::styled(" danger  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("·", Style::default().fg(Color::White)),
+            Span::styled(" empty  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("·", Style::default().fg(Color::DarkGray)),
+            Span::styled(" unscanned", Style::default().fg(Color::DarkGray)),
+        ])),
+        legend_area,
+    );
+
+    // ── Hint / coordinate input ──
+    if let Some(buf) = &state.map.coord_input {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("go to (x y z): ", Style::default().fg(Color::Cyan)),
+                Span::raw(buf.as_str()),
+                Span::styled("█", Style::default().fg(Color::Cyan)),
+                Span::raw("  "),
+                Span::styled("[Enter]", Style::default().fg(Color::Green)),
+                Span::raw(" center  "),
+                Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                Span::raw(" cancel"),
+            ])),
+            hint_area,
+        );
+    } else {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("[hjkl]", Style::default().fg(Color::Cyan)),
+                Span::raw(" pan  "),
+                Span::styled("[u/d]", Style::default().fg(Color::Cyan)),
+                Span::raw(" y±1  "),
+                Span::styled("[0]", Style::default().fg(Color::Cyan)),
+                Span::raw(" probe  "),
+                Span::styled("[c]", Style::default().fg(Color::Cyan)),
+                Span::raw(" go to  "),
+                Span::styled("[g]", Style::default().fg(Color::Yellow)),
+                Span::raw(" travel  "),
+                Span::styled("[b/Esc]", Style::default().fg(Color::Cyan)),
+                Span::raw(" close"),
+            ])),
+            hint_area,
+        );
+    }
     let w = map_area.width as i32;
     let h = map_area.height as i32;
     let center_col = map_area.x as i32 + w / 2;


### PR DESCRIPTION
## N3 — Carte : contexte de la cellule centrale

Sur la carte, la cellule centrale est la cible implicite de `[g]` mais rien n'indiquait son contenu ni le coût pour y aller.

- **Ligne d'info** sous la carte : coords du centre, distance Chebyshev depuis la sonde, ETA estimée (`5 + 35*d` min, même formule que le preview travel), résumé du secteur scanné (`sector_brief` : black hole / star / N planet(s) / N minable / extreme danger / empty), ou `unscanned`.
- **Légende** des symboles sur une ligne dédiée.
- **`[0]`** recentre sur la sonde ; **`[c]`** ouvre une saisie de coordonnées pour déplacer la vue (Enter centre, Esc annule).

## Tests

`cargo clippy` clean ; `cargo test` : 102 passed (pas de logique d'état nouvelle testable hors rendu — `map_center_distance` est trivial et couvert par le typage).

_PR 5/15 — empilée sur #34._

🤖 Generated with [Claude Code](https://claude.com/claude-code)