### PR TITLE
feat(ui): help overlay listing all keybindings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -404,6 +404,7 @@ pub struct AppState {
     pub scanner_obj_selection: Option<usize>,
     pub object_action: ObjectActionInput,
     pub waypoints: WaypointsInput,
+    pub help_open: bool,
     pub travel: TravelInput,
     pub repair: RepairInput,
     pub mine: MineInput,

--- a/src/input.rs
+++ b/src/input.rs
@@ -83,6 +83,13 @@ pub fn handle_event(
         return;
     }
 
+    if state.help_open {
+        if matches!(k.code, KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q')) {
+            state.help_open = false;
+        }
+        return;
+    }
+
     if state.map.open {
         handle_map_event(k.code, state);
         return;
@@ -206,6 +213,7 @@ pub fn handle_event(
     match k.code {
         KeyCode::Char('q') => state.set_quit(),
         KeyCode::Char('b') => state.open_map(),
+        KeyCode::Char('?') => state.help_open = true,
         KeyCode::Char('w') => {
             let entries = state.collect_waypoints();
             if entries.is_empty() {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -103,6 +103,106 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     if !matches!(state.waypoints, WaypointsInput::Inactive) {
         render_waypoints_overlay(frame, area, state);
     }
+    if state.help_open {
+        render_help_overlay(frame, area);
+    }
+}
+
+// ── Help overlay ──────────────────────────────────────────────────────────────
+
+fn help_key_line(key: &'static str, desc: &'static str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("  {key:<10}"), Style::default().fg(Color::Cyan)),
+        Span::raw(desc),
+    ])
+}
+
+fn help_section(title: &'static str) -> Line<'static> {
+    Line::from(Span::styled(
+        title,
+        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn render_help_overlay(frame: &mut Frame, area: Rect) {
+    let popup = centered_rect(76, 28, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" HELP — KEYBINDINGS ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(rows[0]);
+
+    let left: Vec<Line> = vec![
+        help_section("Global"),
+        help_key_line("r", "refresh all"),
+        help_key_line("p i m s", "focus probe / inventory / mannies / scanner"),
+        help_key_line("t", "travel to coordinates"),
+        help_key_line("b", "map"),
+        help_key_line("w", "waypoints"),
+        help_key_line("?", "this help"),
+        help_key_line("q", "quit"),
+        help_key_line("Esc", "unfocus / close"),
+        Line::default(),
+        help_section("Inventory (focused)"),
+        help_key_line("↑↓", "select row"),
+        help_key_line("j", "jettison selection"),
+        help_key_line("d", "deploy waypoint"),
+        help_key_line("a", "atomic printer craft"),
+        Line::default(),
+        help_section("Map"),
+        help_key_line("hjkl/←↓↑→", "pan"),
+        help_key_line("u / d", "layer y ± 1"),
+        help_key_line("0", "center on probe"),
+        help_key_line("c", "jump to coordinates"),
+        help_key_line("g", "travel to center"),
+    ];
+
+    let right: Vec<Line> = vec![
+        help_section("Mannies (focused)"),
+        help_key_line("↑↓/jk", "select manny"),
+        help_key_line("Enter", "repair"),
+        help_key_line("e", "mine"),
+        help_key_line("c", "craft"),
+        help_key_line("s", "salvage"),
+        help_key_line("x", "inspect asteroid"),
+        help_key_line("D", "detach container"),
+        help_key_line("v", "recover container"),
+        help_key_line("n", "rename"),
+        help_key_line("R", "recall (busy manny)"),
+        Line::default(),
+        help_section("Scanner (focused)"),
+        help_key_line("Enter", "rescan current sector"),
+        help_key_line("c", "scan custom coordinates"),
+        help_key_line("n", "scan neighbors (d=1)"),
+        help_key_line("d", "deep scan (axis faces, d=2)"),
+        help_key_line("↑↓/jk", "browse history"),
+        help_key_line("J / K", "scroll detail"),
+        help_key_line("o", "object mode (probe sector)"),
+        help_key_line("g", "travel to displayed sector"),
+    ];
+
+    frame.render_widget(Paragraph::new(left), cols[0]);
+    frame.render_widget(Paragraph::new(right), cols[1]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Esc/?]", Style::default().fg(Color::Cyan)),
+            Span::raw(" close"),
+        ])),
+        rows[1],
+    );
 }
 
 // ── Probe panel ───────────────────────────────────────────────────────────────
@@ -2639,6 +2739,8 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
         Span::raw(" map  "),
         Span::styled("[w]", Style::default().fg(Color::Cyan)),
         Span::raw(" waypoints  "),
+        Span::styled("[?]", Style::default().fg(Color::Cyan)),
+        Span::raw(" help  "),
         Span::styled("[q]", Style::default().fg(Color::Cyan)),
         Span::raw(" quit"),
         Span::styled(error_part, Style::default().fg(Color::Red)),


### PR DESCRIPTION
## T1 — Overlay d'aide `[?]`

Une trentaine de raccourcis contextuels existent ; les hint bars n'en montrent qu'une partie selon le focus. `[?]` ouvre un popup statique deux colonnes regroupant tous les bindings par contexte (Global, Inventory, Mannies, Scanner, Map), `[?]`/`[Esc]`/`[q]` ferme. L'overlay est rendu au-dessus de tout et capture le clavier tant qu'il est ouvert. `[?]` ajouté à la status bar.

## Tests

`cargo clippy` clean ; `cargo test` : 102 passed (rendu statique, pas de logique d'état).

_PR 6/15 — empilée sur #36._

🤖 Generated with [Claude Code](https://claude.com/claude-code)