### PR TITLE
feat(scanner): batch scan progress gauge

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -450,6 +450,8 @@ pub struct AppState {
     pub scan_mode: ScanMode,
     pub scan_error: Option<String>,
     pub scan_batch: Option<usize>,
+    /// Size of the batch in flight (for the progress gauge).
+    pub scan_batch_total: usize,
     pub scan_detail_scroll: usize,
     pub scan_filter: ScanFilter,
     /// Some(idx) when the scanner panel is in object-browsing mode.
@@ -823,6 +825,7 @@ impl AppState {
 
     pub fn start_batch(&mut self, n: usize) {
         self.scan_batch = Some(n);
+        self.scan_batch_total = n;
         self.scan_error = None;
     }
 
@@ -1995,6 +1998,18 @@ mod tests {
         state.scan_batch = Some(3);
         state.batch_tick();
         assert_eq!(state.scan_batch, Some(2));
+    }
+
+    #[test]
+    fn start_batch_records_total() {
+        let mut state = AppState::default();
+        state.start_batch(12);
+        assert_eq!(state.scan_batch, Some(12));
+        assert_eq!(state.scan_batch_total, 12);
+        state.batch_tick();
+        // total is preserved while remaining decreases
+        assert_eq!(state.scan_batch, Some(11));
+        assert_eq!(state.scan_batch_total, 12);
     }
 
     #[test]

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -844,14 +844,15 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
         }
         ScanMode::Current => {
             if let Some(remaining) = state.scan_batch {
+                let total = state.scan_batch_total.max(1);
+                let done = total.saturating_sub(remaining);
+                let ratio = (done as f64 / total as f64).clamp(0.0, 1.0);
                 frame.render_widget(
-                    Paragraph::new(Line::from(vec![
-                        Span::styled("⟳ scanning  ", Style::default().fg(Color::Yellow)),
-                        Span::styled(
-                            format!("{remaining} remaining"),
-                            Style::default().fg(Color::White),
-                        ),
-                    ])),
+                    make_line_gauge(
+                        &format!("⟳ scanning {done}/{total}"),
+                        ratio,
+                        Color::Yellow,
+                    ),
                     hint_area,
                 );
             } else if focused {


### PR DESCRIPTION
## S4 — Progression du batch scan

Remplace le texte « `N remaining` » pendant les scans batch (neighbors `[n]`, deep `[d]`) par une `LineGauge` `done/total`. `start_batch` mémorise la taille du batch (`scan_batch_total`) pour dériver la progression du compteur restant.

## Tests

1 nouveau test (`start_batch_records_total` : total préservé pendant les ticks). `cargo clippy` clean ; `cargo test` : 110 passed.

_PR 9/15 — empilée sur #39._

🤖 Generated with [Claude Code](https://claude.com/claude-code)