### PR TITLE
feat(scanner): stamp and display scan age

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -462,4 +462,8 @@ pub struct SectorObservation {
     pub sensor_mode: Option<SensorMode>,
     pub data_freshness: Option<DataFreshness>,
     pub scan: SectorScan,
+    /// Local timestamp of when this observation was received (not an API
+    /// field — stamped client-side and persisted in scan_history.json).
+    #[serde(default)]
+    pub scanned_at: Option<DateTime<Utc>>,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -549,7 +549,8 @@ impl AppState {
         }
     }
 
-    pub fn update_sector(&mut self, sector: SectorObservation) {
+    pub fn update_sector(&mut self, mut sector: SectorObservation) {
+        sector.scanned_at = Some(Utc::now());
         let key = (
             sector.relative_coordinates.x as i64,
             sector.relative_coordinates.y as i64,
@@ -2035,6 +2036,16 @@ mod tests {
         state.update_sector(make_sector(2., 0., -2.));
         assert_eq!(state.scan_history.len(), 1);
         assert_eq!(state.scan_history_idx, 0);
+    }
+
+    #[test]
+    fn update_sector_stamps_scanned_at() {
+        let mut state = AppState::default();
+        // fixture JSON has no scannedAt field — defaults to None
+        let sector = make_sector(2., 0., -2.);
+        assert!(sector.scanned_at.is_none());
+        state.update_sector(sector);
+        assert!(state.scan_history[0].scanned_at.is_some());
     }
 
     #[test]

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -1021,7 +1021,7 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
     let freshness_str = sector.data_freshness.as_ref().map(freshness_label).unwrap_or("—");
     let freshness_color = sector.data_freshness.as_ref().map(freshness_color).unwrap_or(Color::DarkGray);
     let scan_q = sector.scan.scan_quality;
-    lines.push(Line::from(vec![
+    let mut freshness_spans = vec![
         Span::styled(freshness_str, Style::default().fg(freshness_color)),
         Span::raw("  quality: "),
         Span::styled(
@@ -1030,7 +1030,15 @@ fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused
         ),
         Span::raw("  sensors: "),
         Span::styled(sensor_dot(&sensor), sensor_style(&sensor)),
-    ]));
+    ];
+    if let Some(scanned_at) = sector.scanned_at {
+        let age_secs = (Utc::now() - scanned_at).num_seconds().max(0);
+        freshness_spans.push(Span::styled(
+            format!("  scanned {}", format_age(age_secs)),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    lines.push(Line::from(freshness_spans));
 
     let req = sector.scan.required_residence_seconds;
     let cur = sector.scan.current_sector_residence_seconds;
@@ -3051,6 +3059,19 @@ fn gauge_color(ratio: f64) -> Color {
         Color::Yellow
     } else {
         Color::Red
+    }
+}
+
+/// Compact human age: "just now", "5m ago", "3h ago", "2d ago".
+pub fn format_age(secs: i64) -> String {
+    if secs < 60 {
+        "just now".to_string()
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86400)
     }
 }
 


### PR DESCRIPTION
## S5 — Âge des scans

`dataFreshness` indique la fraîcheur estimée par l'API mais pas *quand* le secteur a été scanné.

- Champ `scanned_at: Option<DateTime<Utc>>` ajouté à `SectorObservation` avec `#[serde(default)]` : champ local (pas API), les `scan_history.json` existants chargent sans migration ; sérialisé `scannedAt` ensuite.
- Horodaté dans `update_sector` à la réception.
- Affiché sur la ligne freshness du détail secteur : `scanned 5m ago` (helper `format_age` : just now / Nm / Nh / Nd).

## Tests

1 nouveau test (`update_sector_stamps_scanned_at`, vérifie aussi le default None sur JSON sans champ). `cargo clippy` clean ; `cargo test` : 111 passed.

_PR 10/15 — empilée sur #40._

🤖 Generated with [Claude Code](https://claude.com/claude-code)