### PR TITLE
feat(inventory): read-only detail popup for the selected row

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -459,6 +459,8 @@ pub struct AppState {
     pub object_action: ObjectActionInput,
     pub waypoints: WaypointsInput,
     pub help_open: bool,
+    /// Read-only detail popup for the selected inventory row.
+    pub inventory_detail_open: bool,
     pub travel: TravelInput,
     pub repair: RepairInput,
     pub mine: MineInput,

--- a/src/input.rs
+++ b/src/input.rs
@@ -90,6 +90,13 @@ pub fn handle_event(
         return;
     }
 
+    if state.inventory_detail_open {
+        if matches!(k.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
+            state.inventory_detail_open = false;
+        }
+        return;
+    }
+
     if state.map.open {
         handle_map_event(k.code, state);
         return;
@@ -283,6 +290,11 @@ pub fn handle_event(
         }
         KeyCode::Up if state.focused == Some(Panel::Inventory) => {
             state.inventory_prev();
+        }
+        KeyCode::Enter if state.focused == Some(Panel::Inventory) => {
+            if state.selected_inventory_row().is_some() {
+                state.inventory_detail_open = true;
+            }
         }
         KeyCode::Char('d') if state.focused == Some(Panel::Inventory) => {
             if state.inventory_waypoint_bookmark_id().is_none() {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2,7 +2,7 @@ use crate::api::types::{
     DangerLevel, DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask,
     MovementPhase, ProbeStatus, SectorObject, SectorObjectType, SectorObservation, SensorMode,
 };
-use crate::app::{is_active_item, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, WaypointKind, WaypointsInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{is_active_item, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, InventoryRow, JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput, WaypointKind, WaypointsInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use chrono::Utc;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -103,9 +103,132 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     if !matches!(state.waypoints, WaypointsInput::Inactive) {
         render_waypoints_overlay(frame, area, state);
     }
+    if state.inventory_detail_open {
+        render_inventory_detail_overlay(frame, area, state);
+    }
     if state.help_open {
         render_help_overlay(frame, area);
     }
+}
+
+// ── Inventory detail overlay ──────────────────────────────────────────────────
+
+fn detail_kv(key: &str, value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{key:<12}"), Style::default().fg(Color::DarkGray)),
+        Span::raw(value),
+    ])
+}
+
+fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let Some(probe) = &state.probe else { return };
+    let Some(row) = state.selected_inventory_row() else { return };
+    let inv = &probe.inventory;
+
+    let (title, lines): (String, Vec<Line>) = match row {
+        InventoryRow::Stock { id } => {
+            let Some(stock) = inv.resource_stocks.iter().find(|s| s.id == id) else { return };
+            let mut lines = vec![
+                detail_kv("Type", stock.stock_type.clone()),
+                detail_kv("Amount", format!("{:.4} ECE", stock.amount)),
+                detail_kv("Space", format!("{:.4}", stock.container_space)),
+            ];
+            if !stock.containers.is_empty() {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(
+                    "── containers ──",
+                    Style::default().fg(Color::DarkGray),
+                )));
+                for line in &stock.containers {
+                    lines.push(detail_kv(
+                        &line.container.label,
+                        format!("{:.4} ECE  (space {:.4})", line.amount, line.container_space),
+                    ));
+                }
+            }
+            (stock.name.clone(), lines)
+        }
+        InventoryRow::ActiveItem { id } => {
+            let Some(item) = inv.items.iter().find(|i| i.id == id) else { return };
+            let mut lines = vec![
+                detail_kv("Type", item.item_type.clone()),
+                detail_kv("Space", format!("{:.4}", item.container_space)),
+                detail_kv(
+                    "Task",
+                    match item.current_task.as_deref() {
+                        None => "idle".into(),
+                        Some(t) => format!("{t}  {:.0}%", item.task_progress_percent),
+                    },
+                ),
+            ];
+            if let Some(loc) = &item.location {
+                lines.push(detail_kv("Location", format!("{:?}", loc.location_type).to_lowercase()));
+            }
+            if let Some(container) = &item.container {
+                lines.push(detail_kv("Container", container.label.clone()));
+            }
+            if let Some(cargo) = &item.cargo {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(
+                    "── cargo ──",
+                    Style::default().fg(Color::DarkGray),
+                )));
+                lines.push(detail_kv("Capacity", format!("{:.3}", cargo.capacity)));
+                lines.push(detail_kv("Deuterium", format!("{:.3}", cargo.deuterium)));
+                lines.push(detail_kv("Metals", format!("{:.3}", cargo.metals)));
+                lines.push(detail_kv("Ice", format!("{:.3}", cargo.ice)));
+                lines.push(detail_kv("Organic", format!("{:.3}", cargo.organic_compounds)));
+            }
+            (item.name.clone(), lines)
+        }
+        InventoryRow::PassiveGroup { item_type } => {
+            let items: Vec<_> = inv.items.iter().filter(|i| i.item_type == item_type).collect();
+            let Some(first) = items.first() else { return };
+            let mut lines = vec![
+                detail_kv("Type", item_type.clone()),
+                detail_kv("Count", format!("{}", items.len())),
+                detail_kv(
+                    "Space",
+                    format!("{:.4} total", items.iter().map(|i| i.container_space).sum::<f64>()),
+                ),
+                Line::default(),
+            ];
+            for item in &items {
+                let container = item.container.as_ref()
+                    .map(|c| format!("  ({})", c.label))
+                    .unwrap_or_default();
+                lines.push(Line::from(vec![
+                    Span::raw(format!("  {}", item.name)),
+                    Span::styled(container, Style::default().fg(Color::DarkGray)),
+                ]));
+            }
+            (first.name.clone(), lines)
+        }
+    };
+
+    let height = (lines.len() as u16 + 4).min(20);
+    let popup = centered_rect(50, height, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(format!(" {title} "))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" close"),
+        ])),
+        rows[1],
+    );
 }
 
 // ── Help overlay ──────────────────────────────────────────────────────────────
@@ -158,6 +281,7 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
         Line::default(),
         help_section("Inventory (focused)"),
         help_key_line("↑↓", "select row"),
+        help_key_line("Enter", "row detail"),
         help_key_line("j", "jettison selection"),
         help_key_line("d", "deploy waypoint"),
         help_key_line("a", "atomic printer craft"),
@@ -396,6 +520,8 @@ fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppState, focus
         let mut hint_spans = vec![
             Span::styled("[↑↓]", Style::default().fg(Color::Cyan)),
             Span::raw(" select  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
+            Span::raw(" detail  "),
             Span::styled("[j]", Style::default().fg(Color::Cyan)),
             Span::raw(" jettison"),
         ];


### PR DESCRIPTION
## I3 — Détail d'item

`[Enter]` sur la ligne sélectionnée du panneau INVENTORY ouvre un popup lecture seule :

- **Stock** : type, amount, container space, ventilation par container (`ResourceStockContainerLine`) ;
- **Item actif** (manny, printer) : type, tâche + progression, location, container, contenu cargo (capacity/deuterium/metals/ice/organic) ;
- **Groupe passif** : type, count, espace total, liste des unités avec leur container.

Ces champs étaient désérialisés mais jamais affichés. `[Esc]/[Enter]/[q]` ferme. Hint bar et help overlay mis à jour.

## Tests

`cargo clippy` clean ; `cargo test` : 111 passed (rendu pur, la sélection est déjà couverte par les tests de `inventory_rows`).

_PR 11/15 — empilée sur #41._

🤖 Generated with [Claude Code](https://claude.com/claude-code)