### PR TITLE
feat(inventory): [M] fills max amount in jettison input

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1197,6 +1197,13 @@ impl AppState {
         }
     }
 
+    pub fn jettison_fill_max(&mut self) {
+        if let JettisonInput::EnterAmount { ref mut buf, max_amount, ref mut error, .. } = self.jettison {
+            *buf = format!("{max_amount:.4}");
+            *error = None;
+        }
+    }
+
     pub fn set_craft_error(&mut self, msg: String) {
         if let CraftInput::PickRecipe { ref mut error, .. } = self.craft {
             *error = Some(msg);
@@ -1802,6 +1809,25 @@ mod tests {
             "location": null, "cargo": null, "container": null}]"#;
         state.probe = Some(probe_with_inventory(items, "[]"));
         assert!(state.jettison_for_selected().is_err());
+    }
+
+    #[test]
+    fn jettison_fill_max_sets_buffer() {
+        let mut state = AppState::default();
+        state.jettison = JettisonInput::EnterAmount {
+            item_id: "stock-metals".into(),
+            item_name: "Metals".into(),
+            max_amount: 0.5,
+            buf: "0.1".into(),
+            error: Some("previous".into()),
+        };
+        state.jettison_fill_max();
+        if let JettisonInput::EnterAmount { ref buf, ref error, .. } = state.jettison {
+            assert_eq!(buf, "0.5000");
+            assert!(error.is_none());
+        } else {
+            panic!("expected EnterAmount");
+        }
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -746,6 +746,7 @@ fn handle_jettison_event(
             match code {
                 KeyCode::Esc => state.jettison = JettisonInput::Inactive,
                 KeyCode::Backspace => state.jettison_backspace(),
+                KeyCode::Char('m') | KeyCode::Char('M') => state.jettison_fill_max(),
                 KeyCode::Char(c) => state.jettison_type_char(c),
                 KeyCode::Enter => {
                     let (item_id, amount) = {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -1888,6 +1888,9 @@ fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
             lines.push(Line::from(vec![
                 Span::styled("MAX  ", Style::default().fg(Color::DarkGray)),
                 Span::styled(format!("{max_amount:.3}"), Style::default().fg(Color::White)),
+                Span::raw("   "),
+                Span::styled("[M]", Style::default().fg(Color::Yellow)),
+                Span::styled(" fill", Style::default().fg(Color::DarkGray)),
                 Span::styled("  [empty = all]", Style::default().fg(Color::DarkGray)),
             ]));
             if let Some(err) = error {


### PR DESCRIPTION
## I4 — Cohérence `[M]` max

La saisie de quantité jettison proposait seulement `[empty = all]` alors que repair et mine utilisent `[M]` max. Ajout de `jettison_fill_max()` (rempli à `max_amount`, efface l'erreur précédente), hint mis à jour ; `empty = all` conservé.

## Tests

1 nouveau test. `cargo clippy` clean ; `cargo test` : 112 passed.

_PR 12/15 — empilée sur #42._

🤖 Generated with [Claude Code](https://claude.com/claude-code)