### PR TITLE
feat(ui): Tab cycles panel focus

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -532,6 +532,29 @@ impl AppState {
         }
     }
 
+    /// Visual order for Tab cycling: top-left → top-right → bottom-left → bottom-right.
+    const PANEL_ORDER: [Panel; 4] = [Panel::Probe, Panel::Inventory, Panel::Scanner, Panel::Mannies];
+
+    pub fn focus_next_panel(&mut self) {
+        self.focused = Some(match self.focused {
+            None => Self::PANEL_ORDER[0],
+            Some(p) => {
+                let i = Self::PANEL_ORDER.iter().position(|&x| x == p).unwrap_or(0);
+                Self::PANEL_ORDER[(i + 1) % Self::PANEL_ORDER.len()]
+            }
+        });
+    }
+
+    pub fn focus_prev_panel(&mut self) {
+        self.focused = Some(match self.focused {
+            None => Self::PANEL_ORDER[Self::PANEL_ORDER.len() - 1],
+            Some(p) => {
+                let i = Self::PANEL_ORDER.iter().position(|&x| x == p).unwrap_or(0);
+                Self::PANEL_ORDER[(i + Self::PANEL_ORDER.len() - 1) % Self::PANEL_ORDER.len()]
+            }
+        });
+    }
+
     pub fn manny_next(&mut self) {
         if let Some(mannies) = &self.mannies {
             if !mannies.is_empty() {
@@ -1902,6 +1925,30 @@ mod tests {
         state.toggle_focus(Panel::Probe);
         state.toggle_focus(Panel::Mannies);
         assert_eq!(state.focused, Some(Panel::Mannies));
+    }
+
+    #[test]
+    fn focus_next_panel_cycles_in_visual_order() {
+        let mut state = AppState::default();
+        state.focus_next_panel();
+        assert_eq!(state.focused, Some(Panel::Probe));
+        state.focus_next_panel();
+        assert_eq!(state.focused, Some(Panel::Inventory));
+        state.focus_next_panel();
+        assert_eq!(state.focused, Some(Panel::Scanner));
+        state.focus_next_panel();
+        assert_eq!(state.focused, Some(Panel::Mannies));
+        state.focus_next_panel();
+        assert_eq!(state.focused, Some(Panel::Probe));
+    }
+
+    #[test]
+    fn focus_prev_panel_cycles_backwards() {
+        let mut state = AppState::default();
+        state.focus_prev_panel();
+        assert_eq!(state.focused, Some(Panel::Mannies));
+        state.focus_prev_panel();
+        assert_eq!(state.focused, Some(Panel::Scanner));
     }
 
     // ── manny_next / manny_prev ───────────────────────────────────────────────

--- a/src/input.rs
+++ b/src/input.rs
@@ -276,6 +276,8 @@ pub fn handle_event(
             state.loading = true;
             fetch_all(client.clone(), tx.clone());
         }
+        KeyCode::Tab => state.focus_next_panel(),
+        KeyCode::BackTab => state.focus_prev_panel(),
         KeyCode::Char('p') => state.toggle_focus(Panel::Probe),
         KeyCode::Char('i') => state.toggle_focus(Panel::Inventory),
         KeyCode::Char('m') => state.toggle_focus(Panel::Mannies),

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -272,6 +272,7 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_section("Global"),
         help_key_line("r", "refresh all"),
         help_key_line("p i m s", "focus probe / inventory / mannies / scanner"),
+        help_key_line("Tab", "cycle panel focus (Shift-Tab reverse)"),
         help_key_line("t", "travel to coordinates"),
         help_key_line("b", "map"),
         help_key_line("w", "waypoints"),


### PR DESCRIPTION
## T2 — Cycle de focus

`Tab` cycle le focus dans l'ordre visuel (Probe → Inventory → Scanner → Mannies), `Shift-Tab` en sens inverse. Les raccourcis directs `p/i/m/s` sont inchangés. Le `Tab` du wizard mine (toggle resources/amount) n'est pas impacté : les handlers d'overlay s'exécutent avant le match global.

## Tests

2 nouveaux tests (cycle avant depuis None et wrap, cycle arrière). `cargo clippy` clean ; `cargo test` : 114 passed.

_PR 13/15 — empilée sur #43._

🤖 Generated with [Claude Code](https://claude.com/claude-code)