### PR TITLE
feat(ui): transient success toasts in the status bar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -461,6 +461,8 @@ pub struct AppState {
     pub help_open: bool,
     /// Read-only detail popup for the selected inventory row.
     pub inventory_detail_open: bool,
+    /// Transient success message shown in the status bar.
+    pub toast: Option<(String, DateTime<Local>)>,
     pub travel: TravelInput,
     pub repair: RepairInput,
     pub mine: MineInput,
@@ -513,6 +515,18 @@ impl AppState {
 
     pub fn set_error(&mut self, msg: String) {
         self.error = Some(msg);
+    }
+
+    pub fn set_toast(&mut self, msg: impl Into<String>) {
+        self.toast = Some((msg.into(), Local::now()));
+    }
+
+    /// Toast message while fresh (< 5 s); expired toasts are not shown.
+    pub fn active_toast(&self) -> Option<&str> {
+        self.toast
+            .as_ref()
+            .filter(|(_, t)| (Local::now() - *t).num_seconds() < 5)
+            .map(|(m, _)| m.as_str())
     }
 
     pub fn clear_error(&mut self) {
@@ -1851,6 +1865,18 @@ mod tests {
         } else {
             panic!("expected EnterAmount");
         }
+    }
+
+    #[test]
+    fn toast_expires_after_five_seconds() {
+        let mut state = AppState::default();
+        state.set_toast("mining order sent");
+        assert_eq!(state.active_toast(), Some("mining order sent"));
+        // age the toast artificially
+        if let Some((_, ref mut t)) = state.toast {
+            *t -= chrono::Duration::seconds(6);
+        }
+        assert_eq!(state.active_toast(), None);
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -62,6 +62,8 @@ pub fn handle_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     let Event::Key(k) = event else { return };
+    // Toasts are transient: any keypress dismisses the current one.
+    state.toast = None;
     let ctrl = k.modifiers.contains(KeyModifiers::CONTROL);
     let in_scan_input = matches!(state.scan_mode, ScanMode::Input(_));
     let in_direction_pick = matches!(state.scan_mode, ScanMode::DirectionPick);

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,62 +93,76 @@ async fn run(
                             state.set_scan_error(e);
                         }
                     }
-                    ApiMessage::MoveStarted(mv) => state.apply_movement(mv),
+                    ApiMessage::MoveStarted(mv) => {
+                        state.apply_movement(mv);
+                        state.set_toast("travel order sent");
+                    }
                     ApiMessage::MoveError(e) => state.set_travel_error(e),
                     ApiMessage::RepairStarted => {
                         state.repair = RepairInput::Inactive;
+                        state.set_toast("repair order sent");
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::RepairError(e) => state.set_repair_error(e),
                     ApiMessage::MineStarted => {
                         state.mine = MineInput::Inactive;
+                        state.set_toast("mining order sent");
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::MineError(e) => state.set_mine_error(e),
                     ApiMessage::JettisonDone(inv) => {
                         state.update_inventory(inv);
                         state.jettison = JettisonInput::Inactive;
+                        state.set_toast("jettisoned");
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::JettisonError(e) => state.set_jettison_error(e),
                     ApiMessage::CraftStarted => {
                         state.craft = CraftInput::Inactive;
+                        state.set_toast("craft order sent");
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::CraftError(e) => state.set_craft_error(e),
                     ApiMessage::SalvageStarted => {
                         state.salvage = SalvageInput::Inactive;
+                        state.set_toast("salvage order sent");
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::SalvageError(e) => state.set_salvage_error(e),
                     ApiMessage::RecallStarted => {
                         state.recall = RecallInput::Inactive;
+                        state.set_toast("recall order sent");
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::RecallError(e) => state.set_recall_error(e),
                     ApiMessage::DeployStarted => {
                         state.deploy = DeployInput::Inactive;
+                        state.set_toast("waypoint deploy order sent");
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::DeployError(e) => state.set_deploy_error(e),
                     ApiMessage::AtomicPrinterCraftStarted => {
                         state.atomic_printer_craft = AtomicPrinterCraftInput::Inactive;
+                        state.set_toast("atomic printer craft started");
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::AtomicPrinterCraftError(e) => state.set_atomic_printer_craft_error(e),
                     ApiMessage::RecipesFetched(recipes) => state.recipes = recipes,
                     ApiMessage::InspectStarted => {
                         state.inspect = InspectInput::Inactive;
+                        state.set_toast("inspect order sent");
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::InspectError(e) => state.set_inspect_error(e),
                     ApiMessage::RecoverStarted => {
                         state.recover = RecoverInput::Inactive;
+                        state.set_toast("recover order sent");
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::RecoverError(e) => state.set_recover_error(e),
                     ApiMessage::DetachStarted => {
                         state.detach = DetachInput::Inactive;
+                        state.set_toast("detach order sent");
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::DetachError(e) => state.set_detach_error(e),
@@ -159,6 +173,7 @@ async fn run(
                             }
                         }
                         state.rename_manny = RenameMannyInput::Inactive;
+                        state.set_toast("manny renamed");
                     }
                     ApiMessage::RenameMannyError(e) => state.set_rename_manny_error(e),
                     ApiMessage::VersionFetched(v) => state.api_version = Some(v),

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2920,6 +2920,11 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
         String::new()
     };
 
+    let toast_part = state
+        .active_toast()
+        .map(|t| format!("  ✓ {t}"))
+        .unwrap_or_default();
+
     let left = Line::from(vec![
         Span::styled("[r]", Style::default().fg(Color::Cyan)),
         Span::raw(" refresh  "),
@@ -2941,6 +2946,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
         Span::raw(" help  "),
         Span::styled("[q]", Style::default().fg(Color::Cyan)),
         Span::raw(" quit"),
+        Span::styled(toast_part, Style::default().fg(Color::Green)),
         Span::styled(error_part, Style::default().fg(Color::Red)),
     ]);
 


### PR DESCRIPTION
## T3 — Feedback de succès

Un ordre accepté (`MineStarted`, `CraftStarted`, …) fermait l'overlay sans aucun feedback. Désormais :

- `set_toast()` sur chacun des 13 messages de succès dans `main.rs` → « `✓ mining order sent` » en vert dans la status bar (avant la zone d'erreur).
- Expiration après 5 s (`active_toast()` filtre à l'affichage) ; toute frappe clavier l'efface immédiatement.
- Limitation connue : sans événement (ni frappe ni message API), le dernier rendu persiste — le toast peut donc rester visible au-delà de 5 s jusqu'au prochain redraw. Pas de tick loop ajouté exprès (design « no polling » du projet).

## Tests

1 nouveau test (expiration). `cargo clippy` clean ; `cargo test` : 115 passed.

_PR 14/15 — empilée sur #44._

🤖 Generated with [Claude Code](https://claude.com/claude-code)