### PR TITLE
feat(api): implement /api/probe/visited-sectors and show visited cells on the map

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,4 +1,4 @@
-use super::types::{CraftingRecipe, Manny, Probe, ProbeInventory, ProbeMovement, SectorObservation};
+use super::types::{CraftingRecipe, Manny, Probe, ProbeInventory, ProbeMovement, SectorObservation, VisitedSector};
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
 use serde::{Deserialize, Serialize};
@@ -267,6 +267,13 @@ impl ApiClient {
         struct Resp { manny: Manny }
         let path = format!("/api/probe/mannies/{manny_id}/recover-storage-container");
         Ok(self.post::<Resp, _>(&path, &Body { object_id }).await?.manny)
+    }
+
+    pub async fn get_visited_sectors(&self) -> Result<Vec<VisitedSector>> {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Resp { visited_sectors: Vec<VisitedSector> }
+        Ok(self.get::<Resp>("/api/probe/visited-sectors").await?.visited_sectors)
     }
 
     pub async fn get_crafting_recipes(&self) -> Result<Vec<CraftingRecipe>> {

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -29,11 +29,20 @@ pub fn fetch_all(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
         }
     });
 
-    let c3 = client;
-    let tx3 = tx;
+    let c3 = client.clone();
+    let tx3 = tx.clone();
     tokio::spawn(async move {
         if let Ok(s) = c3.get_probe_sector().await {
             let _ = tx3.send(ApiMessage::SectorUpdated(s)).await;
+        }
+    });
+
+    // Non-fatal, like mannies and sector.
+    let c4 = client;
+    let tx4 = tx;
+    tokio::spawn(async move {
+        if let Ok(v) = c4.get_visited_sectors().await {
+            let _ = tx4.send(ApiMessage::VisitedSectorsFetched(v)).await;
         }
     });
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -226,6 +226,17 @@ pub struct ProbeInventory {
     pub containers: Vec<StorageContainer>,
 }
 
+// ── Visited sectors ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VisitedSector {
+    pub relative_coordinates: Vector,
+    pub first_visited_at: DateTime<Utc>,
+    pub last_visited_at: DateTime<Utc>,
+    pub visit_count: i64,
+}
+
 // ── Systems ───────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::api::types::{CraftingRecipe, Manny, Probe, ProbeInventory, ProbeMovement, SectorObject, SectorObjectType, SectorObservation};
+use crate::api::types::{CraftingRecipe, Manny, Probe, ProbeInventory, ProbeMovement, SectorObject, SectorObjectType, SectorObservation, VisitedSector};
 use chrono::{DateTime, Local, Utc};
 use std::path::Path;
 use tokio::time::Instant;
@@ -394,6 +394,7 @@ pub enum ApiMessage {
     MineStarted,
     MineError(String),
     VersionFetched(u32),
+    VisitedSectorsFetched(Vec<VisitedSector>),
     JettisonDone(ProbeInventory),
     JettisonError(String),
     CraftStarted,
@@ -463,6 +464,8 @@ pub struct AppState {
     pub inventory_detail_open: bool,
     /// Transient success message shown in the status bar.
     pub toast: Option<(String, DateTime<Local>)>,
+    /// Sectors already visited by the probe (server-side history).
+    pub visited_sectors: Vec<VisitedSector>,
     pub travel: TravelInput,
     pub repair: RepairInput,
     pub mine: MineInput,
@@ -1865,6 +1868,23 @@ mod tests {
         } else {
             panic!("expected EnterAmount");
         }
+    }
+
+    #[test]
+    fn visited_sector_parses_spec_example() {
+        let v: Vec<VisitedSector> = serde_json::from_str(r#"[
+            {"relativeCoordinates": {"x": 0, "y": 0, "z": 0},
+             "firstVisitedAt": "2026-06-01T12:00:00+00:00",
+             "lastVisitedAt": "2026-06-01T12:00:00+00:00",
+             "visitCount": 1},
+            {"relativeCoordinates": {"x": 1, "y": 1, "z": 0},
+             "firstVisitedAt": "2026-06-01T13:15:00+00:00",
+             "lastVisitedAt": "2026-06-01T15:45:00+00:00",
+             "visitCount": 2}
+        ]"#).unwrap();
+        assert_eq!(v.len(), 2);
+        assert_eq!(v[1].visit_count, 2);
+        assert_eq!(v[1].relative_coordinates.x as i32, 1);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,7 @@ async fn run(
                     }
                     ApiMessage::RenameMannyError(e) => state.set_rename_manny_error(e),
                     ApiMessage::VersionFetched(v) => state.api_version = Some(v),
+                    ApiMessage::VisitedSectorsFetched(v) => state.visited_sectors = v,
                     ApiMessage::Error(e) => state.set_error(e),
                 }
             }

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -2759,6 +2759,18 @@ fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
         .and_then(|s| s.relative.as_ref())
         .map(|r| (r.x as i32, r.y as i32, r.z as i32));
 
+    let visited: std::collections::HashSet<(i32, i32, i32)> = state
+        .visited_sectors
+        .iter()
+        .map(|v| {
+            (
+                v.relative_coordinates.x.round() as i32,
+                v.relative_coordinates.y.round() as i32,
+                v.relative_coordinates.z.round() as i32,
+            )
+        })
+        .collect();
+
     let cx = state.map.center_x;
     let cz = state.map.center_z;
     let y = state.map.y_layer;
@@ -2785,7 +2797,19 @@ fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let brief = sector_lookup
         .get(&(cx, y, cz))
         .map(|s| sector_brief(s))
-        .unwrap_or_else(|| "unscanned".into());
+        .unwrap_or_else(|| {
+            if let Some(v) = state.visited_sectors.iter().find(|v| {
+                (
+                    v.relative_coordinates.x.round() as i32,
+                    v.relative_coordinates.y.round() as i32,
+                    v.relative_coordinates.z.round() as i32,
+                ) == (cx, y, cz)
+            }) {
+                format!("visited ×{} — no scan data", v.visit_count)
+            } else {
+                "unscanned".into()
+            }
+        });
     info_spans.push(Span::styled(
         format!("  {brief}"),
         Style::default().fg(Color::DarkGray),
@@ -2805,6 +2829,8 @@ fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
             Span::styled(" black hole  ", Style::default().fg(Color::DarkGray)),
             Span::styled("!", Style::default().fg(Color::Red)),
             Span::styled(" danger  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("○", Style::default().fg(Color::Blue)),
+            Span::styled(" visited  ", Style::default().fg(Color::DarkGray)),
             Span::styled("·", Style::default().fg(Color::White)),
             Span::styled(" empty  ", Style::default().fg(Color::DarkGray)),
             Span::styled("·", Style::default().fg(Color::DarkGray)),
@@ -2888,6 +2914,13 @@ fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
                     (s, st.add_modifier(Modifier::REVERSED))
                 } else {
                     (s, st)
+                }
+            } else if visited.contains(&(x, y, z)) {
+                let st = Style::default().fg(Color::Blue);
+                if is_center {
+                    ("○", st.add_modifier(Modifier::REVERSED))
+                } else {
+                    ("○", st)
                 }
             } else if is_center {
                 ("+", Style::default().fg(Color::DarkGray).add_modifier(Modifier::REVERSED))


### PR DESCRIPTION
## N4 — Endpoint visited-sectors + intégration carte

Le schéma est défini dans `api-specs/v23.yaml` (`ProbeVisitedSectorsResponse`/`VisitedSector`) — implémentation directe :

- `VisitedSector` dans `types.rs` (relativeCoordinates, firstVisitedAt, lastVisitedAt, visitCount) ;
- `get_visited_sectors()` dans `client.rs` (même pattern d'enveloppe que les autres GET) ;
- fetché dans `fetch_all` comme 4ᵉ tâche non-fatale (même politique que mannies/sector) ;
- **Carte** : les secteurs visités mais absents de l'historique local de scans s'affichent en `○` bleu (légende mise à jour), et la ligne d'info du centre retombe sur `visited ×N — no scan data`. Utile après réinstallation ou depuis une autre machine (l'historique serveur peuple la carte au-delà de `scan_history.json`).

La table des endpoints de CLAUDE.md sera mise à jour dans la PR docs qui suit.

## Tests

1 nouveau test (désérialisation de l'exemple exact du spec). `cargo clippy` clean ; `cargo test` : 116 passed.

_PR 15/16 — empilée sur #45._

🤖 Generated with [Claude Code](https://claude.com/claude-code)