### PR TITLE
feat(ui): retro phosphor-CRT theme with idle animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ All other API calls (move, repair, mine, craft, etc.) are also spawned tasks tha
 - `types.rs` — all OpenAPI types. Structs use `#[serde(rename_all = "camelCase")]`; enums use `#[serde(rename_all = "snake_case")]` with `#[serde(other)] Unknown` fallbacks. `#![allow(dead_code)]` suppresses warnings on fields not yet consumed by the UI.
 - `client.rs` — `ApiClient` (cloneable, wraps `reqwest::Client`). Each endpoint has a typed wrapper with an inline `struct Resp` that deserializes the envelope and returns the inner value. HTTP errors extract `error.message` from the JSON body; 401 produces a specific "check your api_key" message.
 
+### Retro theme (`src/ui/retro/`)
+
+Optional phosphor-CRT skin (Alien-style), selected with `theme = "retro"` in config or toggled at runtime with `F2`. Entirely self-contained: `ui::render` dispatches on `AppState::ui_theme` between `cockpit::render` (classic, default) and `retro::render`. Components: `palette.rs` (4-intensity monochrome, green or amber via `phosphor`), `banner.rs`, `systems.rs` (block gauges + probe schematic LEDs), `radar.rs` (sweeping dial, blips for `scanner_objects()`), `drones.rs`, `ticker.rs` (COMMS + pseudo-telemetry), `boot.rs` (teletype boot sequence, any key skips).
+
+Animations are driven by a 100 ms render tick in the main `select!`, guarded by `anim_tick_active()` — it only advances `AnimState::frame` and redraws, **never** triggers API calls; with the classic theme or `animations = false` the branch is disabled and behaviour is exactly the pre-existing event-driven one. All animations are pure functions of the frame counter (`app/anim.rs`, `anim_hash` for deterministic noise). Wizard overlays are shared between themes via `overlays::render_active_overlays`.
+
 ### UI (`src/ui/`)
 
 `cockpit::render(frame, state)` is the single render entry point called every loop iteration. Module layout: `cockpit.rs` (entry point, 4-panel layout, status bar), `panels/` (one file per panel, each with its height helper), `overlays/` (one file per wizard overlay; `pickers.rs` groups the seven pick-list-based ones; `mod.rs` hosts `centered_rect` + `render_pick_list`), `theme.rs` (colours, icons, labels, `format_duration`/`format_age`). Layout — two rows, each split into two columns:

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,2 +1,10 @@
 base_url = "https://neumann-probe.net"
 api_key  = "vng_your_api_key_here"
+
+# UI theme: "classic" (default) or "retro" — phosphor CRT console with
+# idle animations. Toggle at runtime with F2.
+#theme = "retro"
+# Retro phosphor tint: "green" (default) or "amber".
+#phosphor = "green"
+# Retro idle animations (render tick only, never API polling).
+#animations = true

--- a/src/app/anim.rs
+++ b/src/app/anim.rs
@@ -1,0 +1,69 @@
+use super::AppState;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub enum UiTheme {
+    #[default]
+    Classic,
+    Retro,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub enum Phosphor {
+    #[default]
+    Green,
+    Amber,
+}
+
+/// Boot sequence length in animation frames (~10 fps → ~3.5 s).
+pub const BOOT_TOTAL_FRAMES: u64 = 36;
+
+#[derive(Default)]
+pub struct AnimState {
+    /// Monotonic frame counter, advanced by the render tick. All retro
+    /// animations are pure functions of this value.
+    pub frame: u64,
+    pub booting: bool,
+    pub boot_frame: u64,
+}
+
+/// Deterministic 64-bit mixer (splitmix-style finalizer) used to derive
+/// animation noise — blip placement, telemetry ticker, star twinkle —
+/// without a rand dependency.
+pub fn anim_hash(mut x: u64) -> u64 {
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+    x ^= x >> 33;
+    x
+}
+
+impl AppState {
+    /// Advance animation state by one render tick. Never triggers I/O.
+    pub fn tick_anim(&mut self) {
+        self.anim.frame = self.anim.frame.wrapping_add(1);
+        if self.anim.booting {
+            self.anim.boot_frame += 1;
+            if self.anim.boot_frame >= BOOT_TOTAL_FRAMES {
+                self.anim.booting = false;
+            }
+        }
+    }
+
+    pub fn toggle_theme(&mut self) {
+        self.ui_theme = match self.ui_theme {
+            UiTheme::Classic => UiTheme::Retro,
+            UiTheme::Retro => UiTheme::Classic,
+        };
+    }
+
+    pub fn skip_boot(&mut self) {
+        self.anim.booting = false;
+    }
+
+    /// True when the render tick should run: retro theme with animations on,
+    /// or a boot sequence still playing.
+    pub fn anim_tick_active(&self) -> bool {
+        (self.ui_theme == UiTheme::Retro && self.animations_enabled) || self.anim.booting
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod anim;
 mod inputs;
 mod inventory;
 mod mannies;
@@ -9,6 +10,7 @@ mod waypoints;
 #[cfg(test)]
 mod tests;
 
+pub use anim::*;
 pub use inputs::*;
 pub use inventory::*;
 pub use map::*;
@@ -77,6 +79,11 @@ pub struct AppState {
     pub map: MapView,
     pub api_version: Option<u32>,
     pub recipes: Vec<CraftingRecipe>,
+    pub ui_theme: UiTheme,
+    pub phosphor: Phosphor,
+    /// Render-tick animations for the retro theme (no I/O involved).
+    pub animations_enabled: bool,
+    pub anim: AnimState,
 }
 
 impl AppState {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1154,3 +1154,45 @@ fn scanner_obj_nav_wraps() {
     state.scanner_obj_next();
     assert_eq!(state.scanner_obj_selection, Some(0));
 }
+
+// ── anim / theme ──────────────────────────────────────────────────────────
+
+#[test]
+fn tick_anim_advances_and_finishes_boot() {
+    let mut state = AppState::default();
+    state.anim.booting = true;
+    for _ in 0..BOOT_TOTAL_FRAMES {
+        state.tick_anim();
+    }
+    assert!(!state.anim.booting, "boot should complete");
+    assert_eq!(state.anim.frame, BOOT_TOTAL_FRAMES);
+}
+
+#[test]
+fn toggle_theme_flips_between_classic_and_retro() {
+    let mut state = AppState::default();
+    assert_eq!(state.ui_theme, UiTheme::Classic);
+    state.toggle_theme();
+    assert_eq!(state.ui_theme, UiTheme::Retro);
+    state.toggle_theme();
+    assert_eq!(state.ui_theme, UiTheme::Classic);
+}
+
+#[test]
+fn anim_tick_active_only_for_retro_or_boot() {
+    let mut state = AppState::default();
+    state.animations_enabled = true;
+    assert!(!state.anim_tick_active(), "classic theme: no tick");
+    state.ui_theme = UiTheme::Retro;
+    assert!(state.anim_tick_active());
+    state.animations_enabled = false;
+    assert!(!state.anim_tick_active(), "retro without animations: no tick");
+    state.anim.booting = true;
+    assert!(state.anim_tick_active(), "boot still animates");
+}
+
+#[test]
+fn anim_hash_is_deterministic_and_spreads() {
+    assert_eq!(anim_hash(42), anim_hash(42));
+    assert_ne!(anim_hash(1), anim_hash(2));
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,35 @@ use std::path::PathBuf;
 pub struct Config {
     pub base_url: String,
     pub api_key: String,
+    /// UI theme: "classic" (default) or "retro".
+    #[serde(default)]
+    pub theme: Option<String>,
+    /// Retro phosphor tint: "green" (default) or "amber".
+    #[serde(default)]
+    pub phosphor: Option<String>,
+    /// Retro idle animations (render tick only, never API polling).
+    #[serde(default = "default_true")]
+    pub animations: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Config {
+    pub fn ui_theme(&self) -> crate::app::UiTheme {
+        match self.theme.as_deref() {
+            Some("retro") => crate::app::UiTheme::Retro,
+            _ => crate::app::UiTheme::Classic,
+        }
+    }
+
+    pub fn ui_phosphor(&self) -> crate::app::Phosphor {
+        match self.phosphor.as_deref() {
+            Some("amber") => crate::app::Phosphor::Amber,
+            _ => crate::app::Phosphor::Green,
+        }
+    }
 }
 
 impl Config {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -65,6 +65,17 @@ pub fn handle_event(
         return;
     }
 
+    // Retro boot sequence: any key skips it.
+    if state.anim.booting {
+        state.skip_boot();
+        return;
+    }
+
+    if k.code == KeyCode::F(2) {
+        state.toggle_theme();
+        return;
+    }
+
     if state.help_open {
         if matches!(k.code, KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q')) {
             state.help_open = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ use neumann_cockpit::api::client::ApiClient;
 use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies};
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput,
-    InspectInput, JettisonInput, MineInput, RecallInput, RecoverInput, RenameMannyInput,
-    RepairInput, SalvageInput,
+    InspectInput, JettisonInput, MineInput, Phosphor, RecallInput, RecoverInput,
+    RenameMannyInput, RepairInput, SalvageInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -23,6 +23,9 @@ use neumann_cockpit::ui;
 #[tokio::main]
 async fn main() -> Result<()> {
     let cfg = config::Config::load()?;
+    let ui_theme = cfg.ui_theme();
+    let phosphor = cfg.ui_phosphor();
+    let animations = cfg.animations;
     let client = ApiClient::new(cfg.base_url, cfg.api_key)?;
 
     enable_raw_mode()?;
@@ -31,7 +34,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run(&client, &mut terminal).await;
+    let result = run(&client, &mut terminal, ui_theme, phosphor, animations).await;
 
     disable_raw_mode()?;
     execute!(
@@ -47,12 +50,29 @@ async fn main() -> Result<()> {
 async fn run(
     client: &ApiClient,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    ui_theme: UiTheme,
+    phosphor: Phosphor,
+    animations: bool,
 ) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<ApiMessage>(32);
-    let mut state = AppState::default();
+    let mut state = AppState {
+        ui_theme,
+        phosphor,
+        animations_enabled: animations,
+        ..Default::default()
+    };
+    if ui_theme == UiTheme::Retro && animations {
+        state.anim.booting = true;
+    }
     let scan_history_path = config::history_path();
     state.load_scan_history(&scan_history_path);
     let mut events = EventStream::new();
+
+    // Render tick for retro-theme animations: pure redraw, never API calls.
+    // Disabled (guarded branch below) in classic theme or animations=false,
+    // preserving the fully event-driven behaviour.
+    let mut anim_tick = tokio::time::interval(std::time::Duration::from_millis(100));
+    anim_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // Initial data fetch
     fetch_all(client.clone(), tx.clone());
@@ -61,13 +81,17 @@ async fn run(
     state.loading = true;
 
     loop {
-        terminal.draw(|f| ui::cockpit::render(f, &state))?;
+        terminal.draw(|f| ui::render(f, &state))?;
 
         let deadline = state.next_refresh_instant();
 
         tokio::select! {
             Some(event) = events.next() => {
                 handle_event(event?, &mut state, client, &tx);
+            }
+
+            _ = anim_tick.tick(), if state.anim_tick_active() => {
+                state.tick_anim();
             }
 
             Some(msg) = rx.recv() => {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RenameMannyInput, RepairInput, SalvageInput, TravelInput, WaypointsInput};
+use crate::app::{AppState, Panel};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Style},
@@ -7,14 +7,7 @@ use ratatui::{
     Frame,
 };
 
-use super::overlays::{
-    render_atomic_printer_craft_overlay, render_craft_overlay, render_deploy_overlay,
-    render_detach_overlay, render_help_overlay, render_inspect_overlay,
-    render_inventory_detail_overlay, render_jettison_overlay, render_map_overlay,
-    render_mine_overlay, render_object_action_overlay, render_recall_overlay,
-    render_recover_overlay, render_rename_manny_overlay, render_repair_overlay,
-    render_salvage_overlay, render_travel_overlay, render_waypoints_overlay,
-};
+use super::overlays::render_active_overlays;
 use super::panels::{
     inventory_panel_height, probe_panel_height, render_inventory_panel, render_mannies_panel,
     render_probe_panel, render_scanner_panel,
@@ -63,60 +56,7 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     render_scanner_panel(frame, bottom[0], state, state.focused == Some(Panel::Scanner));
     render_mannies_panel(frame, bottom[1], state, state.focused == Some(Panel::Mannies));
     render_status_bar(frame, status_area, state);
-    if !matches!(state.travel, TravelInput::Inactive) {
-        render_travel_overlay(frame, area, state);
-    }
-    if !matches!(state.repair, RepairInput::Inactive) {
-        render_repair_overlay(frame, area, state);
-    }
-    if !matches!(state.mine, MineInput::Inactive) {
-        render_mine_overlay(frame, area, state);
-    }
-    if state.map.open {
-        render_map_overlay(frame, area, state);
-    }
-    if !matches!(state.jettison, JettisonInput::Inactive) {
-        render_jettison_overlay(frame, area, state);
-    }
-    if !matches!(state.craft, CraftInput::Inactive) {
-        render_craft_overlay(frame, area, state);
-    }
-    if !matches!(state.atomic_printer_craft, AtomicPrinterCraftInput::Inactive) {
-        render_atomic_printer_craft_overlay(frame, area, state);
-    }
-    if !matches!(state.salvage, SalvageInput::Inactive) {
-        render_salvage_overlay(frame, area, state);
-    }
-    if !matches!(state.recall, RecallInput::Inactive) {
-        render_recall_overlay(frame, area, state);
-    }
-    if !matches!(state.deploy, DeployInput::Inactive) {
-        render_deploy_overlay(frame, area, state);
-    }
-    if !matches!(state.rename_manny, RenameMannyInput::Inactive) {
-        render_rename_manny_overlay(frame, area, state);
-    }
-    if !matches!(state.inspect, InspectInput::Inactive) {
-        render_inspect_overlay(frame, area, state);
-    }
-    if !matches!(state.recover, RecoverInput::Inactive) {
-        render_recover_overlay(frame, area, state);
-    }
-    if !matches!(state.detach, DetachInput::Inactive) {
-        render_detach_overlay(frame, area, state);
-    }
-    if !matches!(state.object_action, ObjectActionInput::Inactive) {
-        render_object_action_overlay(frame, area, state);
-    }
-    if !matches!(state.waypoints, WaypointsInput::Inactive) {
-        render_waypoints_overlay(frame, area, state);
-    }
-    if state.inventory_detail_open {
-        render_inventory_detail_overlay(frame, area, state);
-    }
-    if state.help_open {
-        render_help_overlay(frame, area);
-    }
+    render_active_overlays(frame, area, state);
 }
 
 // ── Status bar ────────────────────────────────────────────────────────────────

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,16 @@
 pub mod cockpit;
 pub(crate) mod overlays;
 pub(crate) mod panels;
+pub mod retro;
 pub(crate) mod theme;
+
+use crate::app::{AppState, UiTheme};
+use ratatui::Frame;
+
+/// Theme dispatch: classic 4-panel cockpit or the retro phosphor console.
+pub fn render(frame: &mut Frame, state: &AppState) {
+    match state.ui_theme {
+        UiTheme::Classic => cockpit::render(frame, state),
+        UiTheme::Retro => retro::render(frame, state),
+    }
+}

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -49,6 +49,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("r", "refresh all"),
         help_key_line("p i m s", "focus probe / inventory / mannies / scanner"),
         help_key_line("Tab", "cycle panel focus (Shift-Tab reverse)"),
+        help_key_line("F2", "toggle retro/classic theme"),
         help_key_line("t", "travel to coordinates"),
         help_key_line("b", "map"),
         help_key_line("w", "waypoints"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -25,6 +25,11 @@ pub(crate) use repair::render_repair_overlay;
 pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
 
+use crate::app::{
+    AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput, InspectInput,
+    JettisonInput, MineInput, ObjectActionInput, RecallInput, RecoverInput, RenameMannyInput,
+    RepairInput, SalvageInput, TravelInput, WaypointsInput,
+};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -32,6 +37,65 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
+
+/// Render whichever wizard overlays are active, on top of the current
+/// layout. Shared by the classic and retro themes.
+pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppState) {
+    if !matches!(state.travel, TravelInput::Inactive) {
+        render_travel_overlay(frame, area, state);
+    }
+    if !matches!(state.repair, RepairInput::Inactive) {
+        render_repair_overlay(frame, area, state);
+    }
+    if !matches!(state.mine, MineInput::Inactive) {
+        render_mine_overlay(frame, area, state);
+    }
+    if state.map.open {
+        render_map_overlay(frame, area, state);
+    }
+    if !matches!(state.jettison, JettisonInput::Inactive) {
+        render_jettison_overlay(frame, area, state);
+    }
+    if !matches!(state.craft, CraftInput::Inactive) {
+        render_craft_overlay(frame, area, state);
+    }
+    if !matches!(state.atomic_printer_craft, AtomicPrinterCraftInput::Inactive) {
+        render_atomic_printer_craft_overlay(frame, area, state);
+    }
+    if !matches!(state.salvage, SalvageInput::Inactive) {
+        render_salvage_overlay(frame, area, state);
+    }
+    if !matches!(state.recall, RecallInput::Inactive) {
+        render_recall_overlay(frame, area, state);
+    }
+    if !matches!(state.deploy, DeployInput::Inactive) {
+        render_deploy_overlay(frame, area, state);
+    }
+    if !matches!(state.rename_manny, RenameMannyInput::Inactive) {
+        render_rename_manny_overlay(frame, area, state);
+    }
+    if !matches!(state.inspect, InspectInput::Inactive) {
+        render_inspect_overlay(frame, area, state);
+    }
+    if !matches!(state.recover, RecoverInput::Inactive) {
+        render_recover_overlay(frame, area, state);
+    }
+    if !matches!(state.detach, DetachInput::Inactive) {
+        render_detach_overlay(frame, area, state);
+    }
+    if !matches!(state.object_action, ObjectActionInput::Inactive) {
+        render_object_action_overlay(frame, area, state);
+    }
+    if !matches!(state.waypoints, WaypointsInput::Inactive) {
+        render_waypoints_overlay(frame, area, state);
+    }
+    if state.inventory_detail_open {
+        render_inventory_detail_overlay(frame, area, state);
+    }
+    if state.help_open {
+        render_help_overlay(frame, area);
+    }
+}
 
 pub(crate) fn centered_rect(width: u16, height: u16, r: Rect) -> Rect {
     let x = r.x + r.width.saturating_sub(width) / 2;

--- a/src/ui/retro/banner.rs
+++ b/src/ui/retro/banner.rs
@@ -1,0 +1,92 @@
+use crate::api::types::SensorMode;
+use crate::app::AppState;
+use crate::ui::theme::probe_status_label;
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::palette::Pal;
+
+const SPINNER: [&str; 8] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
+
+/// LINK heartbeat: a slow pulse showing the uplink is alive.
+fn heartbeat(frame: u64) -> &'static str {
+    match (frame / 5) % 4 {
+        0 => "◉",
+        1 => "◎",
+        2 => "○",
+        _ => "◎",
+    }
+}
+
+pub(super) fn render_banner(frame: &mut Frame, area: Rect, state: &AppState, p: &Pal) {
+    let f = state.anim.frame;
+
+    // Line 1: system identity + clock
+    let clock = chrono::Local::now().format("%H:%M:%S").to_string();
+    let api = state
+        .api_version
+        .map(|v| format!("API.{v}"))
+        .unwrap_or_else(|| "API.--".into());
+    let line1 = Line::from(vec![
+        Span::styled(
+            format!(" NEUMANN/OS {} ", env!("CARGO_PKG_VERSION")),
+            p.bold(),
+        ),
+        Span::styled("─── DEEP SPACE PROBE COMMAND ───", p.dim()),
+        Span::styled(format!(" {api} "), p.norm()),
+        Span::styled(format!(" T {clock} "), p.bright()),
+    ]);
+
+    // Line 2: probe identity + status lights
+    let (name, status) = match &state.probe {
+        Some(probe) => (probe.name.clone(), probe_status_label(&probe.status).to_uppercase()),
+        None => ("--------".into(), "NO DATA".into()),
+    };
+    let sensors = state
+        .probe
+        .as_ref()
+        .map(|pr| match pr.sensor_mode {
+            SensorMode::Normal => ("▣▣▣▣▣▣", false),
+            SensorMode::Degraded => ("▣▣▣▢▢▢", false),
+            SensorMode::Blind => ("▢▢▢▢▢▢", true),
+            SensorMode::Unknown => ("▢▢▢▢▢▢", false),
+        })
+        .unwrap_or(("▢▢▢▢▢▢", false));
+
+    let busy = state.loading || state.scan_loading;
+    let spinner = if busy {
+        SPINNER[(f % SPINNER.len() as u64) as usize]
+    } else {
+        " "
+    };
+
+    let mut spans = vec![
+        Span::styled("  PROBE: ", p.dim()),
+        Span::styled(name, p.bold()),
+        Span::styled("   MODE: ", p.dim()),
+        Span::styled(status, p.bright()),
+        Span::styled("   LINK ", p.dim()),
+        Span::styled(heartbeat(f), p.bright()),
+        Span::styled("   SENSORS ", p.dim()),
+    ];
+    spans.push(Span::styled(
+        sensors.0,
+        if sensors.1 { p.alert() } else { p.norm() },
+    ));
+    spans.push(Span::styled("   ", p.dim()));
+    spans.push(Span::styled(spinner, p.bright()));
+
+    let rows = ratatui::layout::Layout::default()
+        .direction(ratatui::layout::Direction::Vertical)
+        .constraints([
+            ratatui::layout::Constraint::Length(1),
+            ratatui::layout::Constraint::Length(1),
+        ])
+        .split(area);
+    frame.render_widget(Paragraph::new(line1), rows[0]);
+    frame.render_widget(Paragraph::new(Line::from(spans)), rows[1]);
+}

--- a/src/ui/retro/boot.rs
+++ b/src/ui/retro/boot.rs
@@ -1,0 +1,103 @@
+use crate::app::AppState;
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::palette::Pal;
+
+/// Frames between two boot lines appearing (~10 fps tick).
+const LINE_STRIDE: u64 = 4;
+/// Characters revealed per frame on the active line (teletype effect).
+const CHARS_PER_FRAME: usize = 4;
+
+fn boot_lines(state: &AppState) -> Vec<(String, String)> {
+    let api = state
+        .api_version
+        .map(|v| format!("v{v} OK"))
+        .unwrap_or_else(|| "PENDING".into());
+    vec![
+        ("ROM CHECK".into(), "OK".into()),
+        ("DEUTERIUM FLOW REGULATOR".into(), "OK".into()),
+        ("SENSOR PHASED ARRAY".into(), "6/6 NOMINAL".into()),
+        ("MANNY BAY INTERLOCKS".into(), "OK".into()),
+        ("UPLINK HANDSHAKE".into(), api),
+        (
+            "RESTORING SCAN ARCHIVE".into(),
+            format!("{} SECTORS", state.scan_history.len()),
+        ),
+    ]
+}
+
+pub(super) fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: &Pal) {
+    let bf = state.anim.boot_frame;
+    let lines_data = boot_lines(state);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(28),
+            Constraint::Min(10),
+            Constraint::Percentage(20),
+        ])
+        .split(area);
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(18),
+            Constraint::Min(40),
+            Constraint::Percentage(18),
+        ])
+        .split(rows[1])[1];
+
+    let mut out: Vec<Line> = vec![
+        Line::from(Span::styled(
+            "███ NEUMANN SYSTEMS UNIFIED PROBE COMPUTER ███",
+            p.bold(),
+        )),
+        Line::default(),
+    ];
+
+    for (i, (label, result)) in lines_data.iter().enumerate() {
+        let start = i as u64 * LINE_STRIDE;
+        if bf < start {
+            break;
+        }
+        let revealed = ((bf - start) as usize) * CHARS_PER_FRAME;
+        let dotted = format!("> {label} {}", ".".repeat(34_usize.saturating_sub(label.len())));
+        if revealed >= dotted.chars().count() {
+            out.push(Line::from(vec![
+                Span::styled(dotted, p.norm()),
+                Span::styled(format!(" {result}"), p.bright()),
+            ]));
+        } else {
+            let partial: String = dotted.chars().take(revealed).collect();
+            out.push(Line::from(Span::styled(partial, p.norm())));
+        }
+    }
+
+    let all_done = bf >= lines_data.len() as u64 * LINE_STRIDE + 6;
+    if all_done {
+        out.push(Line::default());
+        out.push(Line::from(Span::styled(
+            "INTERFACE 2337 READY FOR INQUIRY",
+            p.bold(),
+        )));
+    }
+    // Blinking cursor on its own line.
+    out.push(Line::default());
+    out.push(Line::from(Span::styled(
+        if (bf / 3).is_multiple_of(2) { "▌" } else { " " },
+        p.bright(),
+    )));
+
+    frame.render_widget(Paragraph::new(out), body);
+
+    let hint = Paragraph::new(Line::from(Span::styled(
+        "  ANY KEY TO SKIP",
+        p.dim(),
+    )));
+    frame.render_widget(hint, rows[2]);
+}

--- a/src/ui/retro/drones.rs
+++ b/src/ui/retro/drones.rs
@@ -1,0 +1,156 @@
+use crate::api::types::MannyLocationType;
+use crate::app::{AppState, InventoryRow, Panel};
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::palette::{block_gauge, Pal};
+use super::section_title;
+
+const WORK_SPINNER: [&str; 4] = ["▖", "▘", "▝", "▗"];
+
+pub(super) fn render_drones(frame: &mut Frame, area: Rect, state: &AppState, p: &Pal) {
+    let f = state.anim.frame;
+    let drones_focused = state.focused == Some(Panel::Mannies);
+    let cargo_focused = state.focused == Some(Panel::Inventory);
+
+    let mut lines: Vec<Line> = vec![section_title("DRONE BAY", drones_focused, p), Line::default()];
+
+    match &state.mannies {
+        None => lines.push(Line::from(Span::styled("  AWAITING TELEMETRY", p.dim()))),
+        Some(mannies) if mannies.is_empty() => {
+            lines.push(Line::from(Span::styled("  BAY EMPTY", p.dim())))
+        }
+        Some(mannies) => {
+            for (i, m) in mannies.iter().enumerate() {
+                let selected = drones_focused && i == state.mannies_selection;
+                let cursor = if selected { "▸" } else { " " };
+                let bay_led = match m.location.location_type {
+                    MannyLocationType::Probe => "▣",
+                    MannyLocationType::Sector => "▢",
+                    MannyLocationType::Unknown => "?",
+                };
+                let task = m
+                    .current_task
+                    .as_ref()
+                    .map(|t| format!("{t:?}").to_uppercase())
+                    .unwrap_or_else(|| "IDLE".into());
+                let name_style = if selected { p.bold() } else { p.bright() };
+                lines.push(Line::from(vec![
+                    Span::styled(format!(" {cursor}"), p.bright()),
+                    Span::styled(format!("{bay_led} "), p.norm()),
+                    Span::styled(format!("{:<12}", m.name.to_uppercase()), name_style),
+                    Span::styled(task, if m.current_task.is_some() { p.norm() } else { p.dim() }),
+                ]));
+                if m.current_task.is_some() {
+                    let spin = WORK_SPINNER[((f / 2) as usize + i) % WORK_SPINNER.len()];
+                    let ratio = (m.task_progress_percent / 100.0).clamp(0.0, 1.0);
+                    let mut spans = vec![
+                        Span::styled("    ", p.dim()),
+                        Span::styled(spin, p.bright()),
+                        Span::styled(" ", p.dim()),
+                    ];
+                    for (cell, hot) in block_gauge(ratio, 8, f.wrapping_add(i as u64 * 5)) {
+                        spans.push(Span::styled(cell, if hot { p.bright() } else { p.norm() }));
+                    }
+                    spans.push(Span::styled(
+                        format!(" {:>3.0}%", m.task_progress_percent),
+                        p.bright(),
+                    ));
+                    lines.push(Line::from(spans));
+                }
+            }
+        }
+    }
+
+    // ── Cargo ──
+    lines.push(Line::default());
+    lines.push(section_title("CARGO", cargo_focused, p));
+    lines.push(Line::default());
+
+    if let Some(probe) = &state.probe {
+        let inv = &probe.inventory;
+        let ratio = if inv.capacity > 0.0 {
+            (inv.used_capacity / inv.capacity).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let mut spans = vec![Span::styled("  HOLD ", p.dim())];
+        for (cell, hot) in block_gauge(ratio, 10, f.wrapping_add(11)) {
+            spans.push(Span::styled(cell, if hot { p.bright() } else { p.norm() }));
+        }
+        spans.push(Span::styled(
+            format!(" {:.1}/{:.1}", inv.used_capacity, inv.capacity),
+            p.bright(),
+        ));
+        lines.push(Line::from(spans));
+
+        // Resource stocks follow inventory_rows() order so the existing
+        // cursor ([Up]/[Down] + [j]/[Enter]) stays meaningful.
+        let rows = state.inventory_rows();
+        for (idx, row) in rows.iter().enumerate() {
+            let selected = cargo_focused && idx == state.inventory_selection;
+            let cursor = if selected { "▸" } else { " " };
+            match row {
+                InventoryRow::Stock { id } => {
+                    if let Some(stock) = inv.resource_stocks.iter().find(|s| &s.id == id) {
+                        lines.push(Line::from(vec![
+                            Span::styled(format!(" {cursor} "), p.bright()),
+                            Span::styled(
+                                format!("{:<8}", stock.name.to_uppercase()),
+                                if selected { p.bold() } else { p.norm() },
+                            ),
+                            Span::styled(format!("{:>8.3}", stock.amount), p.bright()),
+                        ]));
+                    }
+                }
+                InventoryRow::ActiveItem { id } => {
+                    if let Some(item) = inv.items.iter().find(|i| &i.id == id) {
+                        if item.item_type == "manny" {
+                            continue; // already shown in the drone bay
+                        }
+                        lines.push(Line::from(vec![
+                            Span::styled(format!(" {cursor} "), p.bright()),
+                            Span::styled(
+                                format!("{:<14}", item.name.to_uppercase()),
+                                if selected { p.bold() } else { p.norm() },
+                            ),
+                        ]));
+                    }
+                }
+                InventoryRow::PassiveGroup { item_type } => {
+                    let count = inv.items.iter().filter(|i| &i.item_type == item_type).count();
+                    if let Some(first) = inv.items.iter().find(|i| &i.item_type == item_type) {
+                        lines.push(Line::from(vec![
+                            Span::styled(format!(" {cursor} "), p.bright()),
+                            Span::styled(
+                                format!("{:<12}", first.name.to_uppercase()),
+                                if selected { p.bold() } else { p.norm() },
+                            ),
+                            Span::styled(format!("×{count}"), p.bright()),
+                        ]));
+                    }
+                }
+            }
+        }
+
+        if !inv.external_tanks.is_empty() {
+            for tank in &inv.external_tanks {
+                let ratio = (tank.fill_percent / 100.0).clamp(0.0, 1.0);
+                let mut spans = vec![Span::styled("   TANK ", p.dim())];
+                for (cell, hot) in block_gauge(ratio, 6, f.wrapping_add(17)) {
+                    spans.push(Span::styled(cell, if hot { p.bright() } else { p.norm() }));
+                }
+                spans.push(Span::styled(format!(" {:.0}%", tank.fill_percent), p.norm()));
+                lines.push(Line::from(spans));
+            }
+        }
+    } else {
+        lines.push(Line::from(Span::styled("  AWAITING TELEMETRY", p.dim())));
+    }
+
+    frame.render_widget(Paragraph::new(lines), area);
+}

--- a/src/ui/retro/mod.rs
+++ b/src/ui/retro/mod.rs
@@ -1,0 +1,115 @@
+mod banner;
+mod boot;
+mod drones;
+mod palette;
+mod radar;
+mod systems;
+mod ticker;
+
+#[cfg(test)]
+mod tests;
+
+use crate::app::AppState;
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Paragraph},
+    Frame,
+};
+
+use super::overlays::render_active_overlays;
+use palette::{pal, Pal};
+
+/// Section header used by every retro panel: `─── TITLE ───────`.
+pub(crate) fn section_title(title: &str, focused: bool, p: &Pal) -> Line<'static> {
+    let style = if focused { p.bold() } else { p.norm() };
+    Line::from(vec![
+        Span::styled(" ─── ", p.dim()),
+        Span::styled(title.to_string(), style),
+        Span::styled(" ", p.dim()),
+        Span::styled("─".repeat(18_usize.saturating_sub(title.len())), p.dim()),
+    ])
+}
+
+pub fn render(frame: &mut Frame, state: &AppState) {
+    let p = pal(state.phosphor);
+    let area = frame.area();
+
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(p.norm());
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    if state.anim.booting {
+        boot::render_boot(frame, inner, state, &p);
+        return;
+    }
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // banner
+            Constraint::Length(1), // separator
+            Constraint::Min(8),    // main columns
+            Constraint::Length(1), // comms
+            Constraint::Length(1), // tlm
+            Constraint::Length(1), // hints
+        ])
+        .split(inner);
+
+    banner::render_banner(frame, rows[0], state, &p);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "═".repeat(inner.width as usize),
+            p.dim(),
+        ))),
+        rows[1],
+    );
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(26),
+            Constraint::Min(30),
+            Constraint::Length(30),
+        ])
+        .split(rows[2]);
+
+    systems::render_systems(frame, cols[0], state, &p);
+    radar::render_radar(frame, cols[1], state, &p);
+    drones::render_drones(frame, cols[2], state, &p);
+
+    ticker::render_comms(frame, rows[3], state, &p);
+    ticker::render_tlm(frame, rows[4], state, &p);
+    render_hints(frame, rows[5], state, &p);
+
+    render_active_overlays(frame, area, state);
+}
+
+fn render_hints(frame: &mut Frame, area: ratatui::layout::Rect, state: &AppState, p: &Pal) {
+    let mut spans = vec![
+        Span::styled(" [P][I][M][S]", p.bright()),
+        Span::styled(" FOCUS ", p.dim()),
+        Span::styled("[T]", p.bright()),
+        Span::styled(" TRAVEL ", p.dim()),
+        Span::styled("[B]", p.bright()),
+        Span::styled(" NAV PLOT ", p.dim()),
+        Span::styled("[W]", p.bright()),
+        Span::styled(" WAYPOINTS ", p.dim()),
+        Span::styled("[?]", p.bright()),
+        Span::styled(" HELP ", p.dim()),
+        Span::styled("[F2]", p.bright()),
+        Span::styled(" CLASSIC ", p.dim()),
+        Span::styled("[Q]", p.bright()),
+        Span::styled(" QUIT", p.dim()),
+    ];
+    if let Some(next) = state.seconds_until_refresh() {
+        spans.push(Span::styled(
+            format!("   NEXT CONTACT T-{}", crate::ui::theme::format_duration(next)),
+            p.dim(),
+        ));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}

--- a/src/ui/retro/palette.rs
+++ b/src/ui/retro/palette.rs
@@ -1,0 +1,65 @@
+use crate::app::Phosphor;
+use ratatui::style::{Color, Modifier, Style};
+
+/// Four-intensity monochrome palette emulating a phosphor CRT.
+/// Everything in the retro theme is drawn from these levels; `alert`
+/// is the only chromatic exception.
+#[derive(Clone, Copy)]
+pub(crate) struct Pal {
+    pub dim: Color,
+    pub norm: Color,
+    pub bright: Color,
+    pub alert: Color,
+}
+
+pub(crate) fn pal(phosphor: Phosphor) -> Pal {
+    match phosphor {
+        Phosphor::Green => Pal {
+            dim: Color::Rgb(0, 88, 24),
+            norm: Color::Rgb(0, 176, 64),
+            bright: Color::Rgb(120, 255, 160),
+            alert: Color::Rgb(255, 72, 48),
+        },
+        Phosphor::Amber => Pal {
+            dim: Color::Rgb(112, 64, 0),
+            norm: Color::Rgb(216, 136, 0),
+            bright: Color::Rgb(255, 208, 112),
+            alert: Color::Rgb(255, 72, 48),
+        },
+    }
+}
+
+impl Pal {
+    pub fn dim(&self) -> Style {
+        Style::default().fg(self.dim)
+    }
+    pub fn norm(&self) -> Style {
+        Style::default().fg(self.norm)
+    }
+    pub fn bright(&self) -> Style {
+        Style::default().fg(self.bright)
+    }
+    pub fn bold(&self) -> Style {
+        Style::default().fg(self.bright).add_modifier(Modifier::BOLD)
+    }
+    pub fn alert(&self) -> Style {
+        Style::default().fg(self.alert).add_modifier(Modifier::BOLD)
+    }
+}
+
+/// Retro block gauge: `▓▓▓▓▓░░░░░`. A single bright cell sweeps along the
+/// filled part every few seconds — the periodic "self-check" shimmer.
+pub(crate) fn block_gauge(ratio: f64, width: usize, frame: u64) -> Vec<(String, bool)> {
+    let ratio = ratio.clamp(0.0, 1.0);
+    let filled = (ratio * width as f64).round() as usize;
+    let sweep = ((frame / 2) % (width as u64 * 4)) as usize; // sweeps 1 in 4 cycles
+    let mut cells: Vec<(String, bool)> = Vec::with_capacity(width);
+    for i in 0..width {
+        if i < filled {
+            cells.push(("▓".into(), i == sweep));
+        } else {
+            cells.push(("░".into(), false));
+        }
+    }
+    cells
+}

--- a/src/ui/retro/radar.rs
+++ b/src/ui/retro/radar.rs
@@ -1,0 +1,191 @@
+use crate::app::{anim_hash, AppState, ObjectProvenance, Panel, ScanFilter};
+use crate::ui::theme::object_icon;
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::palette::Pal;
+use super::section_title;
+
+/// Sweep angle in degrees for a given animation frame (one revolution ≈ 6 s
+/// at 10 fps).
+pub(crate) fn sweep_angle(frame: u64) -> f64 {
+    ((frame * 6) % 360) as f64
+}
+
+/// Polar position of a blip derived from its object id: stable across
+/// frames, pseudo-uniform across the dial.
+pub(crate) fn blip_polar(id: &str) -> (f64, f64) {
+    let h = anim_hash(id.bytes().fold(0u64, |a, b| a.wrapping_mul(31).wrapping_add(b as u64)));
+    let angle = (h % 360) as f64;
+    let radius = 0.30 + ((h >> 9) % 60) as f64 / 100.0; // 0.30..0.90
+    (angle, radius)
+}
+
+/// Intensity of a blip given the sweep position: 2 = just illuminated,
+/// 1 = fading, 0 = at rest. The sweep rotates clockwise, so the afterglow
+/// trails behind it.
+pub(crate) fn blip_intensity(sweep_deg: f64, blip_deg: f64) -> u8 {
+    let trail = (sweep_deg - blip_deg).rem_euclid(360.0);
+    if trail < 25.0 {
+        2
+    } else if trail < 110.0 {
+        1
+    } else {
+        0
+    }
+}
+
+fn plot(frame: &mut Frame, x: i32, y: i32, area: Rect, sym: &str, style: ratatui::style::Style) {
+    if x >= area.x as i32
+        && x < (area.x + area.width) as i32
+        && y >= area.y as i32
+        && y < (area.y + area.height) as i32
+    {
+        frame.buffer_mut().set_string(x as u16, y as u16, sym, style);
+    }
+}
+
+pub(super) fn render_radar(frame: &mut Frame, area: Rect, state: &AppState, p: &Pal) {
+    let f = state.anim.frame;
+    let focused = state.focused == Some(Panel::Scanner);
+
+    let rows = ratatui::layout::Layout::default()
+        .direction(ratatui::layout::Direction::Vertical)
+        .constraints([
+            ratatui::layout::Constraint::Length(1),
+            ratatui::layout::Constraint::Min(3),
+            ratatui::layout::Constraint::Length(2),
+        ])
+        .split(area);
+    frame.render_widget(Paragraph::new(section_title("SCANNER", focused, p)), rows[0]);
+    let dial = rows[1];
+    let info = rows[2];
+
+    let cx = dial.x as f64 + dial.width as f64 / 2.0;
+    let cy = dial.y as f64 + dial.height as f64 / 2.0;
+    // Cells are ~2× taller than wide; stretch x to keep the dial round.
+    let rx = (dial.width as f64 / 2.0 - 1.0).max(1.0);
+    let ry = (dial.height as f64 / 2.0 - 1.0).max(1.0);
+    let project = |deg: f64, r: f64| -> (i32, i32) {
+        let rad = deg.to_radians();
+        (
+            (cx + rad.cos() * r * rx).round() as i32,
+            (cy + rad.sin() * r * ry).round() as i32,
+        )
+    };
+
+    // Range rings (dim dots) + twinkling background stars.
+    for a in (0..360).step_by(12) {
+        let (x, y) = project(a as f64, 1.0);
+        plot(frame, x, y, dial, "·", p.dim());
+    }
+    for a in (0..360).step_by(30) {
+        let (x, y) = project(a as f64, 0.55);
+        plot(frame, x, y, dial, "·", p.dim());
+    }
+    let star_seed = state
+        .current_sector()
+        .map(|s| {
+            (s.relative_coordinates.x as i64 * 73 + s.relative_coordinates.y as i64 * 179
+                + s.relative_coordinates.z as i64 * 283) as u64
+        })
+        .unwrap_or(0);
+    for i in 0..10u64 {
+        let h = anim_hash(star_seed.wrapping_add(i.wrapping_mul(0x9e37)));
+        let (x, y) = project((h % 360) as f64, 0.15 + ((h >> 10) % 80) as f64 / 100.0);
+        // each star twinkles on its own cadence
+        let bright = (f / 4).wrapping_add(h).is_multiple_of(7);
+        plot(frame, x, y, dial, "·", if bright { p.norm() } else { p.dim() });
+    }
+
+    // Sweep beam.
+    let sweep = sweep_angle(f);
+    for step in 1..=18 {
+        let r = step as f64 / 18.0;
+        let (x, y) = project(sweep, r);
+        plot(frame, x, y, dial, "·", if step >= 16 { p.bright() } else { p.norm() });
+    }
+
+    // Center: pulses while a scan request is in flight.
+    let center_style = if state.scan_loading && (f / 2).is_multiple_of(2) {
+        p.bold()
+    } else {
+        p.bright()
+    };
+    plot(frame, cx.round() as i32, cy.round() as i32, dial, "⊕", center_style);
+
+    // Blips: actionable objects of the displayed sector.
+    let entries = state.scanner_objects();
+    let selected_idx = state.scanner_obj_selection;
+    let nested_inward = |prov: ObjectProvenance, r: f64| match prov {
+        ObjectProvenance::TopLevel => r,
+        _ => r * 0.6,
+    };
+    for (i, e) in entries.iter().enumerate() {
+        let (deg, r0) = blip_polar(&e.id);
+        let r = nested_inward(e.provenance, r0);
+        let (x, y) = project(deg, r);
+        let (icon, _) = object_icon(&e.object_type);
+        let style = match blip_intensity(sweep, deg) {
+            2 => p.bold(),
+            1 => p.norm(),
+            _ => p.dim(),
+        };
+        let style = if selected_idx == Some(i) { p.bold() } else { style };
+        plot(frame, x, y, dial, icon, style);
+        if selected_idx == Some(i) {
+            plot(frame, x - 1, y, dial, "[", p.bright());
+            plot(frame, x + 1, y, dial, "]", p.bright());
+        }
+    }
+
+    // Info lines under the dial.
+    let mut l1: Vec<Span> = Vec::new();
+    let mut l2: Vec<Span> = Vec::new();
+    if let Some(sector) = state.current_sector() {
+        let c = &sector.relative_coordinates;
+        l1.push(Span::styled(
+            format!("  SECTOR ({},{},{})", c.x as i64, c.y as i64, c.z as i64),
+            p.bold(),
+        ));
+        l1.push(Span::styled(format!("  CONF {:.0}%", sector.confidence * 100.0), p.norm()));
+        l1.push(Span::styled(format!("  SWEEP {:03.0}°", sweep), p.dim()));
+        if state.scan_filter != ScanFilter::All {
+            l1.push(Span::styled(
+                format!("  FILTER:{}", state.scan_filter.label().to_uppercase()),
+                p.bright(),
+            ));
+        }
+        let objects = sector.objects.as_ref().map(|o| o.len()).unwrap_or(0);
+        let minable: usize = sector
+            .objects
+            .iter()
+            .flatten()
+            .map(|o| o.minable_targets.as_ref().map(|t| t.len()).unwrap_or(0))
+            .sum();
+        if let Some(sel) = selected_idx.and_then(|i| entries.get(i)) {
+            l2.push(Span::styled("  TARGET ", p.dim()));
+            l2.push(Span::styled(sel.name.to_uppercase(), p.bold()));
+            l2.push(Span::styled("  [ENTER] ACTIONS", p.norm()));
+        } else {
+            l2.push(Span::styled(
+                format!("  {objects} CONTACTS · {minable} MINABLE"),
+                p.norm(),
+            ));
+            if !entries.is_empty() {
+                l2.push(Span::styled("  [O] TARGETING", p.dim()));
+            }
+        }
+    } else {
+        l1.push(Span::styled("  NO SCAN DATA", p.dim()));
+        l2.push(Span::styled("  AWAITING SWEEP — [ENTER] SCAN SECTOR", p.norm()));
+    }
+    frame.render_widget(
+        Paragraph::new(vec![Line::from(l1), Line::from(l2)]),
+        info,
+    );
+}

--- a/src/ui/retro/systems.rs
+++ b/src/ui/retro/systems.rs
@@ -1,0 +1,116 @@
+use crate::api::types::MovementPhase;
+use crate::app::{AppState, Panel};
+use crate::ui::theme::format_duration;
+use chrono::Utc;
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::palette::{block_gauge, Pal};
+use super::section_title;
+
+fn gauge_line<'a>(label: &'a str, ratio: f64, pct: String, p: &Pal, frame: u64, alert: bool) -> Line<'a> {
+    let mut spans = vec![Span::styled(format!("  {label:<5}"), p.dim())];
+    for (cell, hot) in block_gauge(ratio, 10, frame) {
+        let style = if alert {
+            p.alert()
+        } else if hot {
+            p.bright()
+        } else {
+            p.norm()
+        };
+        spans.push(Span::styled(cell, style));
+    }
+    spans.push(Span::styled(format!(" {pct:>4}"), p.bright()));
+    Line::from(spans)
+}
+
+/// Status LED with a slow pulse when `active`.
+fn led(active: bool, frame: u64, phase: u64) -> &'static str {
+    if !active {
+        return "○";
+    }
+    match (frame / 4 + phase) % 3 {
+        0 => "◉",
+        1 => "◎",
+        _ => "◉",
+    }
+}
+
+pub(super) fn render_systems(frame: &mut Frame, area: Rect, state: &AppState, p: &Pal) {
+    let f = state.anim.frame;
+    let focused = state.focused == Some(Panel::Probe);
+    let mut lines: Vec<Line> = vec![section_title("SYSTEMS", focused, p), Line::default()];
+
+    let Some(probe) = &state.probe else {
+        lines.push(Line::from(Span::styled("  AWAITING TELEMETRY", p.dim())));
+        frame.render_widget(Paragraph::new(lines), area);
+        return;
+    };
+
+    let fuel = probe.fuel.deuterium.map(|d| (d / 100.0).clamp(0.0, 1.0)).unwrap_or(0.0);
+    lines.push(gauge_line("FUEL", fuel, format!("{:.0}%", fuel * 100.0), p, f, fuel < 0.25));
+
+    if let Some(sys) = &probe.systems {
+        let intg = (sys.integrity_percent.unwrap_or(100.0) / 100.0).clamp(0.0, 1.0);
+        lines.push(gauge_line("INTG", intg, format!("{:.0}%", intg * 100.0), p, f.wrapping_add(7), intg < 0.25));
+    }
+
+    // Active burn: progress + ETA
+    let active_mv = probe.movement.as_ref().filter(|mv| {
+        !matches!(
+            mv.phase.as_ref().unwrap_or(&mv.status),
+            MovementPhase::Arrived | MovementPhase::Failed | MovementPhase::Destroyed | MovementPhase::Idle
+        )
+    });
+    if let Some(mv) = active_mv {
+        let elapsed = (Utc::now() - mv.started_at).num_seconds().max(0);
+        let total = (mv.arrival_at - mv.started_at).num_seconds().max(1);
+        let progress = (elapsed as f64 / total as f64).clamp(0.0, 1.0);
+        let remaining = (mv.arrival_at - Utc::now()).num_seconds().max(0);
+        lines.push(gauge_line("BURN", progress, format!("{:.0}%", progress * 100.0), p, f.wrapping_add(3), false));
+        // Living ETA: the colon blinks once per second.
+        let eta = format_duration(remaining);
+        let eta = if (f / 5).is_multiple_of(2) { eta } else { eta.replace(':', " ") };
+        lines.push(Line::from(vec![
+            Span::styled("  ETA  ", p.dim()),
+            Span::styled(eta, p.bright()),
+            Span::styled(
+                format!("  → ({},{},{})", mv.target.x as i64, mv.target.y as i64, mv.target.z as i64),
+                p.norm(),
+            ),
+        ]));
+    } else if let Some((x, y, z)) = state.probe_sector_coords() {
+        lines.push(Line::from(vec![
+            Span::styled("  POS  ", p.dim()),
+            Span::styled(format!("({x},{y},{z})"), p.bright()),
+            Span::styled("  HOLDING", p.dim()),
+        ]));
+    }
+
+    // Probe schematic with status LEDs
+    let busy = state.loading || state.scan_loading;
+    let has_fuel = fuel > 0.0;
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled("      ┌──╥──┐", p.norm())));
+    lines.push(Line::from(vec![
+        Span::styled("     ═╡ ", p.norm()),
+        Span::styled("CORE", p.bright()),
+        Span::styled(" ╞═", p.norm()),
+    ]));
+    lines.push(Line::from(Span::styled("      └──╨──┘", p.norm())));
+    lines.push(Line::from(vec![
+        Span::styled("      ", p.dim()),
+        Span::styled(led(active_mv.is_some(), f, 0), p.bright()),
+        Span::styled("   ", p.dim()),
+        Span::styled(led(has_fuel, f, 1), p.bright()),
+        Span::styled("   ", p.dim()),
+        Span::styled(led(busy, f, 2), if busy { p.bright() } else { p.dim() }),
+    ]));
+    lines.push(Line::from(Span::styled("     NAV  PWR  COM", p.dim())));
+
+    frame.render_widget(Paragraph::new(lines), area);
+}

--- a/src/ui/retro/tests.rs
+++ b/src/ui/retro/tests.rs
@@ -1,0 +1,79 @@
+use super::palette::block_gauge;
+use super::radar::{blip_intensity, blip_polar, sweep_angle};
+use super::ticker::tlm_segment;
+
+#[test]
+fn sweep_angle_wraps_at_360() {
+    assert_eq!(sweep_angle(0), 0.0);
+    assert_eq!(sweep_angle(10), 60.0);
+    assert_eq!(sweep_angle(60), 0.0);
+    assert!(sweep_angle(u64::MAX / 7) < 360.0);
+}
+
+#[test]
+fn blip_polar_is_stable_and_in_range() {
+    let (a1, r1) = blip_polar("ast-221");
+    let (a2, r2) = blip_polar("ast-221");
+    assert_eq!((a1, r1), (a2, r2));
+    assert!((0.0..360.0).contains(&a1));
+    assert!((0.30..=0.90).contains(&r1));
+    // different ids land elsewhere
+    assert_ne!(blip_polar("ast-221"), blip_polar("ast-222"));
+}
+
+#[test]
+fn blip_intensity_trails_behind_sweep() {
+    // beam just passed the blip → hot
+    assert_eq!(blip_intensity(100.0, 90.0), 2);
+    // a quarter turn later → fading
+    assert_eq!(blip_intensity(180.0, 90.0), 1);
+    // long after → at rest
+    assert_eq!(blip_intensity(350.0, 90.0), 0);
+    // wrap-around: sweep at 10°, blip at 350° → trail of 20°
+    assert_eq!(blip_intensity(10.0, 350.0), 2);
+}
+
+#[test]
+fn tlm_segment_is_deterministic_and_non_empty() {
+    for slot in 0..32 {
+        let s1 = tlm_segment(slot);
+        assert_eq!(s1, tlm_segment(slot));
+        assert!(!s1.is_empty());
+    }
+}
+
+#[test]
+fn block_gauge_fill_matches_ratio() {
+    let cells = block_gauge(0.5, 10, 0);
+    assert_eq!(cells.len(), 10);
+    let filled = cells.iter().filter(|(c, _)| c == "▓").count();
+    assert_eq!(filled, 5);
+    let empty = block_gauge(0.0, 10, 0);
+    assert!(empty.iter().all(|(c, _)| c == "░"));
+    let full = block_gauge(1.5, 10, 0); // clamped
+    assert!(full.iter().all(|(c, _)| c == "▓"));
+}
+
+#[test]
+fn retro_render_smoke_test() {
+    use crate::app::{AppState, UiTheme};
+    use ratatui::{backend::TestBackend, Terminal};
+
+    // No probe data, boot screen, then console — must not panic at any size.
+    for (w, h) in [(100u16, 30u16), (80, 24), (40, 12), (10, 4)] {
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut state = AppState {
+            ui_theme: UiTheme::Retro,
+            animations_enabled: true,
+            ..Default::default()
+        };
+        state.anim.booting = true;
+        terminal.draw(|f| super::render(f, &state)).unwrap();
+        for _ in 0..50 {
+            state.tick_anim();
+        }
+        assert!(!state.anim.booting);
+        terminal.draw(|f| super::render(f, &state)).unwrap();
+    }
+}

--- a/src/ui/retro/ticker.rs
+++ b/src/ui/retro/ticker.rs
@@ -1,0 +1,73 @@
+use crate::app::{anim_hash, AppState};
+use ratatui::{
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::palette::Pal;
+
+/// One pseudo-telemetry segment, deterministic in `slot`.
+pub(crate) fn tlm_segment(slot: u64) -> String {
+    let h = anim_hash(slot.wrapping_mul(0x9e37_79b9));
+    match h % 6 {
+        0 => format!("{:02X}.{:02X}.{:04X}", h >> 8 & 0xff, h >> 16 & 0xff, h >> 24 & 0xffff),
+        1 => format!("GYRO {:+.2} {:+.2} {:+.2}",
+            ((h >> 8) % 40) as f64 / 100.0 - 0.2,
+            ((h >> 16) % 40) as f64 / 100.0 - 0.2,
+            ((h >> 24) % 40) as f64 / 100.0 - 0.2),
+        2 => format!("FLOW 0.{:04}", (h >> 8) % 10000),
+        3 => format!("MEM {:>3}/512", 40 + (h >> 8) % 200),
+        4 => "SENS:NOM".to_string(),
+        _ => "∿∿─╱╲─∿∿".to_string(),
+    }
+}
+
+/// COMMS line: latest event (toast), error, or the all-clear.
+pub(super) fn render_comms(frame: &mut Frame, area: Rect, state: &AppState, p: &Pal) {
+    let line = if let Some(err) = &state.error {
+        Line::from(vec![
+            Span::styled(" COMMS ▸ ", p.dim()),
+            Span::styled(format!("ALERT — {}", err.to_uppercase()), p.alert()),
+        ])
+    } else if let Some(toast) = state.active_toast() {
+        Line::from(vec![
+            Span::styled(" COMMS ▸ ", p.dim()),
+            Span::styled(toast.to_uppercase(), p.bright()),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(" COMMS ▸ ", p.dim()),
+            Span::styled("ALL CHANNELS NOMINAL", p.norm()),
+        ])
+    };
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+/// TLM line: scrolling pseudo-telemetry. The scroll speed quadruples while
+/// an API request is in flight — the probe is visibly "thinking".
+pub(super) fn render_tlm(frame: &mut Frame, area: Rect, state: &AppState, p: &Pal) {
+    let f = state.anim.frame;
+    let busy = state.loading || state.scan_loading;
+    let cursor = if busy { f * 4 } else { f };
+
+    // Build a stream of segments and window it by character offset.
+    let slot0 = cursor / 24;
+    let offset = (cursor % 24) as usize;
+    let mut stream = String::new();
+    let mut k = 0u64;
+    while stream.chars().count() < area.width as usize + 32 {
+        stream.push_str(&tlm_segment(slot0 + k));
+        stream.push_str(" ▍ ");
+        k += 1;
+    }
+    let window: String = stream.chars().skip(offset).take(area.width.saturating_sub(8) as usize).collect();
+
+    let label_style = if busy { p.bright() } else { p.dim() };
+    let line = Line::from(vec![
+        Span::styled(" TLM ▸ ", label_style),
+        Span::styled(window, p.dim()),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}


### PR DESCRIPTION
## Console rétro « phosphore » (style MU/TH/UR / Alien)

Skin alternative complète, **totalement à part** (`src/ui/retro/`, 9 fichiers), avec **choix entre les deux thèmes** :

- `theme = "classic"` (défaut) ou `"retro"` dans `config.toml` ; bascule à chaud avec **`F2`** ;
- `phosphor = "green"` ou `"amber"` ; `animations = true|false`.

Par défaut rien ne change : thème classic, pas de tick, comportement event-driven identique à l'existant.

### Ce que contient le mode rétro

- **Palette monochrome 4 intensités** (dim/norm/bright/bold) + rouge réservé aux alertes ;
- **Banner** : identité sonde, heartbeat LINK `◉◎○◎`, barre de capteurs `▣▣▣▢▢▢`, spinner braille pendant les requêtes ;
- **SYSTEMS** : jauges blocs `▓░` avec reflet de self-check périodique, ETA au `:` clignotant, schéma de la sonde avec LEDs NAV/PWR/COM pulsantes ;
- **SCANNER radar** : cadran avec balayage rotatif (~6 s/tour), blips des objets (`scanner_objects()`) avec rémanence 3 niveaux derrière le faisceau, étoiles de fond scintillantes (seedées par secteur), centre `⊕` qui pulse pendant un scan, ciblage `[o]` visible (`[★]`) ;
- **DRONE BAY / CARGO** : curseurs existants (mannies, inventaire) conservés, spinner `▖▘▝▗` sur les drones actifs ;
- **COMMS** (toasts/erreurs) + **ticker TLM** : pseudo-télémétrie défilante qui **accélère ×4 quand une requête est en vol** — on voit la sonde réfléchir ;
- **Boot sequence** téléscripteur au lancement (checks réels : API, archive de scans), toute touche passe.

### Architecture

- Tick de rendu 100 ms ajouté au `select!`, gardé par `anim_tick_active()` : il incrémente un compteur de frame et redessine, **jamais d'appel API** — la règle « no polling » du projet est préservée. Branche désactivée en classic / `animations = false`.
- Toutes les animations sont des **fonctions pures de la frame** (`app/anim.rs`, `anim_hash` déterministe, zéro dépendance `rand`).
- Overlays de wizards **partagés** entre les deux thèmes (`overlays::render_active_overlays`, extrait de `cockpit::render`) : tous les raccourcis existants fonctionnent à l'identique dans les deux modes.

### Tests

10 nouveaux : état anim (tick/boot/toggle/garde du tick), fonctions pures du radar (sweep, position/rémanence des blips), ticker, jauges, et un smoke test de rendu offscreen jusqu'à 10×4. `cargo clippy -- -D warnings` clean ; `cargo test` : **126 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)