### PR TITLE
fix(input): ignore non-press key events to prevent double-trigger on Windows

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
@@ -42,6 +42,7 @@ pub fn handle_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     let Event::Key(k) = event else { return };
+    if k.kind != KeyEventKind::Press { return };
     // Toasts are transient: any keypress dismisses the current one.
     state.toast = None;
     let ctrl = k.modifiers.contains(KeyModifiers::CONTROL);


### PR DESCRIPTION
Fixes #56

On Windows, crossterm emits both `KeyEventKind::Press` and `KeyEventKind::Release` events for each key press (unlike Linux/macOS which only emit `Press`). The handler was not filtering on `kind`, causing every key to be processed twice.

The fix adds a single guard at the top of `handle_event` to drop any event that isn't a `Press`.