### PR TITLE
feat(api): v47 prerequisite type patches and mine targetContainerId

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -144,6 +144,7 @@ impl ApiClient {
         object_id: &str,
         resources: Vec<String>,
         target_amount: f64,
+        target_container_id: Option<String>,
     ) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -151,6 +152,8 @@ impl ApiClient {
             object_id: String,
             resources: Vec<String>,
             target_amount: f64,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            target_container_id: Option<String>,
         }
         #[derive(Deserialize)]
         struct Resp { manny: Manny }
@@ -160,6 +163,7 @@ impl ApiClient {
                 object_id: object_id.to_string(),
                 resources,
                 target_amount,
+                target_container_id,
             })
             .await?
             .manny)

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -80,11 +80,12 @@ pub fn fetch_mine(
     object_id: String,
     resources: Vec<String>,
     target_amount: f64,
+    target_container_id: Option<String>,
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
     tokio::spawn(async move {
-        let msg = match client.mine_manny(&manny_id, &object_id, resources, target_amount).await {
+        let msg = match client.mine_manny(&manny_id, &object_id, resources, target_amount, target_container_id).await {
             Ok(_) => ApiMessage::MineStarted,
             Err(e) => ApiMessage::MineError(e.to_string()),
         };

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -68,6 +68,7 @@ pub enum MannyTask {
     Returning,
     WaitingForSpace,
     MovingStockage,
+    DroppingStorageContainer,
     #[serde(other)]
     Unknown,
 }
@@ -402,6 +403,7 @@ pub struct WaypointBookmarkTarget {
     pub mass_unit: Option<String>,
     pub radius: Option<f64>,
     pub radius_unit: Option<String>,
+    pub habitability_score: Option<f64>,
     #[serde(default)]
     pub waypoint_bookmarks: Vec<WaypointBookmarkHistory>,
 }
@@ -428,6 +430,7 @@ pub struct SectorObject {
     pub radius: Option<f64>,
     pub radius_unit: Option<String>,
     pub danger_level: Option<DangerLevel>,
+    pub habitability_score: Option<f64>,
     pub salvageable: Option<bool>,
     pub manny_state: Option<String>,
     pub manny_uid: Option<String>,
@@ -455,6 +458,8 @@ pub struct MinableTarget {
     pub name: Option<String>,
     pub mass: Option<f64>,
     pub resource_types: Option<Vec<String>>,
+    pub resource_amounts: Option<serde_json::Value>,
+    pub resource_composition: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/input/mine.rs
+++ b/src/input/mine.rs
@@ -92,7 +92,7 @@ pub(super) fn handle_mine_event(
                         if amount <= 0.0 { return }
                         (manny_id.clone(), object_id.clone(), selected, amount)
                     };
-                    fetch_mine(manny_id, object_id, selected_resources, amount, client.clone(), tx.clone());
+                    fetch_mine(manny_id, object_id, selected_resources, amount, None, client.clone(), tx.clone());
                 }
                 _ => {}
             }

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -144,6 +144,7 @@ pub(crate) fn manny_list_item(m: &Manny) -> ListItem<'_> {
         Some(MannyTask::Returning) => Span::styled("returning", Style::default().fg(Color::Blue)),
         Some(MannyTask::WaitingForSpace) => Span::styled("waiting", Style::default().fg(Color::Magenta)),
         Some(MannyTask::MovingStockage) => Span::styled("moving cargo", Style::default().fg(Color::Blue)),
+        Some(MannyTask::DroppingStorageContainer) => Span::styled("dropping container", Style::default().fg(Color::Yellow)),
         Some(MannyTask::Unknown) => Span::styled("?", Style::default().fg(Color::DarkGray)),
     };
 


### PR DESCRIPTION
Part of the API v47 migration. This is Bloc 1 — the prerequisite patch that unblocks all subsequent blocs.

## Changes

**`src/api/types.rs`**
- `MannyTask`: add `DroppingStorageContainer` variant (`"dropping_storage_container"`)
- `SectorObject`: add `habitability_score: Option<f64>`
- `WaypointBookmarkTarget`: add `habitability_score: Option<f64>`
- `MinableTarget`: add `resource_amounts: Option<serde_json::Value>` and `resource_composition: Option<serde_json::Value>`

**`src/api/client.rs`**
- `mine_manny()`: add `target_container_id: Option<String>` parameter, serialized with `skip_serializing_if = "Option::is_none"`

**`src/api/tasks.rs`**
- `fetch_mine()`: thread `target_container_id: Option<String>` through to the client call

**`src/input/mine.rs`**
- Pass `None` at the existing callsite (UI-layer selection comes in Bloc 9)

**`src/ui/panels/mannies.rs`**
- Handle `MannyTask::DroppingStorageContainer` in the task label match (required by the exhaustive check)

## Notes

All new fields are `Option<T>` — no breaking deserialization changes. Existing scan history files load without migration.