### PR TITLE
feat(containers): storage containers CRUD & routing rules (v47 bloc 3)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,6 +1,6 @@
 use super::types::{
-    CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert, ProbeInventory, ProbeMovement,
-    SectorObservation, VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert,
+    ProbeInventory, ProbeMovement, SectorObservation, StorageContainer, VisitedSector,
 };
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
@@ -336,5 +336,56 @@ impl ApiClient {
         struct Resp { alert: ProbeAlert }
         let path = format!("/api/probe/alerts/{id}");
         Ok(self.patch::<Resp, _>(&path, &serde_json::json!({})).await?.alert)
+    }
+
+    pub async fn get_storage_containers(&self) -> Result<Vec<StorageContainer>> {
+        #[derive(Deserialize)]
+        struct Resp { containers: Vec<StorageContainer> }
+        Ok(self.get::<Resp>("/api/probe/storage-containers").await?.containers)
+    }
+
+    pub async fn get_storage_container(&self, id: &str) -> Result<(StorageContainer, ContainerInventory)> {
+        #[derive(Deserialize)]
+        struct Resp { container: StorageContainer, inventory: ContainerInventory }
+        let path = format!("/api/probe/storage-containers/{id}");
+        let r = self.get::<Resp>(&path).await?;
+        Ok((r.container, r.inventory))
+    }
+
+    pub async fn rename_storage_container(
+        &self,
+        id: &str,
+        label: &str,
+    ) -> Result<(StorageContainer, ProbeInventory)> {
+        #[derive(Serialize)]
+        struct Body<'a> { label: &'a str }
+        #[derive(Deserialize)]
+        struct Resp { container: StorageContainer, inventory: ProbeInventory }
+        let path = format!("/api/probe/storage-containers/{id}");
+        let r = self.patch::<Resp, _>(&path, &Body { label }).await?;
+        Ok((r.container, r.inventory))
+    }
+
+    pub async fn update_container_rules(
+        &self,
+        id: &str,
+        priority: Vec<String>,
+        exclusion: Vec<String>,
+        strict_exclusion: Vec<String>,
+    ) -> Result<(StorageContainer, ProbeInventory)> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body {
+            priority: Vec<String>,
+            exclusion: Vec<String>,
+            strict_exclusion: Vec<String>,
+        }
+        #[derive(Deserialize)]
+        struct Resp { container: StorageContainer, inventory: ProbeInventory }
+        let path = format!("/api/probe/storage-containers/{id}/rules");
+        let r = self
+            .patch::<Resp, _>(&path, &Body { priority, exclusion, strict_exclusion })
+            .await?;
+        Ok((r.container, r.inventory))
     }
 }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -83,6 +83,49 @@ pub fn fetch_ack_damage_warning(id: i64, client: ApiClient, tx: mpsc::Sender<Api
     });
 }
 
+pub fn fetch_storage_containers(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        if let Ok(c) = client.get_storage_containers().await {
+            let _ = tx.send(ApiMessage::StorageContainersFetched(c)).await;
+        }
+    });
+}
+
+pub fn fetch_storage_container_detail(id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        if let Ok((c, inv)) = client.get_storage_container(&id).await {
+            let _ = tx.send(ApiMessage::StorageContainerDetailFetched(c, inv)).await;
+        }
+    });
+}
+
+pub fn fetch_rename_container(id: String, label: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.rename_storage_container(&id, &label).await {
+            Ok((c, inv)) => ApiMessage::RenameContainerDone(c, inv),
+            Err(e) => ApiMessage::RenameContainerError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
+pub fn fetch_update_container_rules(
+    id: String,
+    priority: Vec<String>,
+    exclusion: Vec<String>,
+    strict_exclusion: Vec<String>,
+    client: ApiClient,
+    tx: mpsc::Sender<ApiMessage>,
+) {
+    tokio::spawn(async move {
+        let msg = match client.update_container_rules(&id, priority, exclusion, strict_exclusion).await {
+            Ok((c, inv)) => ApiMessage::UpdateContainerRulesDone(c, inv),
+            Err(e) => ApiMessage::UpdateContainerRulesError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
 pub fn fetch_mannies(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
         if let Ok(m) = client.get_mannies().await {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -132,7 +132,20 @@ pub struct StorageContainer {
     pub capacity: f64,
     pub used_capacity: f64,
     pub free_capacity: f64,
+    pub capacity_unit: Option<String>,
     pub rules: StorageContainerRules,
+}
+
+/// Inner inventory of a single storage container
+/// (`GET /api/probe/storage-containers/{id}`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerInventory {
+    pub capacity_unit: Option<String>,
+    #[serde(default)]
+    pub items: Vec<ProbeInventoryItem>,
+    #[serde(default)]
+    pub resource_stocks: Vec<ProbeResourceStock>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/app/containers.rs
+++ b/src/app/containers.rs
@@ -1,0 +1,54 @@
+use super::*;
+use crate::api::types::StorageContainerRules;
+use std::collections::BTreeSet;
+
+impl AppState {
+    /// All storage containers as (id, label) pairs.
+    pub fn collect_renameable_containers(&self) -> Vec<(String, String)> {
+        self.storage_containers
+            .iter()
+            .map(|c| (c.id.clone(), c.label.clone()))
+            .collect()
+    }
+
+    /// Type names selectable in the routing-rules editor: the four resource
+    /// types, every item/stock type currently in inventory, and any type
+    /// already referenced by the container's rules. Sorted and de-duplicated.
+    pub fn routable_types(&self, rules: &StorageContainerRules) -> Vec<String> {
+        let mut set: BTreeSet<String> = RESOURCE_TYPES.iter().map(|s| s.to_string()).collect();
+        if let Some(probe) = &self.probe {
+            for it in &probe.inventory.items {
+                set.insert(it.item_type.clone());
+            }
+            for st in &probe.inventory.resource_stocks {
+                set.insert(st.stock_type.clone());
+            }
+        }
+        for t in rules
+            .priority
+            .iter()
+            .chain(&rules.exclusion)
+            .chain(&rules.strict_exclusion)
+        {
+            set.insert(t.clone());
+        }
+        set.into_iter().collect()
+    }
+
+    /// Build the routing-rules editor for a container (by id), seeded from its
+    /// current rules. Returns `None` if the container is not in the list.
+    pub fn rules_editor_for(&self, container_id: &str) -> Option<ContainerRulesInput> {
+        let c = self.storage_containers.iter().find(|c| c.id == container_id)?;
+        let types = self.routable_types(&c.rules);
+        Some(ContainerRulesInput::Editing {
+            container_id: c.id.clone(),
+            container_label: c.label.clone(),
+            types,
+            priority: c.rules.priority.clone(),
+            exclusion: c.rules.exclusion.clone(),
+            strict_exclusion: c.rules.strict_exclusion.clone(),
+            selection: 0,
+            error: None,
+        })
+    }
+}

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -77,6 +77,46 @@ pub enum AlertsInput {
 }
 
 #[derive(Default)]
+pub enum ContainersInput {
+    #[default]
+    Inactive,
+    /// Browsing the storage-container list (entries live in
+    /// `AppState::storage_containers`).
+    Browsing { selection: usize },
+}
+
+#[derive(Default)]
+pub enum RenameContainerInput {
+    #[default]
+    Inactive,
+    Typing {
+        container_id: String,
+        current_label: String,
+        buf: String,
+        error: Option<String>,
+    },
+}
+
+#[derive(Default)]
+pub enum ContainerRulesInput {
+    #[default]
+    Inactive,
+    /// Each routable type in `types` is assigned to at most one of the three
+    /// lists; `selection` cursors `types`, cycled none → priority → exclusion
+    /// → strict via Space.
+    Editing {
+        container_id: String,
+        container_label: String,
+        types: Vec<String>,
+        priority: Vec<String>,
+        exclusion: Vec<String>,
+        strict_exclusion: Vec<String>,
+        selection: usize,
+        error: Option<String>,
+    },
+}
+
+#[derive(Default)]
 pub enum WaypointsInput {
     #[default]
     Inactive,

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,6 +1,6 @@
 use crate::api::types::{
-    CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert, ProbeInventory, ProbeMovement,
-    SectorObservation, VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert,
+    ProbeInventory, ProbeMovement, SectorObservation, StorageContainer, VisitedSector,
 };
 
 pub enum ApiMessage {
@@ -41,5 +41,11 @@ pub enum ApiMessage {
     DamageWarningAcknowledged(ProbeAlert),
     AlertsFetched(Vec<ProbeAlert>),
     AlertAcknowledged(ProbeAlert),
+    StorageContainersFetched(Vec<StorageContainer>),
+    StorageContainerDetailFetched(StorageContainer, ContainerInventory),
+    RenameContainerDone(StorageContainer, ProbeInventory),
+    RenameContainerError(String),
+    UpdateContainerRulesDone(StorageContainer, ProbeInventory),
+    UpdateContainerRulesError(String),
     Error(String),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 mod anim;
+mod containers;
 mod inputs;
 mod inventory;
 mod mannies;
@@ -19,7 +20,8 @@ pub use scan::*;
 pub use waypoints::*;
 
 use crate::api::types::{
-    CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert, SectorObservation, VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert,
+    ProbeInventory, SectorObservation, StorageContainer, VisitedSector,
 };
 use chrono::{DateTime, Local, Utc};
 use tokio::time::Instant;
@@ -63,6 +65,12 @@ pub struct AppState {
     pub damage_warnings: Vec<ProbeAlert>,
     pub damage_warning_rule: Option<DamageWarningRule>,
     pub alerts_input: AlertsInput,
+    /// Storage containers fetched on demand when the containers overlay opens.
+    pub storage_containers: Vec<StorageContainer>,
+    pub storage_container_detail: Option<(StorageContainer, ContainerInventory)>,
+    pub containers_input: ContainersInput,
+    pub rename_container: RenameContainerInput,
+    pub container_rules: ContainerRulesInput,
     pub help_open: bool,
     /// Read-only detail popup for the selected inventory row.
     pub inventory_detail_open: bool,
@@ -141,6 +149,27 @@ impl AppState {
             .chain(self.damage_warnings.iter())
             .filter(|a| a.is_unread())
             .count()
+    }
+
+    /// Apply a rename/rules response: refresh the container in the list and the
+    /// probe inventory in one shot.
+    pub fn apply_container_update(&mut self, container: StorageContainer, inventory: ProbeInventory) {
+        if let Some(c) = self.storage_containers.iter_mut().find(|c| c.id == container.id) {
+            *c = container;
+        }
+        self.update_inventory(inventory);
+    }
+
+    pub fn set_rename_container_error(&mut self, msg: String) {
+        if let RenameContainerInput::Typing { ref mut error, .. } = self.rename_container {
+            *error = Some(msg);
+        }
+    }
+
+    pub fn set_container_rules_error(&mut self, msg: String) {
+        if let ContainerRulesInput::Editing { ref mut error, .. } = self.container_rules {
+            *error = Some(msg);
+        }
     }
 
     pub fn set_toast(&mut self, msg: impl Into<String>) {

--- a/src/input/containers.rs
+++ b/src/input/containers.rs
@@ -1,0 +1,209 @@
+use crossterm::event::KeyCode;
+use tokio::sync::mpsc;
+
+use crate::api::client::ApiClient;
+use crate::api::tasks::{
+    fetch_rename_container, fetch_storage_container_detail, fetch_update_container_rules,
+};
+use crate::app::{
+    ApiMessage, AppState, ContainerRulesInput, ContainersInput, RenameContainerInput,
+};
+
+use super::geometry::list_nav;
+
+/// Move a type to the next/previous routing list:
+/// none → priority → exclusion → strict → none.
+fn cycle_assignment(
+    ty: &str,
+    priority: &mut Vec<String>,
+    exclusion: &mut Vec<String>,
+    strict: &mut Vec<String>,
+    backward: bool,
+) {
+    let cur = if priority.iter().any(|t| t == ty) {
+        1
+    } else if exclusion.iter().any(|t| t == ty) {
+        2
+    } else if strict.iter().any(|t| t == ty) {
+        3
+    } else {
+        0
+    };
+    priority.retain(|t| t != ty);
+    exclusion.retain(|t| t != ty);
+    strict.retain(|t| t != ty);
+    let next = if backward { (cur + 3) % 4 } else { (cur + 1) % 4 };
+    match next {
+        1 => priority.push(ty.to_string()),
+        2 => exclusion.push(ty.to_string()),
+        3 => strict.push(ty.to_string()),
+        _ => {}
+    }
+}
+
+pub(super) fn handle_containers_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    // The read-only detail popup takes precedence while open.
+    if state.storage_container_detail.is_some() {
+        if matches!(code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
+            state.storage_container_detail = None;
+        }
+        return;
+    }
+
+    let ContainersInput::Browsing { selection } = state.containers_input else {
+        return;
+    };
+    let count = state.storage_containers.len();
+    match code {
+        KeyCode::Esc | KeyCode::Char('C') | KeyCode::Char('q') => {
+            state.containers_input = ContainersInput::Inactive;
+        }
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+            if let Some(ns) = list_nav(code, selection, count) {
+                state.containers_input = ContainersInput::Browsing { selection: ns };
+            }
+        }
+        KeyCode::Enter => {
+            if let Some(c) = state.storage_containers.get(selection) {
+                fetch_storage_container_detail(c.id.clone(), client.clone(), tx.clone());
+            }
+        }
+        KeyCode::Char('n') => {
+            if let Some(c) = state.storage_containers.get(selection) {
+                state.rename_container = RenameContainerInput::Typing {
+                    container_id: c.id.clone(),
+                    current_label: c.label.clone(),
+                    buf: c.label.clone(),
+                    error: None,
+                };
+            }
+        }
+        KeyCode::Char('e') => {
+            if let Some(c) = state.storage_containers.get(selection) {
+                let id = c.id.clone();
+                if let Some(editor) = state.rules_editor_for(&id) {
+                    state.container_rules = editor;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn handle_rename_container_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    if !matches!(state.rename_container, RenameContainerInput::Typing { .. }) {
+        return;
+    }
+    match code {
+        KeyCode::Esc => state.rename_container = RenameContainerInput::Inactive,
+        KeyCode::Backspace => {
+            if let RenameContainerInput::Typing { buf, .. } = &mut state.rename_container {
+                buf.pop();
+            }
+        }
+        KeyCode::Enter => {
+            let (id, label) = {
+                let RenameContainerInput::Typing { container_id, buf, .. } = &state.rename_container
+                else {
+                    return;
+                };
+                (container_id.clone(), buf.trim().to_string())
+            };
+            if label.is_empty() {
+                state.set_rename_container_error("label cannot be empty".into());
+                return;
+            }
+            fetch_rename_container(id, label, client.clone(), tx.clone());
+        }
+        KeyCode::Char(c) => {
+            if let RenameContainerInput::Typing { buf, error, .. } = &mut state.rename_container {
+                if buf.chars().count() < 80 {
+                    buf.push(c);
+                    *error = None;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn handle_container_rules_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let ContainerRulesInput::Editing { selection, types, .. } = &state.container_rules else {
+        return;
+    };
+    let sel = *selection;
+    let count = types.len();
+    match code {
+        KeyCode::Esc => state.container_rules = ContainerRulesInput::Inactive,
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+            if let Some(ns) = list_nav(code, sel, count) {
+                if let ContainerRulesInput::Editing { selection, .. } = &mut state.container_rules {
+                    *selection = ns;
+                }
+            }
+        }
+        KeyCode::Char(' ') | KeyCode::Right | KeyCode::Char('l') => {
+            cycle_selected(state, false);
+        }
+        KeyCode::Left | KeyCode::Char('h') => {
+            cycle_selected(state, true);
+        }
+        KeyCode::Delete | KeyCode::Backspace => {
+            // Clear the selected type back to "none".
+            if let ContainerRulesInput::Editing {
+                types, priority, exclusion, strict_exclusion, selection, ..
+            } = &mut state.container_rules
+            {
+                if let Some(ty) = types.get(*selection).cloned() {
+                    priority.retain(|t| t != &ty);
+                    exclusion.retain(|t| t != &ty);
+                    strict_exclusion.retain(|t| t != &ty);
+                }
+            }
+        }
+        KeyCode::Enter => {
+            let (id, p, e, s) = {
+                let ContainerRulesInput::Editing {
+                    container_id, priority, exclusion, strict_exclusion, ..
+                } = &state.container_rules
+                else {
+                    return;
+                };
+                (
+                    container_id.clone(),
+                    priority.clone(),
+                    exclusion.clone(),
+                    strict_exclusion.clone(),
+                )
+            };
+            fetch_update_container_rules(id, p, e, s, client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}
+
+fn cycle_selected(state: &mut AppState, backward: bool) {
+    if let ContainerRulesInput::Editing {
+        types, priority, exclusion, strict_exclusion, selection, ..
+    } = &mut state.container_rules
+    {
+        if let Some(ty) = types.get(*selection).cloned() {
+            cycle_assignment(&ty, priority, exclusion, strict_exclusion, backward);
+        }
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -5,15 +5,16 @@ use crate::api::client::ApiClient;
 use crate::api::tasks::{
     fetch_all,
     fetch_inspect,
-    fetch_recover, fetch_sector,
+    fetch_recover, fetch_sector, fetch_storage_containers,
 };
 use crate::app::{
-    AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput,
-    DetachInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput,
-    RecoverInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, TravelInput,
-    WaypointsInput,
+    AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
+    ContainersInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput,
+    ObjectActionInput, Panel, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
+    RepairInput, SalvageInput, ScanMode, TravelInput, WaypointsInput,
 };
 mod alerts;
+mod containers;
 mod craft;
 mod geometry;
 mod jettison;
@@ -25,6 +26,9 @@ mod scanner;
 mod travel;
 
 use alerts::handle_alerts_event;
+use containers::{
+    handle_container_rules_event, handle_containers_event, handle_rename_container_event,
+};
 use craft::{handle_atomic_printer_craft_event, handle_craft_event};
 use geometry::{face_d2, neighbors_d1};
 use jettison::handle_jettison_event;
@@ -63,6 +67,9 @@ pub fn handle_event(
     let in_recover = !matches!(state.recover, RecoverInput::Inactive);
     let in_detach = !matches!(state.detach, DetachInput::Inactive);
     let in_alerts = !matches!(state.alerts_input, AlertsInput::Inactive);
+    let in_rename_container = !matches!(state.rename_container, RenameContainerInput::Inactive);
+    let in_container_rules = !matches!(state.container_rules, ContainerRulesInput::Inactive);
+    let in_containers = !matches!(state.containers_input, ContainersInput::Inactive);
 
     if ctrl && k.code == KeyCode::Char('c') {
         state.set_quit();
@@ -151,6 +158,21 @@ pub fn handle_event(
 
     if in_alerts {
         handle_alerts_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_rename_container {
+        handle_rename_container_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_container_rules {
+        handle_container_rules_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_containers {
+        handle_containers_event(k.code, state, client, tx);
         return;
     }
 
@@ -347,6 +369,10 @@ pub fn handle_event(
                     error: None,
                 };
             }
+        }
+        KeyCode::Char('C') if state.focused == Some(Panel::Inventory) => {
+            fetch_storage_containers(client.clone(), tx.clone());
+            state.containers_input = ContainersInput::Browsing { selection: 0 };
         }
         KeyCode::Down | KeyCode::Char('j') if state.focused == Some(Panel::Mannies) => {
             state.manny_next();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,9 @@ use tokio::sync::mpsc;
 use neumann_cockpit::api::client::ApiClient;
 use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies};
 use neumann_cockpit::app::{
-    ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput,
-    InspectInput, JettisonInput, MineInput, Phosphor, RecallInput, RecoverInput,
-    RenameMannyInput, RepairInput, SalvageInput, UiTheme,
+    ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
+    DetachInput, InspectInput, JettisonInput, MineInput, Phosphor, RecallInput, RecoverInput,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -203,6 +203,22 @@ async fn run(
                         state.replace_damage_warning(w);
                         state.set_toast("warning acknowledged");
                     }
+                    ApiMessage::StorageContainersFetched(c) => state.storage_containers = c,
+                    ApiMessage::StorageContainerDetailFetched(c, inv) => {
+                        state.storage_container_detail = Some((c, inv));
+                    }
+                    ApiMessage::RenameContainerDone(c, inv) => {
+                        state.apply_container_update(c, inv);
+                        state.rename_container = RenameContainerInput::Inactive;
+                        state.set_toast("container renamed");
+                    }
+                    ApiMessage::RenameContainerError(e) => state.set_rename_container_error(e),
+                    ApiMessage::UpdateContainerRulesDone(c, inv) => {
+                        state.apply_container_update(c, inv);
+                        state.container_rules = ContainerRulesInput::Inactive;
+                        state.set_toast("routing rules updated");
+                    }
+                    ApiMessage::UpdateContainerRulesError(e) => state.set_container_rules_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {

--- a/src/ui/overlays/containers.rs
+++ b/src/ui/overlays/containers.rs
@@ -1,0 +1,289 @@
+use crate::app::{AppState, ContainerRulesInput, ContainersInput, RenameContainerInput};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+use super::centered_rect;
+use crate::ui::theme::gauge_color;
+
+/// Fixed-width textual capacity bar.
+fn bar(ratio: f64, width: usize) -> String {
+    let filled = (ratio.clamp(0.0, 1.0) * width as f64).round() as usize;
+    (0..width).map(|i| if i < filled { '█' } else { '░' }).collect()
+}
+
+pub(crate) fn render_containers_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let ContainersInput::Browsing { selection } = state.containers_input else {
+        return;
+    };
+    let containers = &state.storage_containers;
+
+    let height = (containers.len() as u16 + 6).clamp(8, 22);
+    let popup = centered_rect(70, height, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" STORAGE CONTAINERS ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    if containers.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "no storage containers — loading…",
+                Style::default().fg(Color::DarkGray),
+            ))),
+            rows[0],
+        );
+    } else {
+        let items: Vec<ListItem> = containers
+            .iter()
+            .map(|c| {
+                let ratio = if c.capacity > 0.0 { c.used_capacity / c.capacity } else { 0.0 };
+                let core = if c.kind == "probe" { " ⌂" } else { "" };
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!("{:<20}", c.label), Style::default().fg(Color::White)),
+                    Span::styled(core, Style::default().fg(Color::DarkGray)),
+                    Span::raw(" "),
+                    Span::styled(bar(ratio, 12), Style::default().fg(gauge_color(1.0 - ratio))),
+                    Span::styled(
+                        format!(" {:.2}/{:.2}", c.used_capacity, c.capacity),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]))
+            })
+            .collect();
+        let list = List::new(items)
+            .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+            .highlight_symbol("▶ ");
+        let mut ls = ListState::default();
+        ls.select(Some(selection.min(containers.len() - 1)));
+        frame.render_stateful_widget(list, rows[0], &mut ls);
+    }
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" content  "),
+            Span::styled("[n]", Style::default().fg(Color::Cyan)),
+            Span::raw(" rename  "),
+            Span::styled("[e]", Style::default().fg(Color::Cyan)),
+            Span::raw(" rules  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" close"),
+        ])),
+        rows[1],
+    );
+}
+
+pub(crate) fn render_container_detail_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let Some((container, inv)) = &state.storage_container_detail else {
+        return;
+    };
+
+    let line_count = inv.resource_stocks.len() + inv.items.len() + 4;
+    let height = (line_count as u16 + 4).clamp(8, 24);
+    let popup = centered_rect(60, height, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(format!(" {} ", container.label))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = Vec::new();
+    let ratio = if container.capacity > 0.0 { container.used_capacity / container.capacity } else { 0.0 };
+    lines.push(Line::from(vec![
+        Span::styled("capacity ", Style::default().fg(Color::Cyan)),
+        Span::styled(bar(ratio, 16), Style::default().fg(gauge_color(1.0 - ratio))),
+        Span::styled(
+            format!(" {:.2}/{:.2}", container.used_capacity, container.capacity),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    lines.push(Line::default());
+
+    lines.push(Line::from(Span::styled("RESOURCES", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))));
+    if inv.resource_stocks.is_empty() {
+        lines.push(Line::from(Span::styled("  —", Style::default().fg(Color::DarkGray))));
+    } else {
+        for st in &inv.resource_stocks {
+            lines.push(Line::from(vec![
+                Span::raw(format!("  {:<16}", st.name)),
+                Span::styled(format!("{:.2}", st.amount), Style::default().fg(Color::White)),
+            ]));
+        }
+    }
+    lines.push(Line::default());
+
+    lines.push(Line::from(Span::styled("ITEMS", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))));
+    if inv.items.is_empty() {
+        lines.push(Line::from(Span::styled("  —", Style::default().fg(Color::DarkGray))));
+    } else {
+        for it in &inv.items {
+            lines.push(Line::from(Span::raw(format!("  {}", it.name))));
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Esc/Enter]", Style::default().fg(Color::Cyan)),
+            Span::raw(" close"),
+        ])),
+        rows[1],
+    );
+}
+
+pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let RenameContainerInput::Typing { ref current_label, ref buf, ref error, .. } =
+        state.rename_container
+    else {
+        return;
+    };
+
+    let popup = centered_rect(50, 7, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(format!(" RENAME — {current_label} "))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = vec![Line::from(vec![
+        Span::styled("Label: ", Style::default().fg(Color::Cyan)),
+        Span::raw(buf.as_str()),
+        Span::styled("█", Style::default().fg(Color::Cyan)),
+    ])];
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+    }
+
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" rename  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
+}
+
+pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let ContainerRulesInput::Editing {
+        ref container_label,
+        ref types,
+        ref priority,
+        ref exclusion,
+        ref strict_exclusion,
+        selection,
+        ref error,
+        ..
+    } = state.container_rules
+    else {
+        return;
+    };
+
+    let height = (types.len() as u16 + 8).clamp(10, 24);
+    let popup = centered_rect(58, height, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(format!(" ROUTING RULES — {container_label} "))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("P", Style::default().fg(Color::Green)),
+            Span::raw(" priority  "),
+            Span::styled("E", Style::default().fg(Color::Yellow)),
+            Span::raw(" exclude  "),
+            Span::styled("S", Style::default().fg(Color::Red)),
+            Span::raw(" strict  "),
+            Span::styled("·", Style::default().fg(Color::DarkGray)),
+            Span::raw(" none"),
+        ])),
+        rows[0],
+    );
+
+    let items: Vec<ListItem> = types
+        .iter()
+        .map(|ty| {
+            let (tag, color) = if priority.iter().any(|t| t == ty) {
+                ("[P]", Color::Green)
+            } else if exclusion.iter().any(|t| t == ty) {
+                ("[E]", Color::Yellow)
+            } else if strict_exclusion.iter().any(|t| t == ty) {
+                ("[S]", Color::Red)
+            } else {
+                ("[ ]", Color::DarkGray)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{tag} "), Style::default().fg(color).add_modifier(Modifier::BOLD)),
+                Span::styled(ty.clone(), Style::default().fg(Color::White)),
+            ]))
+        })
+        .collect();
+    let list = List::new(items)
+        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+        .highlight_symbol("▶ ");
+    let mut ls = ListState::default();
+    if !types.is_empty() {
+        ls.select(Some(selection.min(types.len() - 1)));
+    }
+    frame.render_stateful_widget(list, rows[1], &mut ls);
+
+    let footer = if let Some(err) = error {
+        Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red)))
+    } else {
+        Line::from(vec![
+            Span::styled("[Space]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cycle  "),
+            Span::styled("[Del]", Style::default().fg(Color::Cyan)),
+            Span::raw(" clear  "),
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" save  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])
+    };
+    frame.render_widget(Paragraph::new(footer), rows[2]);
+}

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -64,6 +64,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("j", "jettison selection"),
         help_key_line("d", "deploy waypoint"),
         help_key_line("a", "atomic printer craft"),
+        help_key_line("C", "storage containers"),
         Line::default(),
         help_section("Map"),
         help_key_line("hjkl/←↓↑→", "pan"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod alerts;
+pub(crate) mod containers;
 pub(crate) mod craft;
 pub(crate) mod help;
 pub(crate) mod inventory_detail;
@@ -12,6 +13,10 @@ pub(crate) mod travel;
 pub(crate) mod waypoints;
 
 pub(crate) use alerts::render_alerts_overlay;
+pub(crate) use containers::{
+    render_container_detail_overlay, render_container_rules_overlay, render_containers_overlay,
+    render_rename_container_overlay,
+};
 pub(crate) use craft::{render_atomic_printer_craft_overlay, render_craft_overlay};
 pub(crate) use help::render_help_overlay;
 pub(crate) use inventory_detail::render_inventory_detail_overlay;
@@ -28,9 +33,10 @@ pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
 
 use crate::app::{
-    AlertsInput, AppState, AtomicPrinterCraftInput, CraftInput, DeployInput, DetachInput,
-    InspectInput, JettisonInput, MineInput, ObjectActionInput, RecallInput, RecoverInput,
-    RenameMannyInput, RepairInput, SalvageInput, TravelInput, WaypointsInput,
+    AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
+    CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput,
+    ObjectActionInput, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
+    RepairInput, SalvageInput, TravelInput, WaypointsInput,
 };
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -46,6 +52,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     // Informational overlays first (lowest in the stack); action wizards on top.
     if !matches!(state.alerts_input, AlertsInput::Inactive) {
         render_alerts_overlay(frame, area, state);
+    }
+    if !matches!(state.containers_input, ContainersInput::Inactive) {
+        render_containers_overlay(frame, area, state);
     }
     if !matches!(state.travel, TravelInput::Inactive) {
         render_travel_overlay(frame, area, state);
@@ -97,6 +106,16 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if state.inventory_detail_open {
         render_inventory_detail_overlay(frame, area, state);
+    }
+    // Container action wizards + read-only detail sit above the list.
+    if !matches!(state.rename_container, RenameContainerInput::Inactive) {
+        render_rename_container_overlay(frame, area, state);
+    }
+    if !matches!(state.container_rules, ContainerRulesInput::Inactive) {
+        render_container_rules_overlay(frame, area, state);
+    }
+    if state.storage_container_detail.is_some() {
+        render_container_detail_overlay(frame, area, state);
     }
     if state.help_open {
         render_help_overlay(frame, area);

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -1,7 +1,8 @@
 use neumann_cockpit::api::types::{
-    AlertPhase, AlertStatus, AlertType, CraftingRecipe, DamageWarningRule, DataFreshness,
-    KnowledgeLevel, Manny, MannyLocationType, MannyTask, MovementPhase, Probe, ProbeAlert,
-    ProbeInventory, ProbeMovement, ProbeStatus, SectorObjectType, SectorObservation, SensorMode,
+    AlertPhase, AlertStatus, AlertType, ContainerInventory, CraftingRecipe, DamageWarningRule,
+    DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask, MovementPhase, Probe,
+    ProbeAlert, ProbeInventory, ProbeMovement, ProbeStatus, SectorObjectType, SectorObservation,
+    SensorMode, StorageContainer,
 };
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -544,4 +545,46 @@ struct AlertsResponseProbe {
 struct DamageWarningsResponseProbe {
     damage_warnings: Vec<ProbeAlert>,
     rule: DamageWarningRule,
+}
+
+// ── Storage containers ──────────────────────────────────────────────────────
+// Shape per api-specs/v44.yaml StorageContainerInventoryResponse + StorageContainer.
+
+const CONTAINER_DETAIL_JSON: &str = r#"{
+  "container": {
+    "id": "container-itm_extra",
+    "kind": "container",
+    "label": "Soute metaux",
+    "sortOrder": 2,
+    "capacity": 1.0,
+    "usedCapacity": 0.4,
+    "freeCapacity": 0.6,
+    "capacityUnit": "earth_container_equivalent",
+    "rules": { "priority": ["metals"], "exclusion": ["ice"], "strictExclusion": ["manny"] }
+  },
+  "inventory": {
+    "capacityUnit": "earth_container_equivalent",
+    "items": [],
+    "resourceStocks": [
+      { "id": "stock-metals", "type": "metals", "name": "Metals", "amount": 0.4, "containerSpace": 0.4, "containers": [] }
+    ]
+  }
+}"#;
+
+#[test]
+fn container_detail_deser() {
+    #[derive(serde::Deserialize)]
+    struct Resp {
+        container: StorageContainer,
+        inventory: ContainerInventory,
+    }
+    let r: Resp = deser(CONTAINER_DETAIL_JSON);
+    assert_eq!(r.container.id, "container-itm_extra");
+    assert_eq!(r.container.kind, "container");
+    assert_eq!(r.container.capacity_unit.as_deref(), Some("earth_container_equivalent"));
+    assert_eq!(r.container.rules.priority, vec!["metals"]);
+    assert_eq!(r.container.rules.strict_exclusion, vec!["manny"]);
+    assert_eq!(r.inventory.resource_stocks.len(), 1);
+    assert_eq!(r.inventory.resource_stocks[0].amount, 0.4);
+    assert!(r.inventory.items.is_empty());
 }


### PR DESCRIPTION
## Bloc 3 — Storage containers CRUD + routing rules (migration v47)

Implements the three `/api/probe/storage-containers` endpoints and a TUI to
manage container contents and automatic-routing rules.

### Endpoints
- `GET /api/probe/storage-containers` — list
- `GET /api/probe/storage-containers/{id}` — per-container content
- `PATCH /api/probe/storage-containers/{id}` — rename
- `PATCH /api/probe/storage-containers/{id}/rules` — update routing rules

### UI (`[C]` from the Inventory panel)
- **Container browser**: capacity bars per container.
- `Enter` → read-only content view (resources + items).
- `[n]` → rename wizard.
- `[e]` → routing-rules editor: each routable type cycles
  none → priority → exclusion → strict (`Space` cycle, `Del` clear,
  `Enter` save, `Esc` cancel). Routable types are derived from the four
  resources + current inventory item/stock types + types already in the rules.

### API/state layer
- `ContainerInventory` type; `capacity_unit` added to `StorageContainer`
  (it is required in the spec but was missing from our struct).
- 4 client methods, 4 task spawners (load-on-demand, **not** in `fetch_all()`),
  6 `ApiMessage` variants. Rename/rules responses return the updated container
  + full inventory, applied in one shot via `apply_container_update`.

### Notes / deviations from the roadmap
- The roadmap listed 3 renderers; I added a 4th — the **container list browser**
  — since an entry point was needed to select which container to act on.
- The rules editor uses a single cursored type-list with cycling rather than
  the sketched 3-column grid: same resulting `{priority, exclusion,
  strictExclusion}` payload, simpler to drive.
- `collect_planet_candidates()` (mentioned for this bloc in the roadmap) is
  deferred to bloc 5b where it is actually used, to avoid dead code.

### Validation
- `cargo test` — 130 passed (incl. a new container-detail serde fixture)
- `cargo clippy --all-targets` — 0 errors

Builds on bloc 1 (#59) and bloc 2 (#61), both merged. Depends only on bloc 1
functionally.
