### PR TITLE
feat(storage-move): inter-container stock transfers (v47 bloc 4)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -338,6 +338,44 @@ impl ApiClient {
         Ok(self.patch::<Resp, _>(&path, &serde_json::json!({})).await?.alert)
     }
 
+    /// Assign an idle Manny to move stock between containers
+    /// (`POST /api/probe/storage-moves`). `manny` kind is intentionally
+    /// unsupported here — only `resource` and `item` are wired in the UI.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn storage_move(
+        &self,
+        actor_manny_id: &str,
+        kind: &str,
+        to_container_id: &str,
+        from_container_id: Option<&str>,
+        resource_type: Option<&str>,
+        amount: Option<f64>,
+        item_ids: Option<Vec<String>>,
+    ) -> Result<(Manny, ProbeInventory)> {
+        let mut body = serde_json::Map::new();
+        body.insert("actorMannyId".into(), serde_json::json!(actor_manny_id));
+        body.insert("kind".into(), serde_json::json!(kind));
+        body.insert("toContainerId".into(), serde_json::json!(to_container_id));
+        if let Some(v) = from_container_id {
+            body.insert("fromContainerId".into(), serde_json::json!(v));
+        }
+        if let Some(v) = resource_type {
+            body.insert("resourceType".into(), serde_json::json!(v));
+        }
+        if let Some(v) = amount {
+            body.insert("amount".into(), serde_json::json!(v));
+        }
+        if let Some(v) = item_ids {
+            body.insert("itemIds".into(), serde_json::json!(v));
+        }
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny, inventory: ProbeInventory }
+        let r = self
+            .post::<Resp, _>("/api/probe/storage-moves", &serde_json::Value::Object(body))
+            .await?;
+        Ok((r.manny, r.inventory))
+    }
+
     pub async fn get_storage_containers(&self) -> Result<Vec<StorageContainer>> {
         #[derive(Deserialize)]
         struct Resp { containers: Vec<StorageContainer> }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -83,6 +83,38 @@ pub fn fetch_ack_damage_warning(id: i64, client: ApiClient, tx: mpsc::Sender<Api
     });
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn fetch_storage_move(
+    actor_manny_id: String,
+    kind: String,
+    to_container_id: String,
+    from_container_id: Option<String>,
+    resource_type: Option<String>,
+    amount: Option<f64>,
+    item_ids: Option<Vec<String>>,
+    client: ApiClient,
+    tx: mpsc::Sender<ApiMessage>,
+) {
+    tokio::spawn(async move {
+        let msg = match client
+            .storage_move(
+                &actor_manny_id,
+                &kind,
+                &to_container_id,
+                from_container_id.as_deref(),
+                resource_type.as_deref(),
+                amount,
+                item_ids,
+            )
+            .await
+        {
+            Ok((m, inv)) => ApiMessage::StorageMoveDone(m, inv),
+            Err(e) => ApiMessage::StorageMoveError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
 pub fn fetch_storage_containers(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
         if let Ok(c) = client.get_storage_containers().await {

--- a/src/app/containers.rs
+++ b/src/app/containers.rs
@@ -35,6 +35,39 @@ impl AppState {
         set.into_iter().collect()
     }
 
+    /// Containers available as move source/destination, from the probe
+    /// inventory (always loaded), as (id, label) pairs.
+    pub fn collect_move_containers(&self) -> Vec<(String, String)> {
+        match &self.probe {
+            Some(p) => p
+                .inventory
+                .containers
+                .iter()
+                .map(|c| (c.id.clone(), c.label.clone()))
+                .collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Unit items movable between containers (excludes mannies, which use the
+    /// dedicated `manny` move kind). Label shows the current container.
+    pub fn collect_movable_items(&self) -> Vec<(String, String)> {
+        let Some(p) = &self.probe else { return Vec::new() };
+        p.inventory
+            .items
+            .iter()
+            .filter(|it| it.item_type != "manny")
+            .map(|it| {
+                let loc = it
+                    .container
+                    .as_ref()
+                    .map(|c| c.label.clone())
+                    .unwrap_or_else(|| "—".to_string());
+                (it.id.clone(), format!("{} [{}]", it.name, loc))
+            })
+            .collect()
+    }
+
     /// Build the routing-rules editor for a container (by id), seeded from its
     /// current rules. Returns `None` if the container is not in the list.
     pub fn rules_editor_for(&self, container_id: &str) -> Option<ContainerRulesInput> {

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -116,6 +116,46 @@ pub enum ContainerRulesInput {
     },
 }
 
+/// Resource types movable between containers — deuterium lives in the tank,
+/// not in storage containers, so it is excluded (matches the v44 schema).
+pub const MOVE_RESOURCE_TYPES: [&str; 3] = ["metals", "ice", "carbon_compounds"];
+
+#[derive(Default)]
+pub enum StorageMoveInput {
+    #[default]
+    Inactive,
+    PickManny {
+        mannies: Vec<(String, String)>,
+        selection: usize,
+    },
+    PickKind {
+        actor_manny_id: String,
+        actor_manny_name: String,
+        selection: usize, // 0 = resource, 1 = item
+    },
+    ConfigureResource {
+        actor_manny_id: String,
+        actor_manny_name: String,
+        containers: Vec<(String, String)>,
+        resource_idx: usize,
+        from_sel: usize,
+        to_sel: usize,
+        amount_buf: String,
+        field: u8, // 0 resource, 1 from, 2 to, 3 amount
+        error: Option<String>,
+    },
+    ConfigureItem {
+        actor_manny_id: String,
+        actor_manny_name: String,
+        containers: Vec<(String, String)>,
+        items: Vec<(String, String, bool)>, // (id, label, selected)
+        to_sel: usize,
+        item_cursor: usize,
+        field: u8, // 0 items list, 1 destination
+        error: Option<String>,
+    },
+}
+
 #[derive(Default)]
 pub enum WaypointsInput {
     #[default]

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -47,5 +47,7 @@ pub enum ApiMessage {
     RenameContainerError(String),
     UpdateContainerRulesDone(StorageContainer, ProbeInventory),
     UpdateContainerRulesError(String),
+    StorageMoveDone(Manny, ProbeInventory),
+    StorageMoveError(String),
     Error(String),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -71,6 +71,7 @@ pub struct AppState {
     pub containers_input: ContainersInput,
     pub rename_container: RenameContainerInput,
     pub container_rules: ContainerRulesInput,
+    pub storage_move: StorageMoveInput,
     pub help_open: bool,
     /// Read-only detail popup for the selected inventory row.
     pub inventory_detail_open: bool,
@@ -169,6 +170,14 @@ impl AppState {
     pub fn set_container_rules_error(&mut self, msg: String) {
         if let ContainerRulesInput::Editing { ref mut error, .. } = self.container_rules {
             *error = Some(msg);
+        }
+    }
+
+    pub fn set_storage_move_error(&mut self, msg: String) {
+        match &mut self.storage_move {
+            StorageMoveInput::ConfigureResource { error, .. }
+            | StorageMoveInput::ConfigureItem { error, .. } => *error = Some(msg),
+            _ => {}
         }
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -11,7 +11,7 @@ use crate::app::{
     AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
     ContainersInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput,
     ObjectActionInput, Panel, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, ScanMode, TravelInput, WaypointsInput,
+    RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
 };
 mod alerts;
 mod containers;
@@ -23,6 +23,7 @@ mod mine;
 mod pickers;
 mod repair;
 mod scanner;
+mod storage_move;
 mod travel;
 
 use alerts::handle_alerts_event;
@@ -40,6 +41,7 @@ use pickers::{
 };
 use repair::handle_repair_event;
 use scanner::{handle_object_action_event, handle_waypoints_event};
+use storage_move::handle_storage_move_event;
 use travel::handle_travel_event;
 pub fn handle_event(
     event: Event,
@@ -70,6 +72,7 @@ pub fn handle_event(
     let in_rename_container = !matches!(state.rename_container, RenameContainerInput::Inactive);
     let in_container_rules = !matches!(state.container_rules, ContainerRulesInput::Inactive);
     let in_containers = !matches!(state.containers_input, ContainersInput::Inactive);
+    let in_storage_move = !matches!(state.storage_move, StorageMoveInput::Inactive);
 
     if ctrl && k.code == KeyCode::Char('c') {
         state.set_quit();
@@ -173,6 +176,11 @@ pub fn handle_event(
 
     if in_containers {
         handle_containers_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_storage_move {
+        handle_storage_move_event(k.code, state, client, tx);
         return;
     }
 
@@ -373,6 +381,21 @@ pub fn handle_event(
         KeyCode::Char('C') if state.focused == Some(Panel::Inventory) => {
             fetch_storage_containers(client.clone(), tx.clone());
             state.containers_input = ContainersInput::Browsing { selection: 0 };
+        }
+        KeyCode::Char('M') if state.focused == Some(Panel::Inventory) => {
+            let mannies = state.collect_idle_onboard_mannies();
+            match mannies.len() {
+                0 => state.error = Some("no idle Manny on board".into()),
+                1 => {
+                    let (id, name) = mannies.into_iter().next().unwrap();
+                    state.storage_move = StorageMoveInput::PickKind {
+                        actor_manny_id: id,
+                        actor_manny_name: name,
+                        selection: 0,
+                    };
+                }
+                _ => state.storage_move = StorageMoveInput::PickManny { mannies, selection: 0 },
+            }
         }
         KeyCode::Down | KeyCode::Char('j') if state.focused == Some(Panel::Mannies) => {
             state.manny_next();

--- a/src/input/storage_move.rs
+++ b/src/input/storage_move.rs
@@ -1,0 +1,249 @@
+use crossterm::event::KeyCode;
+use tokio::sync::mpsc;
+
+use crate::api::client::ApiClient;
+use crate::api::tasks::fetch_storage_move;
+use crate::app::{ApiMessage, AppState, StorageMoveInput, MOVE_RESOURCE_TYPES};
+
+use super::geometry::list_nav;
+
+fn wrap_prev(i: usize, len: usize) -> usize {
+    if len == 0 { 0 } else { (i + len - 1) % len }
+}
+fn wrap_next(i: usize, len: usize) -> usize {
+    if len == 0 { 0 } else { (i + 1) % len }
+}
+
+pub(super) fn handle_storage_move_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match &state.storage_move {
+        StorageMoveInput::PickManny { selection, mannies } => {
+            let (sel, count) = (*selection, mannies.len());
+            match code {
+                KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(ns) = list_nav(code, sel, count) {
+                        if let StorageMoveInput::PickManny { selection, .. } = &mut state.storage_move {
+                            *selection = ns;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let (id, name) = {
+                        let StorageMoveInput::PickManny { mannies, selection } = &state.storage_move
+                        else { return };
+                        mannies[*selection].clone()
+                    };
+                    state.storage_move = StorageMoveInput::PickKind {
+                        actor_manny_id: id,
+                        actor_manny_name: name,
+                        selection: 0,
+                    };
+                }
+                _ => {}
+            }
+        }
+        StorageMoveInput::PickKind { selection, .. } => {
+            let sel = *selection;
+            match code {
+                KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(ns) = list_nav(code, sel, 2) {
+                        if let StorageMoveInput::PickKind { selection, .. } = &mut state.storage_move {
+                            *selection = ns;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let (id, name) = {
+                        let StorageMoveInput::PickKind { actor_manny_id, actor_manny_name, .. } =
+                            &state.storage_move else { return };
+                        (actor_manny_id.clone(), actor_manny_name.clone())
+                    };
+                    if sel == 0 {
+                        enter_resource(state, id, name);
+                    } else {
+                        enter_item(state, id, name);
+                    }
+                }
+                _ => {}
+            }
+        }
+        StorageMoveInput::ConfigureResource { .. } => handle_resource(code, state, client, tx),
+        StorageMoveInput::ConfigureItem { .. } => handle_item(code, state, client, tx),
+        StorageMoveInput::Inactive => {}
+    }
+}
+
+fn enter_resource(state: &mut AppState, actor_manny_id: String, actor_manny_name: String) {
+    let containers = state.collect_move_containers();
+    if containers.len() < 2 {
+        state.storage_move = StorageMoveInput::Inactive;
+        state.error = Some("need at least two containers to move resources".into());
+        return;
+    }
+    state.storage_move = StorageMoveInput::ConfigureResource {
+        actor_manny_id,
+        actor_manny_name,
+        containers,
+        resource_idx: 0,
+        from_sel: 0,
+        to_sel: 1,
+        amount_buf: "0.10".into(),
+        field: 0,
+        error: None,
+    };
+}
+
+fn enter_item(state: &mut AppState, actor_manny_id: String, actor_manny_name: String) {
+    let containers = state.collect_move_containers();
+    if containers.is_empty() {
+        state.storage_move = StorageMoveInput::Inactive;
+        state.error = Some("no containers available".into());
+        return;
+    }
+    let items: Vec<(String, String, bool)> = state
+        .collect_movable_items()
+        .into_iter()
+        .map(|(id, label)| (id, label, false))
+        .collect();
+    if items.is_empty() {
+        state.storage_move = StorageMoveInput::Inactive;
+        state.error = Some("no movable items in inventory".into());
+        return;
+    }
+    state.storage_move = StorageMoveInput::ConfigureItem {
+        actor_manny_id,
+        actor_manny_name,
+        containers,
+        items,
+        to_sel: 0,
+        item_cursor: 0,
+        field: 0,
+        error: None,
+    };
+}
+
+fn handle_resource(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let StorageMoveInput::ConfigureResource {
+        actor_manny_id, containers, resource_idx, from_sel, to_sel, amount_buf, field, ..
+    } = &mut state.storage_move
+    else {
+        return;
+    };
+    let clen = containers.len();
+    match code {
+        KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+        KeyCode::Up | KeyCode::BackTab => *field = wrap_prev(*field as usize, 4) as u8,
+        KeyCode::Down | KeyCode::Tab => *field = wrap_next(*field as usize, 4) as u8,
+        KeyCode::Left | KeyCode::Char('h') => match field {
+            0 => *resource_idx = wrap_prev(*resource_idx, MOVE_RESOURCE_TYPES.len()),
+            1 => *from_sel = wrap_prev(*from_sel, clen),
+            2 => *to_sel = wrap_prev(*to_sel, clen),
+            _ => {}
+        },
+        KeyCode::Right | KeyCode::Char('l') => match field {
+            0 => *resource_idx = wrap_next(*resource_idx, MOVE_RESOURCE_TYPES.len()),
+            1 => *from_sel = wrap_next(*from_sel, clen),
+            2 => *to_sel = wrap_next(*to_sel, clen),
+            _ => {}
+        },
+        KeyCode::Char(c) if *field == 3 && (c.is_ascii_digit() || c == '.') => {
+            if amount_buf.chars().count() < 10 {
+                amount_buf.push(c);
+            }
+        }
+        KeyCode::Backspace if *field == 3 => {
+            amount_buf.pop();
+        }
+        KeyCode::Enter => {
+            if from_sel == to_sel {
+                state.set_storage_move_error("source and destination must differ".into());
+                return;
+            }
+            let amount: f64 = match amount_buf.trim().parse() {
+                Ok(a) if a > 0.0 => a,
+                _ => {
+                    state.set_storage_move_error("amount must be a positive number".into());
+                    return;
+                }
+            };
+            let actor = actor_manny_id.clone();
+            let resource = MOVE_RESOURCE_TYPES[*resource_idx].to_string();
+            let from_id = containers[*from_sel].0.clone();
+            let to_id = containers[*to_sel].0.clone();
+            fetch_storage_move(
+                actor,
+                "resource".into(),
+                to_id,
+                Some(from_id),
+                Some(resource),
+                Some(amount),
+                None,
+                client.clone(),
+                tx.clone(),
+            );
+        }
+        _ => {}
+    }
+}
+
+fn handle_item(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let StorageMoveInput::ConfigureItem {
+        actor_manny_id, containers, items, to_sel, item_cursor, field, ..
+    } = &mut state.storage_move
+    else {
+        return;
+    };
+    let clen = containers.len();
+    let ilen = items.len();
+    match code {
+        KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+        KeyCode::Tab => *field = if *field == 0 { 1 } else { 0 },
+        KeyCode::Up | KeyCode::Char('k') if *field == 0 => *item_cursor = wrap_prev(*item_cursor, ilen),
+        KeyCode::Down | KeyCode::Char('j') if *field == 0 => *item_cursor = wrap_next(*item_cursor, ilen),
+        KeyCode::Char(' ') if *field == 0 => {
+            if let Some(it) = items.get_mut(*item_cursor) {
+                it.2 = !it.2;
+            }
+        }
+        KeyCode::Left | KeyCode::Char('h') if *field == 1 => *to_sel = wrap_prev(*to_sel, clen),
+        KeyCode::Right | KeyCode::Char('l') if *field == 1 => *to_sel = wrap_next(*to_sel, clen),
+        KeyCode::Enter => {
+            let ids: Vec<String> =
+                items.iter().filter(|(_, _, sel)| *sel).map(|(id, _, _)| id.clone()).collect();
+            if ids.is_empty() {
+                state.set_storage_move_error("select at least one item with Space".into());
+                return;
+            }
+            let actor = actor_manny_id.clone();
+            let to_id = containers[*to_sel].0.clone();
+            fetch_storage_move(
+                actor,
+                "item".into(),
+                to_id,
+                None,
+                None,
+                None,
+                Some(ids),
+                client.clone(),
+                tx.clone(),
+            );
+        }
+        _ => {}
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_r
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
     DetachInput, InspectInput, JettisonInput, MineInput, Phosphor, RecallInput, RecoverInput,
-    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, UiTheme,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -219,6 +219,17 @@ async fn run(
                         state.set_toast("routing rules updated");
                     }
                     ApiMessage::UpdateContainerRulesError(e) => state.set_container_rules_error(e),
+                    ApiMessage::StorageMoveDone(manny, inv) => {
+                        if let Some(ref mut mannies) = state.mannies {
+                            if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
+                                *m = manny;
+                            }
+                        }
+                        state.update_inventory(inv);
+                        state.storage_move = StorageMoveInput::Inactive;
+                        state.set_toast("storage move order sent");
+                    }
+                    ApiMessage::StorageMoveError(e) => state.set_storage_move_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -65,6 +65,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("d", "deploy waypoint"),
         help_key_line("a", "atomic printer craft"),
         help_key_line("C", "storage containers"),
+        help_key_line("M", "move stock between containers"),
         Line::default(),
         help_section("Map"),
         help_key_line("hjkl/←↓↑→", "pan"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod mine;
 pub(crate) mod object_actions;
 pub(crate) mod pickers;
 pub(crate) mod repair;
+pub(crate) mod storage_move;
 pub(crate) mod travel;
 pub(crate) mod waypoints;
 
@@ -29,6 +30,7 @@ pub(crate) use pickers::{
     render_recover_overlay, render_rename_manny_overlay, render_salvage_overlay,
 };
 pub(crate) use repair::render_repair_overlay;
+pub(crate) use storage_move::render_storage_move_overlay;
 pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
 
@@ -36,7 +38,7 @@ use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
     CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput,
     ObjectActionInput, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, TravelInput, WaypointsInput,
+    RepairInput, SalvageInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -116,6 +118,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if state.storage_container_detail.is_some() {
         render_container_detail_overlay(frame, area, state);
+    }
+    if !matches!(state.storage_move, StorageMoveInput::Inactive) {
+        render_storage_move_overlay(frame, area, state);
     }
     if state.help_open {
         render_help_overlay(frame, area);

--- a/src/ui/overlays/storage_move.rs
+++ b/src/ui/overlays/storage_move.rs
@@ -1,0 +1,159 @@
+use crate::app::{AppState, StorageMoveInput, MOVE_RESOURCE_TYPES};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+use super::{centered_rect, render_pick_list};
+
+fn framed(title: &str, area: Rect, width: u16, height: u16, frame: &mut Frame) -> [Rect; 2] {
+    let popup = centered_rect(width, height, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(title.to_owned())
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+    [rows[0], rows[1]]
+}
+
+/// One `label: < value >` form row, highlighted when active.
+fn field_row(label: &str, value: String, active: bool, editing: bool) -> Line<'static> {
+    let lab_style = if active {
+        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let val = if editing {
+        format!("{value}█")
+    } else if active {
+        format!("‹ {value} ›")
+    } else {
+        format!("  {value}  ")
+    };
+    let val_style = if active {
+        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Gray)
+    };
+    Line::from(vec![
+        Span::styled(format!("{label:<10}"), lab_style),
+        Span::styled(val, val_style),
+    ])
+}
+
+pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match &state.storage_move {
+        StorageMoveInput::Inactive => {}
+        StorageMoveInput::PickManny { mannies, selection } => {
+            let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
+            let height = (mannies.len() as u16 + 6).min(18);
+            render_pick_list(frame, area, " STORAGE MOVE — SELECT MANNY ", 52, height,
+                None, &names, *selection, None, "select");
+        }
+        StorageMoveInput::PickKind { selection, .. } => {
+            render_pick_list(frame, area, " STORAGE MOVE — KIND ", 46, 8,
+                None, &["resource", "item"], *selection, None, "select");
+        }
+        StorageMoveInput::ConfigureResource {
+            containers, resource_idx, from_sel, to_sel, amount_buf, field, error, ..
+        } => {
+            let [body, footer] = framed(" STORAGE MOVE — RESOURCE ", area, 56, 9, frame);
+            let cname = |i: usize| containers.get(i).map(|(_, l)| l.clone()).unwrap_or_default();
+            let lines = vec![
+                field_row("Resource:", MOVE_RESOURCE_TYPES[*resource_idx].to_string(), *field == 0, false),
+                field_row("From:", cname(*from_sel), *field == 1, false),
+                field_row("To:", cname(*to_sel), *field == 2, false),
+                field_row("Amount:", format!("{amount_buf} ECE"), *field == 3, *field == 3),
+                error_line(error),
+            ];
+            frame.render_widget(Paragraph::new(lines), body);
+            frame.render_widget(form_footer(), footer);
+        }
+        StorageMoveInput::ConfigureItem {
+            containers, items, to_sel, item_cursor, field, error, ..
+        } => {
+            let height = (items.len() as u16 + 7).clamp(10, 22);
+            let [body, footer] = framed(" STORAGE MOVE — ITEMS ", area, 60, height, frame);
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(2), Constraint::Min(1)])
+                .split(body);
+
+            let dest = containers.get(*to_sel).map(|(_, l)| l.clone()).unwrap_or_default();
+            let mut head = vec![field_row("To:", dest, *field == 1, false)];
+            if let Some(err) = error {
+                head.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+            }
+            frame.render_widget(Paragraph::new(head), rows[0]);
+
+            let item_lines: Vec<ListItem> = items
+                .iter()
+                .map(|(_, label, sel)| {
+                    let mark = if *sel { "[x] " } else { "[ ] " };
+                    let color = if *sel { Color::Green } else { Color::DarkGray };
+                    ListItem::new(Line::from(vec![
+                        Span::styled(mark, Style::default().fg(color)),
+                        Span::styled(label.clone(), Style::default().fg(Color::White)),
+                    ]))
+                })
+                .collect();
+            let mut list = List::new(item_lines);
+            if *field == 0 {
+                list = list
+                    .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+                    .highlight_symbol("▶ ");
+            }
+            let mut ls = ListState::default();
+            if *field == 0 && !items.is_empty() {
+                ls.select(Some((*item_cursor).min(items.len() - 1)));
+            }
+            frame.render_stateful_widget(list, rows[1], &mut ls);
+            frame.render_widget(item_footer(), footer);
+        }
+    }
+}
+
+fn error_line(error: &Option<String>) -> Line<'static> {
+    match error {
+        Some(err) => Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))),
+        None => Line::default(),
+    }
+}
+
+fn form_footer() -> Paragraph<'static> {
+    Paragraph::new(Line::from(vec![
+        Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+        Span::raw(" field  "),
+        Span::styled("[←/→]", Style::default().fg(Color::Cyan)),
+        Span::raw(" change  "),
+        Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+        Span::raw(" move  "),
+        Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+        Span::raw(" cancel"),
+    ]))
+}
+
+fn item_footer() -> Paragraph<'static> {
+    Paragraph::new(Line::from(vec![
+        Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+        Span::raw(" pane  "),
+        Span::styled("[Space]", Style::default().fg(Color::Cyan)),
+        Span::raw(" toggle  "),
+        Span::styled("[←/→]", Style::default().fg(Color::Cyan)),
+        Span::raw(" dest  "),
+        Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+        Span::raw(" move  "),
+        Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+        Span::raw(" cancel"),
+    ]))
+}


### PR DESCRIPTION
## Bloc 4 — Storage moves (migration v47)

Implements `POST /api/probe/storage-moves`: assign an idle onboard Manny to
move stock between storage containers (starts a `moving_stockage` task).

### UI (`[M]` from the Inventory panel)
1. Pick the actor Manny (skipped automatically if only one is idle onboard).
2. Pick the move kind:
   - **resource**: select type (metals / ice / carbon_compounds — deuterium is
     tank-managed, not a container resource), source + destination container,
     and an amount in ECE. `↑/↓` move between fields, `←/→` change values,
     digits type the amount.
   - **item**: multi-select unit items with `Space`, choose a destination
     container, `Tab` switches between the item list and the destination.

### Scope
- The `manny` move kind exists in the spec but is undocumented gameplay-wise;
  per the roadmap it is intentionally **not** wired here.

### Implementation notes
- `storage_move` client method builds the JSON body dynamically, omitting
  `None` fields (resource vs item send different keys).
- Containers and items come from the already-loaded probe inventory — no extra
  request on overlay open.
- The `{manny, inventory}` response updates the actor Manny and probe inventory
  in place; the overlay closes with a success toast.
- Field names verified against `api-specs/v44.yaml`. No new deserialized types,
  so no new serde fixture (response reuses `Manny` / `ProbeInventory`).

### Validation
- `cargo test` — 130 passed
- `cargo clippy --all-targets` — 0 errors

Builds on blocs 1/2/3 (all merged); depends functionally on 01 + 03.
