### PR TITLE
feat(mannies): drop-manny-cargo action (v47 bloc 5a)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -219,6 +219,16 @@ impl ApiClient {
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
     }
 
+    /// Drop the cargo of a Manny waiting outside for storage space and retry
+    /// docking (`POST /api/probe/mannies/{id}/drop-manny-cargo`). Resource cargo
+    /// is lost; recoverable objects are restored to the current sector.
+    pub async fn drop_manny_cargo(&self, manny_id: &str) -> Result<Manny> {
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/drop-manny-cargo");
+        Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
+    }
+
     pub async fn rename_manny(&self, manny_id: &str, name: &str) -> Result<Manny> {
         #[derive(Serialize)]
         struct Body<'a> { name: &'a str }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -323,6 +323,16 @@ pub fn fetch_detach(
     });
 }
 
+pub fn fetch_drop_manny_cargo(manny_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.drop_manny_cargo(&manny_id).await {
+            Ok(m) => ApiMessage::DropMannyCargoStarted(m),
+            Err(e) => ApiMessage::DropMannyCargoError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
 pub fn fetch_rename_manny(manny_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
         let msg = match client.rename_manny(&manny_id, &name).await {

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -157,6 +157,18 @@ pub enum StorageMoveInput {
 }
 
 #[derive(Default)]
+pub enum DropCargoInput {
+    #[default]
+    Inactive,
+    /// Confirmation for the irreversible cargo drop (resources are lost).
+    Confirm {
+        manny_id: String,
+        manny_name: String,
+        error: Option<String>,
+    },
+}
+
+#[derive(Default)]
 pub enum WaypointsInput {
     #[default]
     Inactive,

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -49,5 +49,7 @@ pub enum ApiMessage {
     UpdateContainerRulesError(String),
     StorageMoveDone(Manny, ProbeInventory),
     StorageMoveError(String),
+    DropMannyCargoStarted(Manny),
+    DropMannyCargoError(String),
     Error(String),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -72,6 +72,7 @@ pub struct AppState {
     pub rename_container: RenameContainerInput,
     pub container_rules: ContainerRulesInput,
     pub storage_move: StorageMoveInput,
+    pub drop_cargo: DropCargoInput,
     pub help_open: bool,
     /// Read-only detail popup for the selected inventory row.
     pub inventory_detail_open: bool,
@@ -178,6 +179,12 @@ impl AppState {
             StorageMoveInput::ConfigureResource { error, .. }
             | StorageMoveInput::ConfigureItem { error, .. } => *error = Some(msg),
             _ => {}
+        }
+    }
+
+    pub fn set_drop_cargo_error(&mut self, msg: String) {
+        if let DropCargoInput::Confirm { ref mut error, .. } = self.drop_cargo {
+            *error = Some(msg);
         }
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -7,11 +7,13 @@ use crate::api::tasks::{
     fetch_inspect,
     fetch_recover, fetch_sector, fetch_storage_containers,
 };
+use crate::api::types::MannyTask;
 use crate::app::{
     AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
-    ContainersInput, CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput,
-    ObjectActionInput, Panel, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
+    ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput, InspectInput,
+    JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, StorageMoveInput,
+    TravelInput, WaypointsInput,
 };
 mod alerts;
 mod containers;
@@ -36,8 +38,8 @@ use jettison::handle_jettison_event;
 use map::handle_map_event;
 use mine::handle_mine_event;
 use pickers::{
-    handle_deploy_event, handle_detach_event, handle_inspect_event, handle_recall_event,
-    handle_recover_event, handle_rename_manny_event, handle_salvage_event,
+    handle_deploy_event, handle_detach_event, handle_drop_cargo_event, handle_inspect_event,
+    handle_recall_event, handle_recover_event, handle_rename_manny_event, handle_salvage_event,
 };
 use repair::handle_repair_event;
 use scanner::{handle_object_action_event, handle_waypoints_event};
@@ -73,6 +75,7 @@ pub fn handle_event(
     let in_container_rules = !matches!(state.container_rules, ContainerRulesInput::Inactive);
     let in_containers = !matches!(state.containers_input, ContainersInput::Inactive);
     let in_storage_move = !matches!(state.storage_move, StorageMoveInput::Inactive);
+    let in_drop_cargo = !matches!(state.drop_cargo, DropCargoInput::Inactive);
 
     if ctrl && k.code == KeyCode::Char('c') {
         state.set_quit();
@@ -181,6 +184,11 @@ pub fn handle_event(
 
     if in_storage_move {
         handle_storage_move_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_drop_cargo {
+        handle_drop_cargo_event(k.code, state, client, tx);
         return;
     }
 
@@ -523,6 +531,21 @@ pub fn handle_event(
                         buf: manny.name.clone(),
                         error: None,
                     };
+                }
+            }
+        }
+        KeyCode::Char('X') if state.focused == Some(Panel::Mannies) => {
+            if let Some(mannies) = &state.mannies {
+                if let Some(manny) = mannies.get(state.mannies_selection) {
+                    if manny.current_task == Some(MannyTask::WaitingForSpace) {
+                        state.drop_cargo = DropCargoInput::Confirm {
+                            manny_id: manny.id.clone(),
+                            manny_name: manny.name.clone(),
+                            error: None,
+                        };
+                    } else {
+                        state.error = Some("manny is not waiting for storage space".into());
+                    }
                 }
             }
         }

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -3,12 +3,12 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{
-    fetch_deploy, fetch_detach,
+    fetch_deploy, fetch_detach, fetch_drop_manny_cargo,
     fetch_inspect, fetch_recall,
     fetch_recover, fetch_rename_manny, fetch_salvage,
 };
 use crate::app::{
-    ApiMessage, AppState, DeployInput, DetachInput,
+    ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput,
     InspectInput, RecallInput,
     RecoverInput, RenameMannyInput, SalvageInput, DETACH_MODES,
 };
@@ -76,6 +76,25 @@ pub(super) fn handle_recall_event(
                 manny_id.clone()
             };
             fetch_recall(manny_id, client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn handle_drop_cargo_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match code {
+        KeyCode::Esc | KeyCode::Char('n') => state.drop_cargo = DropCargoInput::Inactive,
+        KeyCode::Enter | KeyCode::Char('y') => {
+            let manny_id = {
+                let DropCargoInput::Confirm { ref manny_id, .. } = state.drop_cargo else { return };
+                manny_id.clone()
+            };
+            fetch_drop_manny_cargo(manny_id, client.clone(), tx.clone());
         }
         _ => {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,9 @@ use neumann_cockpit::api::client::ApiClient;
 use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies};
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
-    DetachInput, InspectInput, JettisonInput, MineInput, Phosphor, RecallInput, RecoverInput,
-    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput, UiTheme,
+    DetachInput, DropCargoInput, InspectInput, JettisonInput, MineInput, Phosphor, RecallInput,
+    RecoverInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
+    StorageMoveInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -230,6 +231,18 @@ async fn run(
                         state.set_toast("storage move order sent");
                     }
                     ApiMessage::StorageMoveError(e) => state.set_storage_move_error(e),
+                    ApiMessage::DropMannyCargoStarted(manny) => {
+                        if let Some(ref mut mannies) = state.mannies {
+                            if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
+                                *m = manny;
+                            }
+                        }
+                        state.drop_cargo = DropCargoInput::Inactive;
+                        state.set_toast("cargo dropped");
+                        // Recoverable objects may reappear in the sector.
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::DropMannyCargoError(e) => state.set_drop_cargo_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -87,6 +87,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("v", "recover container"),
         help_key_line("n", "rename"),
         help_key_line("R", "recall (busy manny)"),
+        help_key_line("X", "drop cargo (waiting manny)"),
         Line::default(),
         help_section("Scanner (focused)"),
         help_key_line("Enter", "rescan current sector"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -26,8 +26,9 @@ pub(crate) use map::render_map_overlay;
 pub(crate) use mine::render_mine_overlay;
 pub(crate) use object_actions::render_object_action_overlay;
 pub(crate) use pickers::{
-    render_deploy_overlay, render_detach_overlay, render_inspect_overlay, render_recall_overlay,
-    render_recover_overlay, render_rename_manny_overlay, render_salvage_overlay,
+    render_deploy_overlay, render_detach_overlay, render_drop_cargo_overlay, render_inspect_overlay,
+    render_recall_overlay, render_recover_overlay, render_rename_manny_overlay,
+    render_salvage_overlay,
 };
 pub(crate) use repair::render_repair_overlay;
 pub(crate) use storage_move::render_storage_move_overlay;
@@ -36,7 +37,7 @@ pub(crate) use waypoints::render_waypoints_overlay;
 
 use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
-    CraftInput, DeployInput, DetachInput, InspectInput, JettisonInput, MineInput,
+    CraftInput, DeployInput, DetachInput, DropCargoInput, InspectInput, JettisonInput, MineInput,
     ObjectActionInput, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
     RepairInput, SalvageInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
@@ -84,6 +85,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.recall, RecallInput::Inactive) {
         render_recall_overlay(frame, area, state);
+    }
+    if !matches!(state.drop_cargo, DropCargoInput::Inactive) {
+        render_drop_cargo_overlay(frame, area, state);
     }
     if !matches!(state.deploy, DeployInput::Inactive) {
         render_deploy_overlay(frame, area, state);

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, DeployInput, DetachInput, InspectInput, RecallInput, RecoverInput, RenameMannyInput, SalvageInput};
+use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, RecallInput, RecoverInput, RenameMannyInput, SalvageInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -59,6 +59,52 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
 
         SalvageInput::Inactive => {}
     }
+}
+
+pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let DropCargoInput::Confirm { ref manny_name, ref error, .. } = state.drop_cargo else { return };
+
+    let popup = centered_rect(54, 8, area);
+    frame.render_widget(Clear, popup);
+
+    let title = format!(" DROP CARGO — {manny_name} ");
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Red));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled(
+            "Drop cargo and retry docking?",
+            Style::default().fg(Color::White),
+        )),
+        Line::from(Span::styled(
+            "Resource cargo is lost (objects return to sector).",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+    }
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Enter/y]", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Span::raw(" DROP  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
 }
 
 pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppState) {

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -66,16 +66,22 @@ pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppSta
             }
             frame.render_widget(Paragraph::new(Line::from(spans)), hint_area);
         } else if is_busy {
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("busy  ", Style::default().fg(Color::DarkGray)),
-                    Span::styled("[R]", Style::default().fg(Color::Yellow)),
-                    Span::raw(" recall  "),
-                    Span::styled("[n]", Style::default().fg(Color::Cyan)),
-                    Span::raw(" rename"),
-                ])),
-                hint_area,
-            );
+            let is_waiting = selected_manny
+                .map(|m| m.current_task == Some(MannyTask::WaitingForSpace))
+                .unwrap_or(false);
+            let mut spans = vec![
+                Span::styled("busy  ", Style::default().fg(Color::DarkGray)),
+                Span::styled("[R]", Style::default().fg(Color::Yellow)),
+                Span::raw(" recall  "),
+                Span::styled("[n]", Style::default().fg(Color::Cyan)),
+                Span::raw(" rename"),
+            ];
+            if is_waiting {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled("[X]", Style::default().fg(Color::Red)));
+                spans.push(Span::raw(" drop cargo"));
+            }
+            frame.render_widget(Paragraph::new(Line::from(spans)), hint_area);
         } else {
             frame.render_widget(
                 Paragraph::new(Line::from(vec![


### PR DESCRIPTION
## Bloc 5a — drop-manny-cargo (migration v47)

Adds `POST /api/probe/mannies/{id}/drop-manny-cargo`: discard the cargo of a
Manny stuck **waiting for storage space** and immediately retry docking.

### UI (`[X]` in the Mannies panel)
- Shown only when the selected Manny's task is `waiting_for_space`.
- Opens a one-step confirmation, then fires the request.

### Deviation from the roadmap (and why)
The roadmap specified a fire-and-forget bind with **no confirmation**, calling
the action lossless. The v44 spec says otherwise:

> Resource cargo is **lost**. Recoverable cargo objects (a salvaged Manny,
> drifting item, or detached container) are restored to the current sector.

Since resources are irreversibly lost, I treat it as a destructive action and
gate it behind a single confirmation (mirrors the `recall` pattern). The
confirmation copy spells out the consequence.

### Behaviour
- On success: the actor Manny is refreshed in place, and `fetch_all()` reloads
  the sector so any recovered objects show up immediately.
- Errors (e.g. 409 "not waiting / outside sector") surface in the confirmation
  overlay.

### Validation
- `cargo test` — 130 passed (no new deserialized types; response is `{manny}`)
- `cargo clippy --all-targets` — 0 errors

Depends only on bloc 1 (merged).
