### PR TITLE
feat(mannies): drop storage container on a planet (v47 bloc 5b)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -219,6 +219,24 @@ impl ApiClient {
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
     }
 
+    /// Drop an additional storage container onto a planet in the current sector
+    /// (`POST /api/probe/mannies/{id}/drop-storage-container`). Consumes an
+    /// atmospheric_drop_kit; the container leaves the probe inventory.
+    pub async fn drop_storage_container_on_planet(
+        &self,
+        manny_id: &str,
+        container_id: &str,
+        planet_id: &str,
+    ) -> Result<Manny> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body<'a> { container_id: &'a str, planet_id: &'a str }
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/drop-storage-container");
+        Ok(self.post::<Resp, _>(&path, &Body { container_id, planet_id }).await?.manny)
+    }
+
     /// Drop the cargo of a Manny waiting outside for storage space and retry
     /// docking (`POST /api/probe/mannies/{id}/drop-manny-cargo`). Resource cargo
     /// is lost; recoverable objects are restored to the current sector.

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -323,6 +323,25 @@ pub fn fetch_detach(
     });
 }
 
+pub fn fetch_drop_storage_container(
+    manny_id: String,
+    container_id: String,
+    planet_id: String,
+    client: ApiClient,
+    tx: mpsc::Sender<ApiMessage>,
+) {
+    tokio::spawn(async move {
+        let msg = match client
+            .drop_storage_container_on_planet(&manny_id, &container_id, &planet_id)
+            .await
+        {
+            Ok(m) => ApiMessage::DropStorageContainerStarted(m),
+            Err(e) => ApiMessage::DropStorageContainerError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
 pub fn fetch_drop_manny_cargo(manny_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
         let msg = match client.drop_manny_cargo(&manny_id).await {

--- a/src/app/containers.rs
+++ b/src/app/containers.rs
@@ -1,8 +1,36 @@
 use super::*;
-use crate::api::types::StorageContainerRules;
+use crate::api::types::{SectorObjectType, StorageContainerRules};
 use std::collections::BTreeSet;
 
 impl AppState {
+    /// Planets in the probe's current sector, as (id, name) pairs — drop-target
+    /// candidates for dropping a storage container.
+    pub fn collect_planet_candidates(&self) -> Vec<(String, String)> {
+        self.probe_current_sector_scan()
+            .and_then(|s| s.objects.as_ref())
+            .map(|objects| {
+                objects
+                    .iter()
+                    .filter(|o| matches!(o.object_type, SectorObjectType::Planet) && o.id.is_some())
+                    .map(|o| {
+                        let id = o.id.clone().unwrap();
+                        let name = o.name.clone().unwrap_or_else(|| "unnamed planet".into());
+                        (id, name)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Whether the probe inventory holds an atmospheric drop kit (required to
+    /// drop a container on a planet).
+    pub fn has_atmospheric_drop_kit(&self) -> bool {
+        self.probe
+            .as_ref()
+            .map(|p| p.inventory.items.iter().any(|it| it.item_type == "atmospheric_drop_kit"))
+            .unwrap_or(false)
+    }
+
     /// All storage containers as (id, label) pairs.
     pub fn collect_renameable_containers(&self) -> Vec<(String, String)> {
         self.storage_containers

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -157,6 +157,27 @@ pub enum StorageMoveInput {
 }
 
 #[derive(Default)]
+pub enum DropStorageContainerInput {
+    #[default]
+    Inactive,
+    PickContainer {
+        manny_id: String,
+        manny_name: String,
+        containers: Vec<(String, String)>,
+        selection: usize,
+    },
+    PickPlanet {
+        manny_id: String,
+        manny_name: String,
+        container_id: String,
+        container_name: String,
+        planets: Vec<(String, String)>,
+        selection: usize,
+        error: Option<String>,
+    },
+}
+
+#[derive(Default)]
 pub enum DropCargoInput {
     #[default]
     Inactive,

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -51,5 +51,7 @@ pub enum ApiMessage {
     StorageMoveError(String),
     DropMannyCargoStarted(Manny),
     DropMannyCargoError(String),
+    DropStorageContainerStarted(Manny),
+    DropStorageContainerError(String),
     Error(String),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -73,6 +73,7 @@ pub struct AppState {
     pub container_rules: ContainerRulesInput,
     pub storage_move: StorageMoveInput,
     pub drop_cargo: DropCargoInput,
+    pub drop_container: DropStorageContainerInput,
     pub help_open: bool,
     /// Read-only detail popup for the selected inventory row.
     pub inventory_detail_open: bool,
@@ -184,6 +185,12 @@ impl AppState {
 
     pub fn set_drop_cargo_error(&mut self, msg: String) {
         if let DropCargoInput::Confirm { ref mut error, .. } = self.drop_cargo {
+            *error = Some(msg);
+        }
+    }
+
+    pub fn set_drop_container_error(&mut self, msg: String) {
+        if let DropStorageContainerInput::PickPlanet { ref mut error, .. } = self.drop_container {
             *error = Some(msg);
         }
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -10,10 +10,10 @@ use crate::api::tasks::{
 use crate::api::types::MannyTask;
 use crate::app::{
     AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
-    ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput, InspectInput,
-    JettisonInput, MineInput, ObjectActionInput, Panel, RecallInput, RecoverInput,
-    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, StorageMoveInput,
-    TravelInput, WaypointsInput,
+    ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput,
+    DropStorageContainerInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel,
+    RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
+    ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
 };
 mod alerts;
 mod containers;
@@ -38,8 +38,9 @@ use jettison::handle_jettison_event;
 use map::handle_map_event;
 use mine::handle_mine_event;
 use pickers::{
-    handle_deploy_event, handle_detach_event, handle_drop_cargo_event, handle_inspect_event,
-    handle_recall_event, handle_recover_event, handle_rename_manny_event, handle_salvage_event,
+    handle_deploy_event, handle_detach_event, handle_drop_cargo_event,
+    handle_drop_container_event, handle_inspect_event, handle_recall_event, handle_recover_event,
+    handle_rename_manny_event, handle_salvage_event,
 };
 use repair::handle_repair_event;
 use scanner::{handle_object_action_event, handle_waypoints_event};
@@ -76,6 +77,7 @@ pub fn handle_event(
     let in_containers = !matches!(state.containers_input, ContainersInput::Inactive);
     let in_storage_move = !matches!(state.storage_move, StorageMoveInput::Inactive);
     let in_drop_cargo = !matches!(state.drop_cargo, DropCargoInput::Inactive);
+    let in_drop_container = !matches!(state.drop_container, DropStorageContainerInput::Inactive);
 
     if ctrl && k.code == KeyCode::Char('c') {
         state.set_quit();
@@ -189,6 +191,11 @@ pub fn handle_event(
 
     if in_drop_cargo {
         handle_drop_cargo_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_drop_container {
+        handle_drop_container_event(k.code, state, client, tx);
         return;
     }
 
@@ -546,6 +553,33 @@ pub fn handle_event(
                     } else {
                         state.error = Some("manny is not waiting for storage space".into());
                     }
+                }
+            }
+        }
+        KeyCode::Char('P') if state.focused == Some(Panel::Mannies) => {
+            let manny = state.mannies.as_ref()
+                .and_then(|m| m.get(state.mannies_selection))
+                .filter(|m| m.can_receive_orders)
+                .map(|m| (m.id.clone(), m.name.clone()));
+            if let Some((manny_id, manny_name)) = manny {
+                let containers = state.collect_detachable_containers();
+                if containers.is_empty() {
+                    state.error = Some("no additional container to drop".into());
+                } else if !state.has_atmospheric_drop_kit() {
+                    state.error = Some("no atmospheric_drop_kit in inventory".into());
+                } else if state.collect_planet_candidates().is_empty() {
+                    state.error = Some("no planet in current sector — scan first".into());
+                } else if containers.len() == 1 {
+                    let (container_id, container_name) = containers.into_iter().next().unwrap();
+                    let planets = state.collect_planet_candidates();
+                    state.drop_container = DropStorageContainerInput::PickPlanet {
+                        manny_id, manny_name, container_id, container_name,
+                        planets, selection: 0, error: None,
+                    };
+                } else {
+                    state.drop_container = DropStorageContainerInput::PickContainer {
+                        manny_id, manny_name, containers, selection: 0,
+                    };
                 }
             }
         }

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -3,12 +3,12 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{
-    fetch_deploy, fetch_detach, fetch_drop_manny_cargo,
+    fetch_deploy, fetch_detach, fetch_drop_manny_cargo, fetch_drop_storage_container,
     fetch_inspect, fetch_recall,
     fetch_recover, fetch_rename_manny, fetch_salvage,
 };
 use crate::app::{
-    ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput,
+    ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput,
     InspectInput, RecallInput,
     RecoverInput, RenameMannyInput, SalvageInput, DETACH_MODES,
 };
@@ -78,6 +78,77 @@ pub(super) fn handle_recall_event(
             fetch_recall(manny_id, client.clone(), tx.clone());
         }
         _ => {}
+    }
+}
+
+pub(super) fn handle_drop_container_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match &state.drop_container {
+        DropStorageContainerInput::PickContainer { selection, containers, .. } => {
+            let (sel, count) = (*selection, containers.len());
+            match code {
+                KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(ns) = list_nav(code, sel, count) {
+                        if let DropStorageContainerInput::PickContainer { selection, .. } =
+                            &mut state.drop_container
+                        {
+                            *selection = ns;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let (manny_id, manny_name, container_id, container_name) = {
+                        let DropStorageContainerInput::PickContainer {
+                            manny_id, manny_name, containers, selection,
+                        } = &state.drop_container else { return };
+                        let (id, name) = containers[*selection].clone();
+                        (manny_id.clone(), manny_name.clone(), id, name)
+                    };
+                    let planets = state.collect_planet_candidates();
+                    if planets.is_empty() {
+                        state.drop_container = DropStorageContainerInput::Inactive;
+                        state.error = Some("no planet in current sector — scan first".into());
+                        return;
+                    }
+                    state.drop_container = DropStorageContainerInput::PickPlanet {
+                        manny_id, manny_name, container_id, container_name,
+                        planets, selection: 0, error: None,
+                    };
+                }
+                _ => {}
+            }
+        }
+        DropStorageContainerInput::PickPlanet { selection, planets, .. } => {
+            let (sel, count) = (*selection, planets.len());
+            match code {
+                KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(ns) = list_nav(code, sel, count) {
+                        if let DropStorageContainerInput::PickPlanet { selection, .. } =
+                            &mut state.drop_container
+                        {
+                            *selection = ns;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let (manny_id, container_id, planet_id) = {
+                        let DropStorageContainerInput::PickPlanet {
+                            manny_id, container_id, planets, selection, ..
+                        } = &state.drop_container else { return };
+                        (manny_id.clone(), container_id.clone(), planets[*selection].0.clone())
+                    };
+                    fetch_drop_storage_container(manny_id, container_id, planet_id, client.clone(), tx.clone());
+                }
+                _ => {}
+            }
+        }
+        DropStorageContainerInput::Inactive => {}
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,9 @@ use neumann_cockpit::api::client::ApiClient;
 use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies};
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
-    DetachInput, DropCargoInput, InspectInput, JettisonInput, MineInput, Phosphor, RecallInput,
-    RecoverInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
-    StorageMoveInput, UiTheme,
+    DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput, MineInput,
+    Phosphor, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput, RepairInput,
+    SalvageInput, StorageMoveInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -243,6 +243,18 @@ async fn run(
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::DropMannyCargoError(e) => state.set_drop_cargo_error(e),
+                    ApiMessage::DropStorageContainerStarted(manny) => {
+                        if let Some(ref mut mannies) = state.mannies {
+                            if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
+                                *m = manny;
+                            }
+                        }
+                        state.drop_container = DropStorageContainerInput::Inactive;
+                        state.set_toast("drop container order sent");
+                        // Container + drop kit leave the inventory.
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::DropStorageContainerError(e) => state.set_drop_container_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {

--- a/src/ui/overlays/drop_container.rs
+++ b/src/ui/overlays/drop_container.rs
@@ -1,0 +1,23 @@
+use crate::app::{AppState, DropStorageContainerInput};
+use ratatui::{layout::Rect, Frame};
+
+use super::render_pick_list;
+
+pub(crate) fn render_drop_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match &state.drop_container {
+        DropStorageContainerInput::Inactive => {}
+        DropStorageContainerInput::PickContainer { containers, selection, .. } => {
+            let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
+            let height = (containers.len() as u16 + 6).min(18);
+            render_pick_list(frame, area, " DROP CONTAINER — SELECT CONTAINER ", 54, height,
+                None, &names, *selection, None, "select");
+        }
+        DropStorageContainerInput::PickPlanet { container_name, planets, selection, error, .. } => {
+            let names: Vec<&str> = planets.iter().map(|(_, n)| n.as_str()).collect();
+            let height = (planets.len() as u16 + 7).min(18);
+            let prompt = format!("Drop {container_name} on planet:");
+            render_pick_list(frame, area, " DROP CONTAINER — SELECT PLANET ", 54, height,
+                Some(&prompt), &names, *selection, error.as_deref(), "drop");
+        }
+    }
+}

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -88,6 +88,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("n", "rename"),
         help_key_line("R", "recall (busy manny)"),
         help_key_line("X", "drop cargo (waiting manny)"),
+        help_key_line("P", "drop container on planet"),
         Line::default(),
         help_section("Scanner (focused)"),
         help_key_line("Enter", "rescan current sector"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod alerts;
 pub(crate) mod containers;
 pub(crate) mod craft;
+pub(crate) mod drop_container;
 pub(crate) mod help;
 pub(crate) mod inventory_detail;
 pub(crate) mod jettison;
@@ -19,6 +20,7 @@ pub(crate) use containers::{
     render_rename_container_overlay,
 };
 pub(crate) use craft::{render_atomic_printer_craft_overlay, render_craft_overlay};
+pub(crate) use drop_container::render_drop_container_overlay;
 pub(crate) use help::render_help_overlay;
 pub(crate) use inventory_detail::render_inventory_detail_overlay;
 pub(crate) use jettison::render_jettison_overlay;
@@ -37,7 +39,8 @@ pub(crate) use waypoints::render_waypoints_overlay;
 
 use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
-    CraftInput, DeployInput, DetachInput, DropCargoInput, InspectInput, JettisonInput, MineInput,
+    CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput,
+    JettisonInput, MineInput,
     ObjectActionInput, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
     RepairInput, SalvageInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
@@ -103,6 +106,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.detach, DetachInput::Inactive) {
         render_detach_overlay(frame, area, state);
+    }
+    if !matches!(state.drop_container, DropStorageContainerInput::Inactive) {
+        render_drop_container_overlay(frame, area, state);
     }
     if !matches!(state.object_action, ObjectActionInput::Inactive) {
         render_object_action_overlay(frame, area, state);

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -51,6 +51,11 @@ pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppSta
                 spans.push(Span::styled("[D]", Style::default().fg(Color::Cyan)));
                 spans.push(Span::raw(" detach"));
             }
+            if has_detachable && state.has_atmospheric_drop_kit() {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled("[P]", Style::default().fg(Color::Cyan)));
+                spans.push(Span::raw(" drop on planet"));
+            }
             if has_detached {
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled("[v]", Style::default().fg(Color::Cyan)));


### PR DESCRIPTION
## Bloc 5b — drop storage container on a planet (migration v47)

Adds `POST /api/probe/mannies/{id}/drop-storage-container`: assign an idle
onboard Manny to drop an additional storage container onto a planet in the
current sector. Consumes an `atmospheric_drop_kit`; the container, its
contents, and its routing rules leave the probe inventory.

### UI (`[P]` in the Mannies panel)
- Two-step picker: **container → planet**.
- The hint shows only when a detachable container **and** a drop kit are
  present; the entry point additionally requires a planet in the sector
  (otherwise a clear error is shown).
- On success the actor Manny is refreshed and `fetch_all()` reloads the
  inventory (container + kit consumed).

### Implementation
- Reuses `collect_detachable_containers()` (additional containers) for the
  container step.
- Adds `collect_planet_candidates()` (sector objects of type `planet`) and
  `has_atmospheric_drop_kit()` to `app/containers.rs` — `collect_planet_candidates`
  was earmarked for this bloc in the roadmap and deferred from bloc 3.
- Field names (`containerId`, `planetId`) verified against `api-specs/v44.yaml`.
  No new deserialized types (response is `{manny}`).

### Validation
- `cargo test` — 130 passed
- `cargo clippy --all-targets` — 0 errors

Depends on blocs 1 + 3 (both merged).
