### PR TITLE
ci: run cargo test in the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
+      - name: Test
+        run: cargo test
+
       - name: Build release
         run: cargo build --release


### PR DESCRIPTION
## What

Adds a `cargo test` step to the CI workflow, after Clippy and before the release build.

## Why

The CI job only ran `check` + `clippy` + `build release`. The ~130 existing tests (`app/tests.rs`, `serde_types.rs`, `input/geometry.rs`, `retro/tests.rs`) were never executed in CI, so test regressions could merge silently.

## Verification

`cargo test` locally: **130 passed** (4 suites).