### PR TITLE
feat(mannies): deuterium refuel station (bloc B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,5 +152,6 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 | `/api/crafting-recipes` | GET | ✓ |
 | `/api/sector` | GET | ✓ |
 | `/api/probe/visited-sectors` | GET | ✓ |
-| `/api/probe/mannies/{id}/drop-storage-container` | POST | ✗ (bloc 5b, in review) |
+| `/api/probe/mannies/{id}/drop-storage-container` | POST | ✓ |
+| `/api/probe/mannies/{id}/refill-deuterium-tank` | POST | ✓ |
 | `/api/probe/messages` | GET/POST | ✗ (not implemented) |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -247,6 +247,16 @@ impl ApiClient {
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
     }
 
+    /// Start a one-minute Manny task that refills the probe deuterium tank
+    /// (`POST /api/probe/mannies/{id}/refill-deuterium-tank`). Requires a
+    /// deuterium refuel station in the current sector.
+    pub async fn refill_deuterium_tank(&self, manny_id: &str) -> Result<Manny> {
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/refill-deuterium-tank");
+        Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
+    }
+
     pub async fn rename_manny(&self, manny_id: &str, name: &str) -> Result<Manny> {
         #[derive(Serialize)]
         struct Body<'a> { name: &'a str }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -352,6 +352,16 @@ pub fn fetch_drop_manny_cargo(manny_id: String, client: ApiClient, tx: mpsc::Sen
     });
 }
 
+pub fn fetch_refill_deuterium(manny_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.refill_deuterium_tank(&manny_id).await {
+            Ok(_) => ApiMessage::DeuteriumRefuelStarted,
+            Err(e) => ApiMessage::DeuteriumRefuelError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
 pub fn fetch_rename_manny(manny_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
         let msg = match client.rename_manny(&manny_id, &name).await {

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -274,6 +274,18 @@ pub enum RecallInput {
 }
 
 #[derive(Default)]
+pub enum RefuelInput {
+    #[default]
+    Inactive,
+    /// Confirmation to send a Manny to refill the probe deuterium tank.
+    Confirm {
+        manny_id: String,
+        manny_name: String,
+        error: Option<String>,
+    },
+}
+
+#[derive(Default)]
 pub enum RenameMannyInput {
     #[default]
     Inactive,

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -99,6 +99,23 @@ impl AppState {
         }
     }
 
+    pub fn set_refuel_error(&mut self, msg: String) {
+        if let RefuelInput::Confirm { ref mut error, .. } = self.refuel {
+            *error = Some(msg);
+        }
+    }
+
+    /// True when the probe's current sector exposes a deuterium refuel station.
+    pub fn deuterium_station_in_current_sector(&self) -> bool {
+        self.probe_current_sector_scan()
+            .and_then(|s| s.objects.as_ref())
+            .is_some_and(|objects| {
+                objects.iter().any(|o| {
+                    matches!(o.object_type, SectorObjectType::DeuteriumRefuelStation)
+                })
+            })
+    }
+
     pub fn collect_mineable_candidates(&self) -> Vec<(String, String)> {
         let sector = self.probe_current_sector_scan();
         sector

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -51,6 +51,8 @@ pub enum ApiMessage {
     StorageMoveError(String),
     DropMannyCargoStarted(Manny),
     DropMannyCargoError(String),
+    DeuteriumRefuelStarted,
+    DeuteriumRefuelError(String),
     DropStorageContainerStarted(Manny),
     DropStorageContainerError(String),
     Error(String),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -89,6 +89,7 @@ pub struct AppState {
     pub atomic_printer_craft: AtomicPrinterCraftInput,
     pub salvage: SalvageInput,
     pub recall: RecallInput,
+    pub refuel: RefuelInput,
     pub deploy: DeployInput,
     pub rename_manny: RenameMannyInput,
     pub inspect: InspectInput,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -813,6 +813,42 @@ fn collect_mineable_candidates_returns_asteroid_targets() {
 }
 
 #[test]
+fn deuterium_station_detected_in_current_sector() {
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(2., 0., -2.));
+    state.scan_history = vec![make_sector_with_objects(2., 0., -2., r#"[
+        {
+            "id": "station-1", "type": "deuterium_refuel_station", "name": "Refuel Stop",
+            "estimated": null, "summary": null, "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+            "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+            "capacity": null, "capacityUnit": null,
+            "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
+        }
+    ]"#)];
+    assert!(state.deuterium_station_in_current_sector());
+}
+
+#[test]
+fn deuterium_station_absent_in_current_sector() {
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+        {
+            "id": "planet-1", "type": "planet", "name": "P1",
+            "estimated": null, "summary": null, "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+            "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+            "capacity": null, "capacityUnit": null,
+            "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
+        }
+    ]"#)];
+    assert!(!state.deuterium_station_in_current_sector());
+}
+
+#[test]
 fn collect_mineable_candidates_unnamed_fallback() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -12,8 +12,8 @@ use crate::app::{
     AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
     ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput,
     DropStorageContainerInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel,
-    RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
-    ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
+    RecallInput, RecoverInput, RefuelInput, RenameContainerInput, RenameMannyInput, RepairInput,
+    SalvageInput, ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
 };
 mod alerts;
 mod containers;
@@ -40,7 +40,7 @@ use mine::handle_mine_event;
 use pickers::{
     handle_deploy_event, handle_detach_event, handle_drop_cargo_event,
     handle_drop_container_event, handle_inspect_event, handle_recall_event, handle_recover_event,
-    handle_rename_manny_event, handle_salvage_event,
+    handle_refuel_event, handle_rename_manny_event, handle_salvage_event,
 };
 use repair::handle_repair_event;
 use scanner::{handle_object_action_event, handle_waypoints_event};
@@ -66,6 +66,7 @@ pub fn handle_event(
     let in_atomic_craft = !matches!(state.atomic_printer_craft, AtomicPrinterCraftInput::Inactive);
     let in_salvage = !matches!(state.salvage, SalvageInput::Inactive);
     let in_recall = !matches!(state.recall, RecallInput::Inactive);
+    let in_refuel = !matches!(state.refuel, RefuelInput::Inactive);
     let in_rename_manny = !matches!(state.rename_manny, RenameMannyInput::Inactive);
     let in_deploy = !matches!(state.deploy, DeployInput::Inactive);
     let in_inspect = !matches!(state.inspect, InspectInput::Inactive);
@@ -136,6 +137,11 @@ pub fn handle_event(
 
     if in_recall {
         handle_recall_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_refuel {
+        handle_refuel_event(k.code, state, client, tx);
         return;
     }
 
@@ -527,6 +533,25 @@ pub fn handle_event(
                         };
                     }
                 }
+            }
+        }
+        KeyCode::Char('F') if state.focused == Some(Panel::Mannies) => {
+            if state.deuterium_station_in_current_sector() {
+                if let Some(mannies) = &state.mannies {
+                    if let Some(manny) = mannies.get(state.mannies_selection) {
+                        if manny.can_receive_orders {
+                            state.refuel = RefuelInput::Confirm {
+                                manny_id: manny.id.clone(),
+                                manny_name: manny.name.clone(),
+                                error: None,
+                            };
+                        } else {
+                            state.error = Some("manny is not available for orders".into());
+                        }
+                    }
+                }
+            } else {
+                state.error = Some("no deuterium refuel station in this sector".into());
             }
         }
         KeyCode::Char('n') if state.focused == Some(Panel::Mannies) => {

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -4,12 +4,12 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::{
     fetch_deploy, fetch_detach, fetch_drop_manny_cargo, fetch_drop_storage_container,
-    fetch_inspect, fetch_recall,
+    fetch_inspect, fetch_recall, fetch_refill_deuterium,
     fetch_recover, fetch_rename_manny, fetch_salvage,
 };
 use crate::app::{
     ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput,
-    InspectInput, RecallInput,
+    InspectInput, RecallInput, RefuelInput,
     RecoverInput, RenameMannyInput, SalvageInput, DETACH_MODES,
 };
 use super::geometry::list_nav;
@@ -76,6 +76,25 @@ pub(super) fn handle_recall_event(
                 manny_id.clone()
             };
             fetch_recall(manny_id, client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn handle_refuel_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match code {
+        KeyCode::Esc | KeyCode::Char('n') => state.refuel = RefuelInput::Inactive,
+        KeyCode::Enter | KeyCode::Char('y') => {
+            let manny_id = {
+                let RefuelInput::Confirm { ref manny_id, .. } = state.refuel else { return };
+                manny_id.clone()
+            };
+            fetch_refill_deuterium(manny_id, client.clone(), tx.clone());
         }
         _ => {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_r
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
     DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput, MineInput,
-    Phosphor, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput, RepairInput,
-    SalvageInput, StorageMoveInput, UiTheme,
+    Phosphor, RecallInput, RecoverInput, RefuelInput, RenameContainerInput, RenameMannyInput,
+    RepairInput, SalvageInput, StorageMoveInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -160,6 +160,12 @@ async fn run(
                         fetch_mannies(client.clone(), tx.clone());
                     }
                     ApiMessage::RecallError(e) => state.set_recall_error(e),
+                    ApiMessage::DeuteriumRefuelStarted => {
+                        state.refuel = RefuelInput::Inactive;
+                        state.set_toast("refuel order sent");
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::DeuteriumRefuelError(e) => state.set_refuel_error(e),
                     ApiMessage::DeployStarted => {
                         state.deploy = DeployInput::Inactive;
                         state.set_toast("waypoint deploy order sent");

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -86,6 +86,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("D", "detach container"),
         help_key_line("v", "recover container"),
         help_key_line("n", "rename"),
+        help_key_line("F", "refuel deuterium (at station)"),
         help_key_line("R", "recall (busy manny)"),
         help_key_line("X", "drop cargo (waiting manny)"),
         help_key_line("P", "drop container on planet"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use mine::render_mine_overlay;
 pub(crate) use object_actions::render_object_action_overlay;
 pub(crate) use pickers::{
     render_deploy_overlay, render_detach_overlay, render_drop_cargo_overlay, render_inspect_overlay,
-    render_recall_overlay, render_recover_overlay, render_rename_manny_overlay,
+    render_recall_overlay, render_recover_overlay, render_refuel_overlay, render_rename_manny_overlay,
     render_salvage_overlay,
 };
 pub(crate) use repair::render_repair_overlay;
@@ -41,8 +41,8 @@ use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
     CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput,
     JettisonInput, MineInput,
-    ObjectActionInput, RecallInput, RecoverInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, StorageMoveInput, TravelInput, WaypointsInput,
+    ObjectActionInput, RecallInput, RecoverInput, RefuelInput, RenameContainerInput,
+    RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -88,6 +88,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.recall, RecallInput::Inactive) {
         render_recall_overlay(frame, area, state);
+    }
+    if !matches!(state.refuel, RefuelInput::Inactive) {
+        render_refuel_overlay(frame, area, state);
     }
     if !matches!(state.drop_cargo, DropCargoInput::Inactive) {
         render_drop_cargo_overlay(frame, area, state);

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, RecallInput, RecoverInput, RenameMannyInput, SalvageInput};
+use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -144,6 +144,50 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         Paragraph::new(Line::from(vec![
             Span::styled("[Enter]", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
             Span::raw(" RECALL  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
+}
+
+pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let RefuelInput::Confirm { ref manny_name, ref error, .. } = state.refuel else { return };
+
+    let popup = centered_rect(50, 7, area);
+    frame.render_widget(Clear, popup);
+
+    let title = format!(" REFUEL — {manny_name} ");
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Green));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        "Refill the probe deuterium tank?",
+        Style::default().fg(Color::White),
+    )));
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(Color::Red),
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" REFUEL  "),
             Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
             Span::raw(" cancel"),
         ])),

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -64,6 +64,11 @@ pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppSta
             spans.push(Span::raw("  "));
             spans.push(Span::styled("[n]", Style::default().fg(Color::Cyan)));
             spans.push(Span::raw(" rename"));
+            if state.deuterium_station_in_current_sector() {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled("[F]", Style::default().fg(Color::Green)));
+                spans.push(Span::raw(" refuel"));
+            }
             if is_busy {
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled("[R]", Style::default().fg(Color::Yellow)));


### PR DESCRIPTION
## What

Bloc B of the v44 → v61 catch-up. Adds the deuterium refuel Manny action.

- New endpoint: `POST /api/probe/mannies/{id}/refill-deuterium-tank`
- `[F]` in the Mannies panel → confirmation overlay → refuel order. The hint and key are gated on a `deuterium_refuel_station` being present in the probe's current sector and the selected Manny being available.
- Toast on success + `fetch_all` to refresh the fuel gauge; API errors (manny busy 409, no station 422) surface inline.
- Doc: marks the endpoint done in CLAUDE.md and corrects the stale `drop-storage-container` row (✗ → ✓, merged in #65).

## Why

Deuterium stations were added server-side in v48–v49. Bloc A made the station object type and `refilling_deuterium_tank` task render; this bloc lets the player actually trigger a refill.

## Verification

`cargo clippy -- -D warnings` clean · `cargo test` → 137 passed (+2 unit tests on `deuterium_station_in_current_sector`).