### PR TITLE
feat(probe): mind-snapshot reassign (bloc C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 - Storage containers (`[C]` in Inventory) — container browser with capacity bars; `Enter` content view, `[n]` rename, `[e]` routing-rules editor (cycle each type none → priority → exclusion → strict)
 - Storage move (`[M]` in Inventory) — pick actor manny → kind (resource / item) → source/destination + amount, or multi-select items + destination
 - Drop cargo (`[X]` on a Manny waiting for space) — one-step confirmation (resource cargo is lost)
+- Mind-snapshot reassign (`Ctrl+R`, only when the probe is dead or trapped by a black hole — `probe.alert` present) — confirmation; reassigns the mind snapshot to a fresh probe and resets the local frame to 0,0,0
 - Waypoints (`[w]`) — known destinations from scan history (bookmarks, stars, minable), `Enter` → travel confirmation
 - Inventory detail (`Enter` in inventory) — read-only detail of the selected row
 - Map (`[b]`) — isometric sector overview: pan (`[hjkl/←↓↑→]`), `[u/d]` y±1, `[0]` recenter on probe, `[c]` jump to coords, `[g]` travel to center; info line (distance, ETA, sector summary) + legend; visited-but-unscanned sectors shown as `○`
@@ -126,6 +127,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 | `/api/probe` | GET | ✓ |
 | `/api/probe/mannies` | GET | ✓ |
 | `/api/probe/sector` | GET | ✓ |
+| `/api/probe/mind-snapshot/reassign` | POST | ✓ |
 | `/api/probe/move` | POST | ✓ |
 | `/api/probe/mannies/{id}/repair` | POST | ✓ |
 | `/api/probe/mannies/{id}/mine` | POST | ✓ |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -257,6 +257,19 @@ impl ApiClient {
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
     }
 
+    /// Reassign the player's mind snapshot to a fresh probe chassis
+    /// (`POST /api/probe/mind-snapshot/reassign`). Only valid when the current
+    /// probe is dead or trapped by a black hole; resets the local reference
+    /// frame to 0,0,0 and returns the new probe.
+    pub async fn reassign_mind_snapshot(&self) -> Result<Probe> {
+        #[derive(Deserialize)]
+        struct Resp { probe: Probe }
+        Ok(self
+            .post::<Resp, _>("/api/probe/mind-snapshot/reassign", &serde_json::json!({}))
+            .await?
+            .probe)
+    }
+
     pub async fn rename_manny(&self, manny_id: &str, name: &str) -> Result<Manny> {
         #[derive(Serialize)]
         struct Body<'a> { name: &'a str }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -362,6 +362,16 @@ pub fn fetch_refill_deuterium(manny_id: String, client: ApiClient, tx: mpsc::Sen
     });
 }
 
+pub fn fetch_reassign_mind_snapshot(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.reassign_mind_snapshot().await {
+            Ok(probe) => ApiMessage::MindSnapshotReassigned(probe),
+            Err(e) => ApiMessage::MindSnapshotReassignError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
 pub fn fetch_rename_manny(manny_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
         let msg = match client.rename_manny(&manny_id, &name).await {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -25,6 +25,7 @@ pub enum ProbeStatus {
     Orbiting,
     Disabled,
     Dead,
+    TrappedByBlackHole,
     #[serde(other)]
     Unknown,
 }
@@ -411,6 +412,29 @@ pub struct Probe {
     pub movement: Option<ProbeMovement>,
     pub systems: Option<ProbeSystems>,
     pub inventory: ProbeInventory,
+    /// Critical recovery alert raised when the probe is dead or trapped by a
+    /// black hole, carrying the mind-snapshot reassignment action.
+    #[serde(default)]
+    pub alert: Option<ProbeTerminalAlert>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeTerminalAlert {
+    #[serde(rename = "type")]
+    pub alert_type: String,
+    pub severity: String,
+    pub title: String,
+    pub message: String,
+    pub action: ProbeTerminalAlertAction,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeTerminalAlertAction {
+    pub label: String,
+    pub method: String,
+    pub endpoint: String,
 }
 
 // ── Mannies list ──────────────────────────────────────────────────────────────

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -286,6 +286,15 @@ pub enum RefuelInput {
 }
 
 #[derive(Default)]
+pub enum MindSnapshotInput {
+    #[default]
+    Inactive,
+    /// Confirmation for the irreversible mind-snapshot reassignment to a fresh
+    /// probe (only offered when the probe is dead or trapped by a black hole).
+    Confirm { error: Option<String> },
+}
+
+#[derive(Default)]
 pub enum RenameMannyInput {
     #[default]
     Inactive,

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -105,6 +105,17 @@ impl AppState {
         }
     }
 
+    pub fn set_mind_snapshot_error(&mut self, msg: String) {
+        if let MindSnapshotInput::Confirm { ref mut error } = self.mind_snapshot {
+            *error = Some(msg);
+        }
+    }
+
+    /// The probe's terminal recovery alert (dead / black-hole), if any.
+    pub fn probe_terminal_alert(&self) -> Option<&crate::api::types::ProbeTerminalAlert> {
+        self.probe.as_ref().and_then(|p| p.alert.as_ref())
+    }
+
     /// True when the probe's current sector exposes a deuterium refuel station.
     pub fn deuterium_station_in_current_sector(&self) -> bool {
         self.probe_current_sector_scan()

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -53,6 +53,8 @@ pub enum ApiMessage {
     DropMannyCargoError(String),
     DeuteriumRefuelStarted,
     DeuteriumRefuelError(String),
+    MindSnapshotReassigned(Probe),
+    MindSnapshotReassignError(String),
     DropStorageContainerStarted(Manny),
     DropStorageContainerError(String),
     Error(String),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -90,6 +90,7 @@ pub struct AppState {
     pub salvage: SalvageInput,
     pub recall: RecallInput,
     pub refuel: RefuelInput,
+    pub mind_snapshot: MindSnapshotInput,
     pub deploy: DeployInput,
     pub rename_manny: RenameMannyInput,
     pub inspect: InspectInput,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -11,9 +11,10 @@ use crate::api::types::MannyTask;
 use crate::app::{
     AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
     ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput,
-    DropStorageContainerInput, InspectInput, JettisonInput, MineInput, ObjectActionInput, Panel,
-    RecallInput, RecoverInput, RefuelInput, RenameContainerInput, RenameMannyInput, RepairInput,
-    SalvageInput, ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
+    DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
+    ObjectActionInput, Panel, RecallInput, RecoverInput, RefuelInput, RenameContainerInput,
+    RenameMannyInput, RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput,
+    WaypointsInput,
 };
 mod alerts;
 mod containers;
@@ -39,8 +40,9 @@ use map::handle_map_event;
 use mine::handle_mine_event;
 use pickers::{
     handle_deploy_event, handle_detach_event, handle_drop_cargo_event,
-    handle_drop_container_event, handle_inspect_event, handle_recall_event, handle_recover_event,
-    handle_refuel_event, handle_rename_manny_event, handle_salvage_event,
+    handle_drop_container_event, handle_inspect_event, handle_mind_snapshot_event,
+    handle_recall_event, handle_recover_event, handle_refuel_event, handle_rename_manny_event,
+    handle_salvage_event,
 };
 use repair::handle_repair_event;
 use scanner::{handle_object_action_event, handle_waypoints_event};
@@ -67,6 +69,7 @@ pub fn handle_event(
     let in_salvage = !matches!(state.salvage, SalvageInput::Inactive);
     let in_recall = !matches!(state.recall, RecallInput::Inactive);
     let in_refuel = !matches!(state.refuel, RefuelInput::Inactive);
+    let in_mind_snapshot = !matches!(state.mind_snapshot, MindSnapshotInput::Inactive);
     let in_rename_manny = !matches!(state.rename_manny, RenameMannyInput::Inactive);
     let in_deploy = !matches!(state.deploy, DeployInput::Inactive);
     let in_inspect = !matches!(state.inspect, InspectInput::Inactive);
@@ -142,6 +145,11 @@ pub fn handle_event(
 
     if in_refuel {
         handle_refuel_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_mind_snapshot {
+        handle_mind_snapshot_event(k.code, state, client, tx);
         return;
     }
 
@@ -272,6 +280,9 @@ pub fn handle_event(
 
     match k.code {
         KeyCode::Char('q') => state.set_quit(),
+        KeyCode::Char('r') if ctrl && state.probe_terminal_alert().is_some() => {
+            state.mind_snapshot = MindSnapshotInput::Confirm { error: None };
+        }
         KeyCode::Char('A') => {
             // Open on the tab that actually has entries (warnings if alerts empty).
             let show_warnings = state.alerts.is_empty() && !state.damage_warnings.is_empty();

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -4,12 +4,12 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::{
     fetch_deploy, fetch_detach, fetch_drop_manny_cargo, fetch_drop_storage_container,
-    fetch_inspect, fetch_recall, fetch_refill_deuterium,
+    fetch_inspect, fetch_reassign_mind_snapshot, fetch_recall, fetch_refill_deuterium,
     fetch_recover, fetch_rename_manny, fetch_salvage,
 };
 use crate::app::{
     ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput,
-    InspectInput, RecallInput, RefuelInput,
+    InspectInput, MindSnapshotInput, RecallInput, RefuelInput,
     RecoverInput, RenameMannyInput, SalvageInput, DETACH_MODES,
 };
 use super::geometry::list_nav;
@@ -95,6 +95,21 @@ pub(super) fn handle_refuel_event(
                 manny_id.clone()
             };
             fetch_refill_deuterium(manny_id, client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn handle_mind_snapshot_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match code {
+        KeyCode::Esc | KeyCode::Char('n') => state.mind_snapshot = MindSnapshotInput::Inactive,
+        KeyCode::Enter | KeyCode::Char('y') => {
+            fetch_reassign_mind_snapshot(client.clone(), tx.clone());
         }
         _ => {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,9 @@ use neumann_cockpit::api::client::ApiClient;
 use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies};
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
-    DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput, MineInput,
-    Phosphor, RecallInput, RecoverInput, RefuelInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, StorageMoveInput, UiTheme,
+    DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput,
+    MindSnapshotInput, MineInput, Phosphor, RecallInput, RecoverInput, RefuelInput,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -166,6 +166,13 @@ async fn run(
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::DeuteriumRefuelError(e) => state.set_refuel_error(e),
+                    ApiMessage::MindSnapshotReassigned(probe) => {
+                        state.mind_snapshot = MindSnapshotInput::Inactive;
+                        state.update_probe(probe);
+                        state.set_toast("mind snapshot reassigned");
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::MindSnapshotReassignError(e) => state.set_mind_snapshot_error(e),
                     ApiMessage::DeployStarted => {
                         state.deploy = DeployInput::Inactive;
                         state.set_toast("waypoint deploy order sent");

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -47,6 +47,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
     let left: Vec<Line> = vec![
         help_section("Global"),
         help_key_line("r", "refresh all"),
+        help_key_line("^R", "reassign mind snapshot (dead/trapped probe)"),
         help_key_line("p i m s", "focus probe / inventory / mannies / scanner"),
         help_key_line("Tab", "cycle panel focus (Shift-Tab reverse)"),
         help_key_line("F2", "toggle retro/classic theme"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -29,8 +29,8 @@ pub(crate) use mine::render_mine_overlay;
 pub(crate) use object_actions::render_object_action_overlay;
 pub(crate) use pickers::{
     render_deploy_overlay, render_detach_overlay, render_drop_cargo_overlay, render_inspect_overlay,
-    render_recall_overlay, render_recover_overlay, render_refuel_overlay, render_rename_manny_overlay,
-    render_salvage_overlay,
+    render_mind_snapshot_overlay, render_recall_overlay, render_recover_overlay,
+    render_refuel_overlay, render_rename_manny_overlay, render_salvage_overlay,
 };
 pub(crate) use repair::render_repair_overlay;
 pub(crate) use storage_move::render_storage_move_overlay;
@@ -41,8 +41,9 @@ use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
     CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput,
     JettisonInput, MineInput,
-    ObjectActionInput, RecallInput, RecoverInput, RefuelInput, RenameContainerInput,
-    RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput, TravelInput, WaypointsInput,
+    MindSnapshotInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput,
+    TravelInput, WaypointsInput,
 };
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -91,6 +92,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.refuel, RefuelInput::Inactive) {
         render_refuel_overlay(frame, area, state);
+    }
+    if !matches!(state.mind_snapshot, MindSnapshotInput::Inactive) {
+        render_mind_snapshot_overlay(frame, area, state);
     }
     if !matches!(state.drop_cargo, DropCargoInput::Inactive) {
         render_drop_cargo_overlay(frame, area, state);

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -1,9 +1,9 @@
-use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput};
+use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, MindSnapshotInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
 };
 
@@ -188,6 +188,64 @@ pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         Paragraph::new(Line::from(vec![
             Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
             Span::raw(" REFUEL  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
+}
+
+pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let MindSnapshotInput::Confirm { ref error } = state.mind_snapshot else { return };
+    let alert = state.probe_terminal_alert();
+
+    let popup = centered_rect(60, 10, area);
+    frame.render_widget(Clear, popup);
+
+    let title = alert
+        .map(|a| format!(" {} ", a.title))
+        .unwrap_or_else(|| " MIND SNAPSHOT REASSIGN ".to_string());
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = Vec::new();
+    if let Some(a) = alert {
+        lines.push(Line::from(Span::styled(
+            a.message.clone(),
+            Style::default().fg(Color::White),
+        )));
+        lines.push(Line::default());
+    }
+    lines.push(Line::from(Span::styled(
+        "Reassign your mind snapshot to a fresh probe?",
+        Style::default().fg(Color::White),
+    )));
+    lines.push(Line::from(Span::styled(
+        "The terminal probe is deleted and the local reference frame resets to 0,0,0.",
+        Style::default().fg(Color::DarkGray),
+    )));
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(Color::Red),
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Enter]", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Span::raw(" REASSIGN  "),
             Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
             Span::raw(" cancel"),
         ])),

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -80,16 +80,20 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     } else {
         Span::raw("")
     };
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(&probe.name, Style::default().add_modifier(Modifier::BOLD)),
-            Span::raw("  "),
-            Span::styled(probe_status_label(&probe.status), probe_status_style(&probe.status)),
-            alert_badge,
-            Span::styled(spinner, Style::default().fg(Color::DarkGray)),
-        ])),
-        rows[row],
-    );
+    let mut status_spans = vec![
+        Span::styled(&probe.name, Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("  "),
+        Span::styled(probe_status_label(&probe.status), probe_status_style(&probe.status)),
+        alert_badge,
+        Span::styled(spinner, Style::default().fg(Color::DarkGray)),
+    ];
+    if state.probe_terminal_alert().is_some() {
+        status_spans.push(Span::styled(
+            "  [^R reassign]",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ));
+    }
+    frame.render_widget(Paragraph::new(Line::from(status_spans)), rows[row]);
     row += 1;
 
     // ── Current sector ──

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -124,6 +124,7 @@ pub(crate) fn probe_status_label(s: &ProbeStatus) -> &'static str {
         ProbeStatus::Orbiting => "orbiting",
         ProbeStatus::Disabled => "disabled",
         ProbeStatus::Dead => "DEAD",
+        ProbeStatus::TrappedByBlackHole => "TRAPPED",
         ProbeStatus::Unknown => "?",
     }
 }
@@ -137,7 +138,9 @@ pub(crate) fn probe_status_style(s: &ProbeStatus) -> Style {
         }
         ProbeStatus::Cruising => Style::default().fg(Color::Cyan),
         ProbeStatus::Disabled => Style::default().fg(Color::Red),
-        ProbeStatus::Dead => Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ProbeStatus::Dead | ProbeStatus::TrappedByBlackHole => {
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+        }
         ProbeStatus::Unknown => Style::default().fg(Color::DarkGray),
     }
 }

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -617,3 +617,42 @@ fn new_sector_object_types_deserialize() {
     );
     assert_eq!(deser::<SectorObjectType>(r#""scut_relay""#), SectorObjectType::ScutRelay);
 }
+
+#[test]
+fn trapped_probe_status_deserializes() {
+    assert_eq!(
+        deser::<ProbeStatus>(r#""trapped_by_black_hole""#),
+        ProbeStatus::TrappedByBlackHole
+    );
+}
+
+#[test]
+fn dead_probe_with_terminal_alert_deserializes() {
+    let json = r#"{
+      "id": 7, "name": "Von Neumann #7", "status": "dead",
+      "fuel": { "deuterium": 0.0 }, "sensorMode": "blind",
+      "sector": null, "movement": null, "systems": null,
+      "alert": {
+        "type": "mind_snapshot_reassignment_available",
+        "severity": "critical",
+        "title": "Probe lost",
+        "message": "Your probe is gone. Reassign your mind snapshot.",
+        "action": { "label": "Reassign", "method": "POST", "endpoint": "/api/probe/mind-snapshot/reassign" }
+      },
+      "inventory": {
+        "capacity": 10.0, "usedCapacity": 0.0, "freeCapacity": 10.0,
+        "items": [], "resourceStocks": [], "externalTanks": [], "containers": []
+      }
+    }"#;
+    let probe: Probe = deser(json);
+    assert_eq!(probe.status, ProbeStatus::Dead);
+    let alert = probe.alert.expect("terminal alert present");
+    assert_eq!(alert.severity, "critical");
+    assert_eq!(alert.action.endpoint, "/api/probe/mind-snapshot/reassign");
+}
+
+#[test]
+fn probe_without_alert_defaults_to_none() {
+    let probe: Probe = deser(PROBE_JSON);
+    assert!(probe.alert.is_none());
+}


### PR DESCRIPTION
## What

Bloc C of the v44 → v61 catch-up — recovery from a terminal probe state.

- `ProbeStatus::TrappedByBlackHole` (previously fell back to `Unknown`)
- New `probe.alert` field (`ProbeTerminalAlert` + action) on the probe response
- `[^R reassign]` badge on the probe panel whenever `probe.alert` is present
- `Ctrl+R` → confirmation overlay → `POST /api/probe/mind-snapshot/reassign`; on success the fresh probe replaces state, local frame resets to 0,0,0, full refetch runs. API errors surface inline.

## Why

Before this, a dead or black-hole-trapped probe left the client with no way out — the whole cockpit was inert. This is the recovery path (server-side since v32/v36).

## Verification

`cargo clippy -- -D warnings` clean · `cargo test` → 138 passed (+3 serde tests: trapped status, probe-with-alert, default no-alert).