### PR TITLE
feat(missions): list & abandon probe missions (bloc D)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Single `tokio::select!` loop over three sources:
 
 The timer deadline is set to `movement.arrival_at` (ISO 8601) converted to a `tokio::time::Instant`. When no movement is in progress the deadline is 24 h away — no polling, no tick loop.
 
-`fetch_all()` spawns **six** independent `tokio::spawn` tasks: probe, mannies, sector, visited sectors, alerts, and damage warnings. All but probe are non-fatal.
+`fetch_all()` spawns **seven** independent `tokio::spawn` tasks: probe, mannies, sector, visited sectors, alerts, damage warnings, and missions. All but probe are non-fatal.
 
 All other API calls (move, repair, mine, craft, storage container CRUD, storage moves, etc.) are also spawned tasks that send results back via the `mpsc::Sender<ApiMessage>`. Keyboard handlers live in `src/input/` (`mod.rs` holds `handle_event` — overlay dispatch + global key match; one module per wizard handler — `pickers.rs` groups the manny pick-list/confirm ones, `containers.rs` the storage-container ones, `storage_move.rs`, `alerts.rs`, `geometry.rs` for the scan offset helpers); fetch spawners live in `src/api/tasks.rs`. `main.rs` only contains the select loop and the `ApiMessage` dispatch (which also sets the success toasts).
 
@@ -110,6 +110,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 - Deploy waypoint — 3-step wizard: pick manny → pick object → enter bookmark name
 - Object actions — action picker for the selected scanner object (+ manny picker when several idle)
 - Alerts (`[A]`) — tabbed Alerts / Damage-warnings list, `Tab` switches tab, `Enter` marks read; `[!]` badge on the probe panel + status bar when unread
+- Missions (`[O]`) — active-mission list with steps and status; `[a]` abandons the selected active mission (confirmation sub-popup)
 - Storage containers (`[C]` in Inventory) — container browser with capacity bars; `Enter` content view, `[n]` rename, `[e]` routing-rules editor (cycle each type none → priority → exclusion → strict)
 - Storage move (`[M]` in Inventory) — pick actor manny → kind (resource / item) → source/destination + amount, or multi-select items + destination
 - Drop cargo (`[X]` on a Manny waiting for space) — one-step confirmation (resource cargo is lost)
@@ -156,4 +157,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 | `/api/probe/visited-sectors` | GET | ✓ |
 | `/api/probe/mannies/{id}/drop-storage-container` | POST | ✓ |
 | `/api/probe/mannies/{id}/refill-deuterium-tank` | POST | ✓ |
+| `/api/probe/missions` | GET | ✓ |
+| `/api/probe/mission` | GET | ✓ (alias) |
+| `/api/probe/missions/{id}/abandon` | POST | ✓ |
 | `/api/probe/messages` | GET/POST | ✗ (not implemented) |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,5 +1,5 @@
 use super::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
     ProbeInventory, ProbeMovement, SectorObservation, StorageContainer, VisitedSector,
 };
 use anyhow::{Context, Result};
@@ -255,6 +255,24 @@ impl ApiClient {
         struct Resp { manny: Manny }
         let path = format!("/api/probe/mannies/{manny_id}/refill-deuterium-tank");
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
+    }
+
+    /// List the probe's active missions (`GET /api/probe/missions`).
+    pub async fn get_missions(&self) -> Result<Vec<Mission>> {
+        #[derive(Deserialize)]
+        struct Resp {
+            #[serde(default)]
+            missions: Vec<Mission>,
+        }
+        Ok(self.get::<Resp>("/api/probe/missions").await?.missions)
+    }
+
+    /// Abandon an active mission (`POST /api/probe/missions/{id}/abandon`).
+    pub async fn abandon_mission(&self, mission_id: &str) -> Result<Mission> {
+        #[derive(Deserialize)]
+        struct Resp { mission: Mission }
+        let path = format!("/api/probe/missions/{mission_id}/abandon");
+        Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.mission)
     }
 
     /// Reassign the player's mind snapshot to a fresh probe chassis

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -46,9 +46,28 @@ pub fn fetch_all(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
         }
     });
 
-    // Alerts + damage warnings: non-fatal, same pattern as mannies/sector.
+    // Alerts + damage warnings + missions: non-fatal, same pattern as mannies/sector.
     fetch_alerts(client.clone(), tx.clone());
+    fetch_missions(client.clone(), tx.clone());
     fetch_damage_warnings(client, tx);
+}
+
+pub fn fetch_missions(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        if let Ok(m) = client.get_missions().await {
+            let _ = tx.send(ApiMessage::MissionsFetched(m)).await;
+        }
+    });
+}
+
+pub fn fetch_abandon_mission(mission_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.abandon_mission(&mission_id).await {
+            Ok(m) => ApiMessage::MissionAbandoned(m),
+            Err(e) => ApiMessage::MissionAbandonError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
 }
 
 pub fn fetch_alerts(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -437,6 +437,51 @@ pub struct ProbeTerminalAlertAction {
     pub endpoint: String,
 }
 
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionStatus {
+    Active,
+    Completed,
+    Failed,
+    Abandoned,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionStepStatus {
+    Pending,
+    Completed,
+    Failed,
+    Skipped,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Mission {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub mission_type: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: MissionStatus,
+    #[serde(default)]
+    pub steps: Vec<MissionStep>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MissionStep {
+    pub id: String,
+    pub sort_order: i64,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: MissionStepStatus,
+}
+
 // ── Mannies list ──────────────────────────────────────────────────────────────
 
 // ── Crafting recipes ─────────────────────────────────────────────────────────

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -295,6 +295,21 @@ pub enum MindSnapshotInput {
 }
 
 #[derive(Default)]
+pub enum MissionsInput {
+    #[default]
+    Inactive,
+    /// Browsing the mission list; entries live in `AppState::missions`.
+    Browsing { selection: usize },
+    /// Confirmation for abandoning the selected active mission.
+    ConfirmAbandon {
+        mission_id: String,
+        mission_title: String,
+        selection: usize,
+        error: Option<String>,
+    },
+}
+
+#[derive(Default)]
 pub enum RenameMannyInput {
     #[default]
     Inactive,

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -111,6 +111,12 @@ impl AppState {
         }
     }
 
+    pub fn set_mission_abandon_error(&mut self, msg: String) {
+        if let MissionsInput::ConfirmAbandon { ref mut error, .. } = self.missions_input {
+            *error = Some(msg);
+        }
+    }
+
     /// The probe's terminal recovery alert (dead / black-hole), if any.
     pub fn probe_terminal_alert(&self) -> Option<&crate::api::types::ProbeTerminalAlert> {
         self.probe.as_ref().and_then(|p| p.alert.as_ref())

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,5 +1,5 @@
 use crate::api::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
     ProbeInventory, ProbeMovement, SectorObservation, StorageContainer, VisitedSector,
 };
 
@@ -55,6 +55,9 @@ pub enum ApiMessage {
     DeuteriumRefuelError(String),
     MindSnapshotReassigned(Probe),
     MindSnapshotReassignError(String),
+    MissionsFetched(Vec<Mission>),
+    MissionAbandoned(Mission),
+    MissionAbandonError(String),
     DropStorageContainerStarted(Manny),
     DropStorageContainerError(String),
     Error(String),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,7 +20,7 @@ pub use scan::*;
 pub use waypoints::*;
 
 use crate::api::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Probe, ProbeAlert,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
     ProbeInventory, SectorObservation, StorageContainer, VisitedSector,
 };
 use chrono::{DateTime, Local, Utc};
@@ -91,6 +91,8 @@ pub struct AppState {
     pub recall: RecallInput,
     pub refuel: RefuelInput,
     pub mind_snapshot: MindSnapshotInput,
+    pub missions: Vec<Mission>,
+    pub missions_input: MissionsInput,
     pub deploy: DeployInput,
     pub rename_manny: RenameMannyInput,
     pub inspect: InspectInput,

--- a/src/input/missions.rs
+++ b/src/input/missions.rs
@@ -1,0 +1,64 @@
+use crossterm::event::KeyCode;
+use tokio::sync::mpsc;
+
+use crate::api::tasks::fetch_abandon_mission;
+use crate::api::types::MissionStatus;
+use crate::app::{ApiMessage, AppState, MissionsInput};
+use crate::api::client::ApiClient;
+
+use super::geometry::list_nav;
+
+pub(super) fn handle_missions_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match state.missions_input {
+        MissionsInput::Browsing { selection } => {
+            let count = state.missions.len();
+            match code {
+                KeyCode::Esc | KeyCode::Char('O') | KeyCode::Char('q') => {
+                    state.missions_input = MissionsInput::Inactive;
+                }
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, selection, count) {
+                        state.missions_input = MissionsInput::Browsing { selection: new_sel };
+                    }
+                }
+                KeyCode::Char('a') => {
+                    if let Some(m) = state.missions.get(selection) {
+                        if m.status == MissionStatus::Active {
+                            state.missions_input = MissionsInput::ConfirmAbandon {
+                                mission_id: m.id.clone(),
+                                mission_title: m.title.clone(),
+                                selection,
+                                error: None,
+                            };
+                        } else {
+                            state.error = Some("only active missions can be abandoned".into());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        MissionsInput::ConfirmAbandon { selection, .. } => match code {
+            KeyCode::Esc | KeyCode::Char('n') => {
+                state.missions_input = MissionsInput::Browsing { selection };
+            }
+            KeyCode::Enter | KeyCode::Char('y') => {
+                let mission_id = {
+                    let MissionsInput::ConfirmAbandon { ref mission_id, .. } = state.missions_input
+                    else {
+                        return;
+                    };
+                    mission_id.clone()
+                };
+                fetch_abandon_mission(mission_id, client.clone(), tx.clone());
+            }
+            _ => {}
+        },
+        MissionsInput::Inactive => {}
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -12,9 +12,9 @@ use crate::app::{
     AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
     ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput,
     DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
-    ObjectActionInput, Panel, RecallInput, RecoverInput, RefuelInput, RenameContainerInput,
-    RenameMannyInput, RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput,
-    WaypointsInput,
+    MissionsInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RefuelInput,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, StorageMoveInput,
+    TravelInput, WaypointsInput,
 };
 mod alerts;
 mod containers;
@@ -23,6 +23,7 @@ mod geometry;
 mod jettison;
 mod map;
 mod mine;
+mod missions;
 mod pickers;
 mod repair;
 mod scanner;
@@ -38,6 +39,7 @@ use geometry::{face_d2, neighbors_d1};
 use jettison::handle_jettison_event;
 use map::handle_map_event;
 use mine::handle_mine_event;
+use missions::handle_missions_event;
 use pickers::{
     handle_deploy_event, handle_detach_event, handle_drop_cargo_event,
     handle_drop_container_event, handle_inspect_event, handle_mind_snapshot_event,
@@ -70,6 +72,7 @@ pub fn handle_event(
     let in_recall = !matches!(state.recall, RecallInput::Inactive);
     let in_refuel = !matches!(state.refuel, RefuelInput::Inactive);
     let in_mind_snapshot = !matches!(state.mind_snapshot, MindSnapshotInput::Inactive);
+    let in_missions = !matches!(state.missions_input, MissionsInput::Inactive);
     let in_rename_manny = !matches!(state.rename_manny, RenameMannyInput::Inactive);
     let in_deploy = !matches!(state.deploy, DeployInput::Inactive);
     let in_inspect = !matches!(state.inspect, InspectInput::Inactive);
@@ -150,6 +153,11 @@ pub fn handle_event(
 
     if in_mind_snapshot {
         handle_mind_snapshot_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_missions {
+        handle_missions_event(k.code, state, client, tx);
         return;
     }
 
@@ -289,6 +297,9 @@ pub fn handle_event(
             state.alerts_input = AlertsInput::Browsing { selection: 0, show_warnings };
         }
         KeyCode::Char('b') => state.open_map(),
+        KeyCode::Char('O') => {
+            state.missions_input = MissionsInput::Browsing { selection: 0 };
+        }
         KeyCode::Char('?') => state.help_open = true,
         KeyCode::Char('w') => {
             let entries = state.collect_waypoints();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,13 @@ use std::io;
 use tokio::sync::mpsc;
 
 use neumann_cockpit::api::client::ApiClient;
-use neumann_cockpit::api::tasks::{fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies};
+use neumann_cockpit::api::tasks::{
+    fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies, fetch_missions,
+};
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
     DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput,
-    MindSnapshotInput, MineInput, Phosphor, RecallInput, RecoverInput, RefuelInput,
+    MindSnapshotInput, MineInput, MissionsInput, Phosphor, RecallInput, RecoverInput, RefuelInput,
     RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput, UiTheme,
 };
 use neumann_cockpit::config;
@@ -173,6 +175,13 @@ async fn run(
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::MindSnapshotReassignError(e) => state.set_mind_snapshot_error(e),
+                    ApiMessage::MissionsFetched(missions) => state.missions = missions,
+                    ApiMessage::MissionAbandoned(_) => {
+                        state.missions_input = MissionsInput::Browsing { selection: 0 };
+                        state.set_toast("mission abandoned");
+                        fetch_missions(client.clone(), tx.clone());
+                    }
+                    ApiMessage::MissionAbandonError(e) => state.set_mission_abandon_error(e),
                     ApiMessage::DeployStarted => {
                         state.deploy = DeployInput::Inactive;
                         state.set_toast("waypoint deploy order sent");

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -105,6 +105,8 @@ pub(crate) fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState)
             Style::default().fg(if state.unread_alert_count() > 0 { Color::Red } else { Color::Cyan }),
         ),
         Span::raw(" alerts  "),
+        Span::styled("[O]", Style::default().fg(Color::Cyan)),
+        Span::raw(" missions  "),
         Span::styled("[?]", Style::default().fg(Color::Cyan)),
         Span::raw(" help  "),
         Span::styled("[q]", Style::default().fg(Color::Cyan)),

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -55,6 +55,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("b", "map"),
         help_key_line("w", "waypoints"),
         help_key_line("A", "alerts & damage warnings"),
+        help_key_line("O", "missions"),
         help_key_line("?", "this help"),
         help_key_line("q", "quit"),
         help_key_line("Esc", "unfocus / close"),

--- a/src/ui/overlays/missions.rs
+++ b/src/ui/overlays/missions.rs
@@ -1,0 +1,157 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::api::types::{Mission, MissionStatus, MissionStepStatus};
+use crate::app::{AppState, MissionsInput};
+
+use super::centered_rect;
+
+fn mission_status_style(s: &MissionStatus) -> (&'static str, Style) {
+    match s {
+        MissionStatus::Active => ("active", Style::default().fg(Color::Cyan)),
+        MissionStatus::Completed => ("done", Style::default().fg(Color::Green)),
+        MissionStatus::Failed => ("failed", Style::default().fg(Color::Red)),
+        MissionStatus::Abandoned => ("abandoned", Style::default().fg(Color::DarkGray)),
+        MissionStatus::Unknown => ("?", Style::default().fg(Color::DarkGray)),
+    }
+}
+
+fn step_mark(s: &MissionStepStatus) -> (&'static str, Color) {
+    match s {
+        MissionStepStatus::Pending => ("○", Color::Yellow),
+        MissionStepStatus::Completed => ("✔", Color::Green),
+        MissionStepStatus::Failed => ("✗", Color::Red),
+        MissionStepStatus::Skipped => ("–", Color::DarkGray),
+        MissionStepStatus::Unknown => ("?", Color::DarkGray),
+    }
+}
+
+fn mission_lines(m: &Mission, selected: bool) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let (status_text, status_style) = mission_status_style(&m.status);
+    let marker = if selected { "▸ " } else { "  " };
+    let title_style = if selected {
+        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    };
+    lines.push(Line::from(vec![
+        Span::styled(marker, Style::default().fg(Color::Cyan)),
+        Span::styled(m.title.clone(), title_style),
+        Span::raw("  "),
+        Span::styled(format!("[{status_text}]"), status_style),
+    ]));
+    if let Some(desc) = &m.description {
+        lines.push(Line::from(Span::styled(
+            format!("    {desc}"),
+            Style::default().fg(Color::Gray),
+        )));
+    }
+    let mut steps: Vec<&_> = m.steps.iter().collect();
+    steps.sort_by_key(|s| s.sort_order);
+    for step in steps {
+        let (mark, color) = step_mark(&step.status);
+        lines.push(Line::from(vec![
+            Span::styled(format!("    {mark} "), Style::default().fg(color)),
+            Span::styled(step.title.clone(), Style::default().fg(Color::White)),
+        ]));
+    }
+    lines
+}
+
+pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let selection = match state.missions_input {
+        MissionsInput::Browsing { selection } => selection,
+        MissionsInput::ConfirmAbandon { selection, .. } => selection,
+        MissionsInput::Inactive => return,
+    };
+
+    let popup = centered_rect(78, 80, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" MISSIONS ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::White));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines: Vec<Line> = Vec::new();
+    if state.missions.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No active missions.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        for (i, m) in state.missions.iter().enumerate() {
+            lines.extend(mission_lines(m, i == selection));
+            lines.push(Line::default());
+        }
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[↑↓]", Style::default().fg(Color::Cyan)),
+            Span::raw(" select  "),
+            Span::styled("[a]", Style::default().fg(Color::Yellow)),
+            Span::raw(" abandon  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" close"),
+        ])),
+        rows[1],
+    );
+
+    if let MissionsInput::ConfirmAbandon { ref mission_title, ref error, .. } = state.missions_input {
+        render_abandon_confirm(frame, area, mission_title, error.as_deref());
+    }
+}
+
+fn render_abandon_confirm(frame: &mut Frame, area: Rect, title: &str, error: Option<&str>) {
+    let popup = centered_rect(50, 8, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" ABANDON MISSION ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let mut lines = vec![Line::from(Span::styled(
+        format!("Abandon \"{title}\"?"),
+        Style::default().fg(Color::White),
+    ))];
+    if let Some(err) = error {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(Color::Red),
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Enter]", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::raw(" abandon  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" keep"),
+        ])),
+        rows[1],
+    );
+}

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod inventory_detail;
 pub(crate) mod jettison;
 pub(crate) mod map;
 pub(crate) mod mine;
+pub(crate) mod missions;
 pub(crate) mod object_actions;
 pub(crate) mod pickers;
 pub(crate) mod repair;
@@ -26,6 +27,7 @@ pub(crate) use inventory_detail::render_inventory_detail_overlay;
 pub(crate) use jettison::render_jettison_overlay;
 pub(crate) use map::render_map_overlay;
 pub(crate) use mine::render_mine_overlay;
+pub(crate) use missions::render_missions_overlay;
 pub(crate) use object_actions::render_object_action_overlay;
 pub(crate) use pickers::{
     render_deploy_overlay, render_detach_overlay, render_drop_cargo_overlay, render_inspect_overlay,
@@ -41,7 +43,7 @@ use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
     CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput,
     JettisonInput, MineInput,
-    MindSnapshotInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
+    MindSnapshotInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
     RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput,
     TravelInput, WaypointsInput,
 };
@@ -95,6 +97,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.mind_snapshot, MindSnapshotInput::Inactive) {
         render_mind_snapshot_overlay(frame, area, state);
+    }
+    if !matches!(state.missions_input, MissionsInput::Inactive) {
+        render_missions_overlay(frame, area, state);
     }
     if !matches!(state.drop_cargo, DropCargoInput::Inactive) {
         render_drop_cargo_overlay(frame, area, state);

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -1,6 +1,7 @@
 use neumann_cockpit::api::types::{
     AlertPhase, AlertStatus, AlertType, ContainerInventory, CraftingRecipe, DamageWarningRule,
-    DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask, MovementPhase, Probe,
+    DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask, Mission, MissionStatus,
+    MissionStepStatus, MovementPhase, Probe,
     ProbeAlert, ProbeInventory, ProbeMovement, ProbeStatus, SectorObjectType, SectorObservation,
     SensorMode, StorageContainer,
 };
@@ -655,4 +656,30 @@ fn dead_probe_with_terminal_alert_deserializes() {
 fn probe_without_alert_defaults_to_none() {
     let probe: Probe = deser(PROBE_JSON);
     assert!(probe.alert.is_none());
+}
+
+#[test]
+fn mission_with_steps_deserializes() {
+    let json = r#"{
+      "id": "mission-1",
+      "type": "first_contact.return_to_space_program",
+      "title": "First contact",
+      "description": "Deliver materials to the inhabited planet.",
+      "status": "active",
+      "stepOrder": "sequential",
+      "metadata": {},
+      "startedAt": "2026-06-06T12:00:00+00:00",
+      "createdAt": "2026-06-06T12:00:00+00:00",
+      "updatedAt": "2026-06-06T12:00:00+00:00",
+      "steps": [
+        {"id": "s2", "sortOrder": 2, "title": "Deliver carbon", "status": "pending", "metadata": {}, "createdAt": "2026-06-06T12:00:00+00:00", "updatedAt": "2026-06-06T12:00:00+00:00"},
+        {"id": "s1", "sortOrder": 1, "title": "Deliver metals", "status": "completed", "metadata": {}, "createdAt": "2026-06-06T12:00:00+00:00", "updatedAt": "2026-06-06T12:00:00+00:00"}
+      ]
+    }"#;
+    let m: Mission = deser(json);
+    assert_eq!(m.status, MissionStatus::Active);
+    assert_eq!(m.mission_type, "first_contact.return_to_space_program");
+    assert_eq!(m.steps.len(), 2);
+    assert_eq!(m.steps[0].status, MissionStepStatus::Pending);
+    assert_eq!(m.steps[1].status, MissionStepStatus::Completed);
 }


### PR DESCRIPTION
## What

Bloc D of the v44 → v61 catch-up — the mission system.

- Types `Mission` / `MissionStep` (+ `MissionStatus`, `MissionStepStatus`)
- `GET /api/probe/missions` and `POST /api/probe/missions/{id}/abandon`
- `fetch_all` now also pulls missions (non-fatal, 7th task)
- New `[O]` overlay: active-mission list with each mission's steps and status; `[a]` abandons the selected **active** mission behind a confirmation sub-popup. API errors surface inline.
- Status bar + help wiring.

## Why

Missions (incl. the first-contact `return_to_space_program` scenario) were added server-side from v35/v37. The client had no way to see or manage them.

## Verification

`cargo clippy -- -D warnings` clean · `cargo test` → 139 passed (+1 serde test on Mission with steps and statuses).