### PR TITLE
feat(scut): inspect networks & coverage (bloc E2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 - Jettison a `scut_relay` inventory item (Inventory `[j]` on the SCUT-relay group) — confirmation; deploys an inactive relay into the current sector
 - Alerts (`[A]`) — tabbed Alerts / Damage-warnings list, `Tab` switches tab, `Enter` marks read; `[!]` badge on the probe panel + status bar when unread
 - Missions (`[O]`) — active-mission list with steps and status; `[a]` abandons the selected active mission (confirmation sub-popup)
+- SCUT network (`[N]`) — inspect a network covering the current sector (`scutNetworks` in the sector scan): relays (status, position, coverage) and probes. When several networks cover the sector, a picker precedes the detail view. A `≣ SCUT` badge on the probe panel + a lit `[N]` in the status bar signal active coverage.
 - Storage containers (`[C]` in Inventory) — container browser with capacity bars; `Enter` content view, `[n]` rename, `[e]` routing-rules editor (cycle each type none → priority → exclusion → strict)
 - Storage move (`[M]` in Inventory) — pick actor manny → kind (resource / item) → source/destination + amount, or multi-select items + destination
 - Drop cargo (`[X]` on a Manny waiting for space) — one-step confirmation (resource cargo is lost)
@@ -159,6 +160,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 | `/api/probe/mannies/{id}/drop-storage-container` | POST | ✓ |
 | `/api/probe/mannies/{id}/refill-deuterium-tank` | POST | ✓ |
 | `/api/probe/mannies/{id}/turn-on-relay` | POST | ✓ |
+| `/api/probe/scut-network/{id}` | GET | ✓ |
 | `/api/probe/missions` | GET | ✓ |
 | `/api/probe/mission` | GET | ✓ (alias) |
 | `/api/probe/missions/{id}/abandon` | POST | ✓ |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,6 +1,6 @@
 use super::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeInventory, ProbeMovement, SectorObservation, StorageContainer, VisitedSector,
+    ProbeInventory, ProbeMovement, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
 };
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
@@ -273,6 +273,15 @@ impl ApiClient {
         struct Resp { mission: Mission }
         let path = format!("/api/probe/missions/{mission_id}/abandon");
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.mission)
+    }
+
+    /// Inspect a SCUT relay network covering the current probe
+    /// (`GET /api/probe/scut-network/{id}`).
+    pub async fn get_scut_network(&self, network_id: i64) -> Result<ScutNetwork> {
+        #[derive(Deserialize)]
+        struct Resp { network: ScutNetwork }
+        let path = format!("/api/probe/scut-network/{network_id}");
+        Ok(self.get::<Resp>(&path).await?.network)
     }
 
     /// Send a Manny to turn on an inactive SCUT relay in the current sector

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -381,6 +381,16 @@ pub fn fetch_refill_deuterium(manny_id: String, client: ApiClient, tx: mpsc::Sen
     });
 }
 
+pub fn fetch_scut_network(network_id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        let msg = match client.get_scut_network(network_id).await {
+            Ok(n) => ApiMessage::ScutNetworkFetched(n),
+            Err(e) => ApiMessage::ScutNetworkError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
 pub fn fetch_turn_on_relay(
     manny_id: String,
     relay_id: i64,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -677,6 +677,40 @@ pub struct ScutNetworkReference {
     pub name: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScutRelay {
+    pub id: i64,
+    pub name: String,
+    pub status: ScutRelayStatus,
+    pub sector: ProbeSector,
+    pub created_by_probe_name: Option<String>,
+    pub coverage_radius_sectors: i64,
+    pub activated_at: Option<String>,
+    pub network: Option<ScutNetworkReference>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScutNetworkProbe {
+    pub id: i64,
+    pub name: String,
+    pub sector: ProbeSector,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScutNetwork {
+    pub id: i64,
+    pub name: String,
+    pub relay_count: i64,
+    pub covered_sector_count: i64,
+    #[serde(default)]
+    pub relays: Vec<ScutRelay>,
+    #[serde(default)]
+    pub probes: Vec<ScutNetworkProbe>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MinableTarget {
@@ -705,6 +739,8 @@ pub struct SectorObservation {
     pub message: Option<String>,
     pub sensor_mode: Option<SensorMode>,
     pub data_freshness: Option<DataFreshness>,
+    #[serde(default)]
+    pub scut_networks: Vec<ScutNetworkReference>,
     pub scan: SectorScan,
     /// Local timestamp of when this observation was received (not an API
     /// field — stamped client-side and persisted in scan_history.json).

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -310,6 +310,20 @@ pub enum ScutRelayInput {
 }
 
 #[derive(Default)]
+pub enum ScutNetworkInput {
+    #[default]
+    Inactive,
+    /// Several networks cover the sector — pick which one to inspect.
+    Picking {
+        networks: Vec<(i64, String)>, // (network id, name)
+        selection: usize,
+    },
+    /// Inspecting a network; details live in `AppState::scut_network_view`
+    /// (None while the fetch is in flight).
+    Viewing { error: Option<String> },
+}
+
+#[derive(Default)]
 pub enum MissionsInput {
     #[default]
     Inactive,

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,6 +1,6 @@
 use crate::api::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeInventory, ProbeMovement, SectorObservation, StorageContainer, VisitedSector,
+    ProbeInventory, ProbeMovement, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
 };
 
 pub enum ApiMessage {
@@ -60,6 +60,8 @@ pub enum ApiMessage {
     MissionAbandonError(String),
     ScutRelayTurnedOn,
     ScutRelayTurnOnError(String),
+    ScutNetworkFetched(ScutNetwork),
+    ScutNetworkError(String),
     DropStorageContainerStarted(Manny),
     DropStorageContainerError(String),
     Error(String),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,7 +21,7 @@ pub use waypoints::*;
 
 use crate::api::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeInventory, SectorObservation, StorageContainer, VisitedSector,
+    ProbeInventory, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
 };
 use chrono::{DateTime, Local, Utc};
 use tokio::time::Instant;
@@ -92,6 +92,8 @@ pub struct AppState {
     pub refuel: RefuelInput,
     pub mind_snapshot: MindSnapshotInput,
     pub scut_relay: ScutRelayInput,
+    pub scut_network: ScutNetworkInput,
+    pub scut_network_view: Option<ScutNetwork>,
     pub missions: Vec<Mission>,
     pub missions_input: MissionsInput,
     pub deploy: DeployInput,

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -218,6 +218,13 @@ impl AppState {
         actions
     }
 
+    /// SCUT networks covering the probe's current sector, as (id, name) pairs.
+    pub fn scut_coverage(&self) -> Vec<(i64, String)> {
+        self.probe_current_sector_scan()
+            .map(|s| s.scut_networks.iter().map(|n| (n.id, n.name.clone())).collect())
+            .unwrap_or_default()
+    }
+
     /// Status of a SCUT relay object in the probe's current sector, by object id.
     pub fn sector_object_relay_status(&self, id: &str) -> Option<ScutRelayStatus> {
         self.probe_current_sector_scan()

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -848,6 +848,20 @@ fn relay_sector(status: &str) -> SectorObservation {
 }
 
 #[test]
+fn scut_coverage_read_from_sector() {
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    let mut sector = make_sector_with_objects(0., 0., 0., "[]");
+    sector.scut_networks = vec![
+        serde_json::from_str(r#"{"id": 7, "name": "Delta SCUT"}"#).unwrap(),
+    ];
+    state.scan_history = vec![sector];
+    let cov = state.scut_coverage();
+    assert_eq!(cov.len(), 1);
+    assert_eq!(cov[0], (7, "Delta SCUT".to_string()));
+}
+
+#[test]
 fn relay_status_read_from_sector_object() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -5,7 +5,7 @@ use crate::api::client::ApiClient;
 use crate::api::tasks::{
     fetch_all,
     fetch_inspect,
-    fetch_recover, fetch_sector, fetch_storage_containers,
+    fetch_recover, fetch_scut_network, fetch_sector, fetch_storage_containers,
 };
 use crate::api::types::MannyTask;
 use crate::app::{
@@ -13,8 +13,8 @@ use crate::app::{
     ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput,
     DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
     MissionsInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RefuelInput,
-    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, ScutRelayInput,
-    StorageMoveInput, TravelInput, WaypointsInput,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode, ScutNetworkInput,
+    ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
 mod alerts;
 mod containers;
@@ -47,7 +47,10 @@ use pickers::{
     handle_salvage_event,
 };
 use repair::handle_repair_event;
-use scanner::{handle_object_action_event, handle_scut_relay_event, handle_waypoints_event};
+use scanner::{
+    handle_object_action_event, handle_scut_network_event, handle_scut_relay_event,
+    handle_waypoints_event,
+};
 use storage_move::handle_storage_move_event;
 use travel::handle_travel_event;
 pub fn handle_event(
@@ -73,6 +76,7 @@ pub fn handle_event(
     let in_refuel = !matches!(state.refuel, RefuelInput::Inactive);
     let in_mind_snapshot = !matches!(state.mind_snapshot, MindSnapshotInput::Inactive);
     let in_scut_relay = !matches!(state.scut_relay, ScutRelayInput::Inactive);
+    let in_scut_network = !matches!(state.scut_network, ScutNetworkInput::Inactive);
     let in_missions = !matches!(state.missions_input, MissionsInput::Inactive);
     let in_rename_manny = !matches!(state.rename_manny, RenameMannyInput::Inactive);
     let in_deploy = !matches!(state.deploy, DeployInput::Inactive);
@@ -159,6 +163,11 @@ pub fn handle_event(
 
     if in_scut_relay {
         handle_scut_relay_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_scut_network {
+        handle_scut_network_event(k.code, state, client, tx);
         return;
     }
 
@@ -305,6 +314,19 @@ pub fn handle_event(
         KeyCode::Char('b') => state.open_map(),
         KeyCode::Char('O') => {
             state.missions_input = MissionsInput::Browsing { selection: 0 };
+        }
+        KeyCode::Char('N') => {
+            let nets = state.scut_coverage();
+            match nets.len() {
+                0 => state.error = Some("no SCUT coverage in this sector".into()),
+                1 => {
+                    let id = nets[0].0;
+                    state.scut_network = ScutNetworkInput::Viewing { error: None };
+                    state.scut_network_view = None;
+                    fetch_scut_network(id, client.clone(), tx.clone());
+                }
+                _ => state.scut_network = ScutNetworkInput::Picking { networks: nets, selection: 0 },
+            }
         }
         KeyCode::Char('?') => state.help_open = true,
         KeyCode::Char('w') => {

--- a/src/input/scanner.rs
+++ b/src/input/scanner.rs
@@ -5,11 +5,12 @@ use crate::api::client::ApiClient;
 use crate::api::tasks::{
     fetch_inspect,
     fetch_recover,
+    fetch_scut_network,
     fetch_turn_on_relay,
 };
 use crate::app::{
     ApiMessage, AppState, DeployInput, MineInput, ObjectAction, ObjectActionInput, SalvageInput,
-    ScutRelayInput, WaypointsInput,
+    ScutNetworkInput, ScutRelayInput, WaypointsInput,
 };
 use super::geometry::list_nav;
 /// Send the chosen object action, reusing the existing wizards/endpoints.
@@ -112,6 +113,43 @@ pub(super) fn handle_scut_relay_event(
             fetch_turn_on_relay(manny_id, relay_id, name, client.clone(), tx.clone());
         }
         _ => {}
+    }
+}
+
+pub(super) fn handle_scut_network_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match state.scut_network {
+        ScutNetworkInput::Picking { ref networks, selection } => {
+            let count = networks.len();
+            match code {
+                KeyCode::Esc => state.scut_network = ScutNetworkInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, selection, count) {
+                        if let ScutNetworkInput::Picking { ref mut selection, .. } = state.scut_network {
+                            *selection = new_sel;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let id = networks[selection].0;
+                    state.scut_network = ScutNetworkInput::Viewing { error: None };
+                    state.scut_network_view = None;
+                    fetch_scut_network(id, client.clone(), tx.clone());
+                }
+                _ => {}
+            }
+        }
+        ScutNetworkInput::Viewing { .. } => {
+            if code == KeyCode::Esc {
+                state.scut_network = ScutNetworkInput::Inactive;
+                state.scut_network_view = None;
+            }
+        }
+        ScutNetworkInput::Inactive => {}
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
     DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput,
     MindSnapshotInput, MineInput, MissionsInput, Phosphor, RecallInput, RecoverInput, RefuelInput,
-    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScutRelayInput,
-    StorageMoveInput, UiTheme,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScutNetworkInput,
+    ScutRelayInput, StorageMoveInput, UiTheme,
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
@@ -191,6 +191,16 @@ async fn run(
                         fetch_all(client.clone(), tx.clone());
                     }
                     ApiMessage::ScutRelayTurnOnError(e) => state.set_scut_relay_error(e),
+                    ApiMessage::ScutNetworkFetched(network) => {
+                        if matches!(state.scut_network, ScutNetworkInput::Viewing { .. }) {
+                            state.scut_network_view = Some(network);
+                        }
+                    }
+                    ApiMessage::ScutNetworkError(e) => {
+                        if matches!(state.scut_network, ScutNetworkInput::Viewing { .. }) {
+                            state.scut_network = ScutNetworkInput::Viewing { error: Some(e) };
+                        }
+                    }
                     ApiMessage::DeployStarted => {
                         state.deploy = DeployInput::Inactive;
                         state.set_toast("waypoint deploy order sent");

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -107,6 +107,11 @@ pub(crate) fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState)
         Span::raw(" alerts  "),
         Span::styled("[O]", Style::default().fg(Color::Cyan)),
         Span::raw(" missions  "),
+        Span::styled(
+            "[N]",
+            Style::default().fg(if state.scut_coverage().is_empty() { Color::Cyan } else { Color::LightBlue }),
+        ),
+        Span::raw(" network  "),
         Span::styled("[?]", Style::default().fg(Color::Cyan)),
         Span::raw(" help  "),
         Span::styled("[q]", Style::default().fg(Color::Cyan)),

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -56,6 +56,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("w", "waypoints"),
         help_key_line("A", "alerts & damage warnings"),
         help_key_line("O", "missions"),
+        help_key_line("N", "inspect SCUT network (when covered)"),
         help_key_line("?", "this help"),
         help_key_line("q", "quit"),
         help_key_line("Esc", "unfocus / close"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod map;
 pub(crate) mod mine;
 pub(crate) mod missions;
 pub(crate) mod object_actions;
+pub(crate) mod scut_network;
 pub(crate) mod pickers;
 pub(crate) mod repair;
 pub(crate) mod storage_move;
@@ -28,6 +29,7 @@ pub(crate) use jettison::render_jettison_overlay;
 pub(crate) use map::render_map_overlay;
 pub(crate) use mine::render_mine_overlay;
 pub(crate) use missions::render_missions_overlay;
+pub(crate) use scut_network::render_scut_network_overlay;
 pub(crate) use object_actions::render_object_action_overlay;
 pub(crate) use pickers::{
     render_deploy_overlay, render_detach_overlay, render_drop_cargo_overlay, render_inspect_overlay,
@@ -45,8 +47,8 @@ use crate::app::{
     CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput,
     JettisonInput, MineInput,
     MindSnapshotInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
-    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScutRelayInput,
-    StorageMoveInput, TravelInput, WaypointsInput,
+    RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScutNetworkInput,
+    ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -104,6 +106,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.scut_relay, ScutRelayInput::Inactive) {
         render_scut_relay_overlay(frame, area, state);
+    }
+    if !matches!(state.scut_network, ScutNetworkInput::Inactive) {
+        render_scut_network_overlay(frame, area, state);
     }
     if !matches!(state.drop_cargo, DropCargoInput::Inactive) {
         render_drop_cargo_overlay(frame, area, state);

--- a/src/ui/overlays/scut_network.rs
+++ b/src/ui/overlays/scut_network.rs
@@ -1,0 +1,115 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::api::types::{ProbeSector, ScutRelayStatus};
+use crate::app::{AppState, ScutNetworkInput};
+
+use super::{centered_rect, render_pick_list};
+
+fn rel(sector: &ProbeSector) -> String {
+    match sector.relative.as_ref() {
+        Some(v) => format!("({},{},{})", v.x as i64, v.y as i64, v.z as i64),
+        None => "(?)".into(),
+    }
+}
+
+pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match &state.scut_network {
+        ScutNetworkInput::Picking { networks, selection } => {
+            let items: Vec<&str> = networks.iter().map(|(_, name)| name.as_str()).collect();
+            let height = (items.len() as u16) + 4;
+            render_pick_list(
+                frame,
+                area,
+                " SCUT NETWORK ",
+                52,
+                height,
+                Some("Pick a network to inspect"),
+                &items,
+                *selection,
+                None,
+                "inspect",
+            );
+        }
+        ScutNetworkInput::Viewing { error } => {
+            let popup = centered_rect(74, 80, area);
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(" SCUT NETWORK ")
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::LightBlue));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(inner);
+
+            let mut lines: Vec<Line> = Vec::new();
+            if let Some(err) = error {
+                lines.push(Line::from(Span::styled(
+                    format!("✗ {err}"),
+                    Style::default().fg(Color::Red),
+                )));
+            } else if let Some(net) = &state.scut_network_view {
+                lines.push(Line::from(vec![
+                    Span::styled(net.name.clone(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                    Span::raw("   "),
+                    Span::styled(
+                        format!("{} relays · {} sectors covered", net.relay_count, net.covered_sector_count),
+                        Style::default().fg(Color::Gray),
+                    ),
+                ]));
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled("RELAYS", Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD))));
+                for r in &net.relays {
+                    let (mark, color) = match r.status {
+                        ScutRelayStatus::On => ("●", Color::Green),
+                        ScutRelayStatus::Off => ("○", Color::DarkGray),
+                        ScutRelayStatus::Unknown => ("?", Color::DarkGray),
+                    };
+                    let by = r.created_by_probe_name.clone().unwrap_or_else(|| "—".into());
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("  {mark} "), Style::default().fg(color)),
+                        Span::styled(rel(&r.sector), Style::default().fg(Color::White)),
+                        Span::styled(
+                            format!("  r={}  by {by}", r.coverage_radius_sectors),
+                            Style::default().fg(Color::DarkGray),
+                        ),
+                    ]));
+                }
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled("PROBES", Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD))));
+                if net.probes.is_empty() {
+                    lines.push(Line::from(Span::styled("  none detected", Style::default().fg(Color::DarkGray))));
+                } else {
+                    for p in &net.probes {
+                        lines.push(Line::from(vec![
+                            Span::styled("  ◆ ", Style::default().fg(Color::Cyan)),
+                            Span::styled(p.name.clone(), Style::default().fg(Color::White)),
+                            Span::styled(format!("  {}", rel(&p.sector)), Style::default().fg(Color::DarkGray)),
+                        ]));
+                    }
+                }
+            } else {
+                lines.push(Line::from(Span::styled("loading…", Style::default().fg(Color::DarkGray))));
+            }
+            frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" close"),
+                ])),
+                rows[1],
+            );
+        }
+        ScutNetworkInput::Inactive => {}
+    }
+}

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -93,6 +93,12 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         ));
     }
+    if !state.scut_coverage().is_empty() {
+        status_spans.push(Span::styled(
+            "  ≣ SCUT",
+            Style::default().fg(Color::LightBlue),
+        ));
+    }
     frame.render_widget(Paragraph::new(Line::from(status_spans)), rows[row]);
     row += 1;
 

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -1,7 +1,7 @@
 use neumann_cockpit::api::types::{
     AlertPhase, AlertStatus, AlertType, ContainerInventory, CraftingRecipe, DamageWarningRule,
     DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask, Mission, MissionStatus,
-    MissionStepStatus, MovementPhase, Probe, ScutRelayStatus, SectorObject,
+    MissionStepStatus, MovementPhase, Probe, ScutNetwork, ScutRelayStatus, SectorObject,
     ProbeAlert, ProbeInventory, ProbeMovement, ProbeStatus, SectorObjectType, SectorObservation,
     SensorMode, StorageContainer,
 };
@@ -634,6 +634,32 @@ fn scut_relay_sector_object_deserializes() {
     let net = obj.network.expect("network present");
     assert_eq!(net.id, 7);
     assert_eq!(net.name, "Delta SCUT");
+}
+
+#[test]
+fn scut_network_deserializes() {
+    let json = r#"{
+      "id": 7, "name": "Delta SCUT",
+      "createdAt": "2026-06-25T12:00:00+00:00", "updatedAt": "2026-06-25T12:00:00+00:00",
+      "relayCount": 2, "coveredSectorCount": 41,
+      "relays": [
+        {"id": 12, "type": "scut_relay", "name": "Relais SCUT", "status": "on",
+         "sector": {"relative": {"x": 0, "y": 0, "z": 0}}, "coverageRadiusSectors": 10,
+         "createdByProbeName": "Probe X", "createdAt": "2026-06-25T12:00:00+00:00",
+         "activatedAt": null, "network": {"id": 7, "name": "Delta SCUT"}}
+      ],
+      "probes": [
+        {"id": 3, "name": "Probe of nova", "sector": {"relative": {"x": 2, "y": 0, "z": -2}}}
+      ]
+    }"#;
+    let net: ScutNetwork = deser(json);
+    assert_eq!(net.id, 7);
+    assert_eq!(net.relay_count, 2);
+    assert_eq!(net.covered_sector_count, 41);
+    assert_eq!(net.relays.len(), 1);
+    assert_eq!(net.relays[0].status, ScutRelayStatus::On);
+    assert_eq!(net.probes.len(), 1);
+    assert_eq!(net.probes[0].name, "Probe of nova");
 }
 
 #[test]


### PR DESCRIPTION
## What

Second SCUT increment (E2). Lets the player see networks and coverage.

- Types `ScutNetwork` / `ScutRelay` / `ScutNetworkProbe` + `scutNetworks` field on `SectorObservation`.
- `GET /api/probe/scut-network/{id}` behind `[N]`: detail overlay listing the network's relays (status, relative position, coverage radius) and probes. A picker precedes the detail when several networks cover the sector.
- Active-coverage indicators: `≣ SCUT` badge on the probe panel + a lit `[N]` in the status bar.

## Why

Builds on E1 (relays). Coverage drives inter-probe comms and remote Manny control (E3 next). Per the server source (issue #22), relay state is already in the sector scan, so coverage shows without extra calls; the network endpoint adds the full relay+probe roster.

## Verification

`cargo clippy -- -D warnings` clean · `cargo test` → 145 passed (+2: scut_coverage from sector, ScutNetwork serde).