### PR TITLE
feat(mining): target container in local mine wizard (P1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 
 **Overlays** (rendered on top of the 4-panel layout):
 - Travel (`[t]`) — coordinate input (absolute, or relative with a leading `+`) with live parity check, fuel cost preview + confirmation
-- Repair / Mine / Craft / Atomic printer craft — manny/target/recipe pickers
+- Repair / Mine / Craft / Atomic printer craft — manny/target/recipe pickers. The Mine wizard's `[c]` cycles an optional detached target container in the current sector (`targetContainerId`; default = probe).
 - Jettison / Salvage / Recall / Rename / Inspect / Recover / Detach — inventory/sector object pickers
 - Deploy waypoint — 3-step wizard: pick manny → pick object → enter bookmark name
 - Object actions — action picker for the selected scanner object (+ manny picker when several idle). An inactive `scut_relay` object offers **turn on relay** (pick manny → optional network name → `turn-on-relay`; needs a star in the sector + an integrated_circuit) and salvage.

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -227,6 +227,9 @@ pub enum MineInput {
         resources: [bool; 4], // deuterium, metals, ice, carbon_compounds
         amount_buf: String,
         amount_mode: bool, // false = toggling resources, true = editing amount
+        /// Optional detached container in the current sector to deliver mined
+        /// resources into ([c] cycles None → containers). `None` = probe.
+        target_container: Option<(String, String)>, // (id, name)
         error: Option<String>,
     },
 }

--- a/src/input/mine.rs
+++ b/src/input/mine.rs
@@ -7,6 +7,56 @@ use crate::app::{
     ApiMessage, AppState, MineInput, RemoteMineInput, RESOURCE_TYPES,
 };
 use super::geometry::list_nav;
+
+/// Cycle the optional mining target container: None → first → … → last → None.
+pub(crate) fn next_target_container(
+    current: Option<&(String, String)>,
+    containers: &[(String, String)],
+) -> Option<(String, String)> {
+    match current {
+        None => containers.first().cloned(),
+        Some((id, _)) => match containers.iter().position(|(cid, _)| cid == id) {
+            Some(i) => containers.get(i + 1).cloned(),
+            None => containers.first().cloned(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::next_target_container;
+
+    fn c(id: &str) -> (String, String) {
+        (id.into(), format!("container {id}"))
+    }
+
+    #[test]
+    fn cycles_none_through_containers_back_to_none() {
+        let list = vec![c("a"), c("b")];
+        let s0 = next_target_container(None, &list);
+        assert_eq!(s0.as_ref().map(|(id, _)| id.as_str()), Some("a"));
+        let s1 = next_target_container(s0.as_ref(), &list);
+        assert_eq!(s1.as_ref().map(|(id, _)| id.as_str()), Some("b"));
+        let s2 = next_target_container(s1.as_ref(), &list);
+        assert_eq!(s2, None);
+    }
+
+    #[test]
+    fn no_containers_stays_none() {
+        assert_eq!(next_target_container(None, &[]), None);
+    }
+
+    #[test]
+    fn stale_selection_resets_to_first() {
+        let list = vec![c("a")];
+        let stale = c("gone");
+        assert_eq!(
+            next_target_container(Some(&stale), &list).as_ref().map(|(id, _)| id.as_str()),
+            Some("a")
+        );
+    }
+}
+
 pub(super) fn handle_mine_event(
     code: KeyCode,
     state: &mut AppState,
@@ -37,6 +87,7 @@ pub(super) fn handle_mine_event(
                         resources: [false, true, false, false],
                         amount_buf: "0.30".into(),
                         amount_mode: false,
+                        target_container: None,
                         error: None,
                     };
                 }
@@ -80,9 +131,16 @@ pub(super) fn handle_mine_event(
                         amount_buf.pop();
                     }
                 }
+                KeyCode::Char('c') => {
+                    let containers = state.collect_detached_containers();
+                    if let MineInput::Configure { ref mut target_container, ref mut error, .. } = state.mine {
+                        *target_container = next_target_container(target_container.as_ref(), &containers);
+                        *error = None;
+                    }
+                }
                 KeyCode::Enter => {
-                    let (manny_id, object_id, selected_resources, amount) = {
-                        let MineInput::Configure { ref manny_id, ref object_id, resources, ref amount_buf, .. } = state.mine else { return };
+                    let (manny_id, object_id, selected_resources, amount, container_id) = {
+                        let MineInput::Configure { ref manny_id, ref object_id, resources, ref amount_buf, ref target_container, .. } = state.mine else { return };
                         let selected: Vec<String> = RESOURCE_TYPES.iter().enumerate()
                             .filter(|(i, _)| resources[*i])
                             .map(|(_, &t)| t.to_string())
@@ -90,9 +148,9 @@ pub(super) fn handle_mine_event(
                         if selected.is_empty() { return }
                         let Ok(amount) = amount_buf.parse::<f64>() else { return };
                         if amount <= 0.0 { return }
-                        (manny_id.clone(), object_id.clone(), selected, amount)
+                        (manny_id.clone(), object_id.clone(), selected, amount, target_container.as_ref().map(|(id, _)| id.clone()))
                     };
-                    fetch_mine(manny_id, object_id, selected_resources, amount, None, client.clone(), tx.clone());
+                    fetch_mine(manny_id, object_id, selected_resources, amount, container_id, client.clone(), tx.clone());
                 }
                 _ => {}
             }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -535,6 +535,7 @@ pub fn handle_event(
                                     resources: [false, true, false, false],
                                     amount_buf: "0.30".into(),
                                     amount_mode: false,
+                                    target_container: None,
                                     error: None,
                                 };
                             }

--- a/src/input/scanner.rs
+++ b/src/input/scanner.rs
@@ -36,6 +36,7 @@ pub(super) fn dispatch_object_action(
                 resources: [false, true, false, false],
                 amount_buf: "0.30".into(),
                 amount_mode: false,
+                target_container: None,
                 error: None,
             };
         }

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -35,8 +35,8 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 Some("Select mining target:"), &names, *selection, None, "confirm");
         }
 
-        MineInput::Configure { manny_name, object_name, resources, amount_buf, amount_mode, error, .. } => {
-            let popup = centered_rect(52, 14, area);
+        MineInput::Configure { manny_name, object_name, resources, amount_buf, amount_mode, target_container, error, .. } => {
+            let popup = centered_rect(52, 15, area);
             frame.render_widget(Clear, popup);
 
             let manny_short = if manny_name.len() > 10 { &manny_name[..10] } else { manny_name };
@@ -118,6 +118,20 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 }
             } else {
                 lines.push(Line::default());
+            }
+
+            // Optional target container (only when the sector has detached ones)
+            let has_containers = !state.collect_detached_containers().is_empty();
+            if has_containers {
+                let target_label = match target_container {
+                    Some((_, name)) => name.as_str(),
+                    None => "probe (none)",
+                };
+                lines.push(Line::from(vec![
+                    Span::styled("Store in: ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(target_label, Style::default().fg(Color::Cyan)),
+                    Span::styled("  [c] cycle", Style::default().fg(Color::DarkGray)),
+                ]));
             }
 
             // Error


### PR DESCRIPTION
## What

Closes the partial-wiring gap P1 (old roadmap bloc 09). The local mine flow can now deliver into a detached container.

- `MineInput::Configure` gains an optional `target_container`.
- `[c]` in the mine wizard cycles None → detached containers in the current sector (reusing `collect_detached_containers`); the overlay shows `Store in: <name>` when containers exist.
- The choice is passed to the existing `mine` endpoint as `targetContainerId` (default = probe). Deuterium-to-container is rejected server-side and surfaces inline.
- `next_target_container` extracted as a pure, unit-tested helper.

## Why

The `targetContainerId` plumbing existed since v45 but was never reachable in the local UI (always `None`). E3b built the remote pick-container; this exposes it locally too.

## Verification

`cargo clippy -- -D warnings` clean · `cargo test` → 152 passed (+3: cycle through containers, empty list, stale selection).