### PR TITLE
feat(messaging): inter-probe inbox, sent & compose (bloc F)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 - Jettison a `scut_relay` inventory item (Inventory `[j]` on the SCUT-relay group) — confirmation; deploys an inactive relay into the current sector
 - Alerts (`[A]`) — tabbed Alerts / Damage-warnings list, `Tab` switches tab, `Enter` marks read; `[!]` badge on the probe panel + status bar when unread
 - Missions (`[O]`) — active-mission list with steps and status; `[a]` abandons the selected active mission (confirmation sub-popup)
+- Messaging (`[Y]`) — tabbed inbox / sent list (`Tab` switches), `Enter` marks an inbox message read, `[c]` composes: pick a recipient (probes detected in the sector + inhabited planets) → type the body → send. Inbox/sent are loaded on open (not in `fetch_all`); a `•` on `[Y]` in the status bar signals unread. `EndpointId` is an untagged int|string (probe id | planet object id).
 - SCUT network (`[N]`) — inspect a network covering the current sector (`scutNetworks` in the sector scan): relays (status, position, coverage) and probes. When several networks cover the sector, a picker precedes the detail view. A `≣ SCUT` badge on the probe panel + a lit `[N]` in the status bar signal active coverage.
 - Remote mannies via SCUT — `Manny.taskVisibility` (`local` / `scut_network` / `too_far`) drives display: a Manny in a different sector reachable via a shared SCUT network shows `≣ via SCUT` and its `[R]` action is labelled **abandon** (the recall cancels the task and leaves it forgotten, it does not return); out-of-range tasks render as `too far` (`unknown_too_far`).
 - Remote mine (`[e]` on an idle SCUT-reachable Manny — API v60) — fetches the Manny's sector, then a wizard: pick asteroid → resources/amount → **pick detached container** (mandatory; the dropped mining stays in the Manny's sector). Drives the same `mine` endpoint with `targetContainerId`. `RemoteMineInput` advances to asteroid selection when the awaited sector scan arrives.
@@ -166,4 +167,6 @@ Scanner specifics: the history column shows symbol + coords + distance, scrolls 
 | `/api/probe/missions` | GET | ✓ |
 | `/api/probe/mission` | GET | ✓ (alias) |
 | `/api/probe/missions/{id}/abandon` | POST | ✓ |
-| `/api/probe/messages` | GET/POST | ✗ (not implemented) |
+| `/api/probe/messages` | GET/POST | ✓ |
+| `/api/probe/messages/sent` | GET | ✓ |
+| `/api/probe/messages/{id}/read` | PATCH | ✓ |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,6 +1,7 @@
 use super::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeInventory, ProbeMovement, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, EndpointId, Manny, Mission, Pagination,
+    Probe, ProbeAlert, ProbeInventory, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork,
+    SectorObservation, StorageContainer, VisitedSector,
 };
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
@@ -265,6 +266,46 @@ impl ApiClient {
             missions: Vec<Mission>,
         }
         Ok(self.get::<Resp>("/api/probe/missions").await?.missions)
+    }
+
+    /// List received messages (`GET /api/probe/messages`, newest first).
+    pub async fn get_messages(&self) -> Result<(Vec<ProbeMessage>, Pagination)> {
+        #[derive(Deserialize)]
+        struct Resp { #[serde(default)] messages: Vec<ProbeMessage>, pagination: Pagination }
+        let r = self.get::<Resp>("/api/probe/messages").await?;
+        Ok((r.messages, r.pagination))
+    }
+
+    /// List sent messages (`GET /api/probe/messages/sent`, newest first).
+    pub async fn get_sent_messages(&self) -> Result<(Vec<ProbeSentMessage>, Pagination)> {
+        #[derive(Deserialize)]
+        struct Resp { #[serde(default)] messages: Vec<ProbeSentMessage>, pagination: Pagination }
+        let r = self.get::<Resp>("/api/probe/messages/sent").await?;
+        Ok((r.messages, r.pagination))
+    }
+
+    /// Send a message to a probe or inhabited planet (`POST /api/probe/messages`).
+    pub async fn send_message(
+        &self,
+        recipient_type: &str,
+        recipient_id: &EndpointId,
+        body: &str,
+    ) -> Result<ProbeMessage> {
+        #[derive(Deserialize)]
+        struct Resp { message: ProbeMessage }
+        let payload = serde_json::json!({
+            "recipient": { "type": recipient_type, "id": recipient_id },
+            "body": body,
+        });
+        Ok(self.post::<Resp, _>("/api/probe/messages", &payload).await?.message)
+    }
+
+    /// Mark a received message as read (`PATCH /api/probe/messages/{id}/read`).
+    pub async fn mark_message_read(&self, message_id: i64) -> Result<ProbeMessage> {
+        #[derive(Deserialize)]
+        struct Resp { message: ProbeMessage }
+        let path = format!("/api/probe/messages/{message_id}/read");
+        Ok(self.patch::<Resp, _>(&path, &serde_json::json!({})).await?.message)
     }
 
     /// Abandon an active mission (`POST /api/probe/missions/{id}/abandon`).

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -1,4 +1,5 @@
 use crate::api::client::ApiClient;
+use crate::api::types::EndpointId;
 use crate::app::ApiMessage;
 use tokio::sync::mpsc;
 
@@ -56,6 +57,46 @@ pub fn fetch_missions(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
         if let Ok(m) = client.get_missions().await {
             let _ = tx.send(ApiMessage::MissionsFetched(m)).await;
+        }
+    });
+}
+
+pub fn fetch_messages(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        if let Ok((messages, _pag)) = client.get_messages().await {
+            let _ = tx.send(ApiMessage::MessagesFetched(messages)).await;
+        }
+    });
+}
+
+pub fn fetch_sent_messages(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        if let Ok((messages, _pag)) = client.get_sent_messages().await {
+            let _ = tx.send(ApiMessage::SentMessagesFetched(messages)).await;
+        }
+    });
+}
+
+pub fn fetch_send_message(
+    recipient_type: String,
+    recipient_id: EndpointId,
+    body: String,
+    client: ApiClient,
+    tx: mpsc::Sender<ApiMessage>,
+) {
+    tokio::spawn(async move {
+        let msg = match client.send_message(&recipient_type, &recipient_id, &body).await {
+            Ok(m) => ApiMessage::MessageSent(m),
+            Err(e) => ApiMessage::MessageSendError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
+pub fn fetch_mark_message_read(id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        if let Ok(m) = client.mark_message_read(id).await {
+            let _ = tx.send(ApiMessage::MessageMarkedRead(m)).await;
         }
     });
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -487,6 +487,63 @@ pub struct Mission {
     pub steps: Vec<MissionStep>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum EndpointId {
+    Probe(i64),
+    Planet(String),
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageStatus {
+    Unread,
+    Read,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeMessageEndpoint {
+    #[serde(rename = "type")]
+    pub endpoint_type: String,
+    pub id: EndpointId,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeMessage {
+    pub id: i64,
+    pub sender: ProbeMessageEndpoint,
+    pub recipient: ProbeMessageEndpoint,
+    pub body: String,
+    pub status: MessageStatus,
+    pub read_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeSentMessage {
+    pub id: i64,
+    pub sender: ProbeMessageEndpoint,
+    pub recipient: ProbeMessageEndpoint,
+    pub body: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Pagination {
+    pub limit: i64,
+    pub offset: i64,
+    pub count: i64,
+    pub total: i64,
+    pub has_more: bool,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MissionStep {

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api::types::EndpointId;
 
 #[derive(Default)]
 pub enum ScanMode {
@@ -358,6 +359,27 @@ pub enum ScutRelayInput {
         relay_id: i64,
         relay_name: String,
         buf: String,
+        error: Option<String>,
+    },
+}
+
+#[derive(Default)]
+pub enum MessagesInput {
+    #[default]
+    Inactive,
+    /// Browsing inbox (sent_tab=false) or sent (true); entries in AppState.
+    Browsing { sent_tab: bool, selection: usize },
+    /// Picking a recipient for a new message (probes + planets in sector).
+    PickRecipient {
+        recipients: Vec<(String, EndpointId, String)>, // (kind, id, name)
+        selection: usize,
+    },
+    /// Typing the message body for the chosen recipient.
+    Compose {
+        recipient_type: String,
+        recipient_id: EndpointId,
+        recipient_name: String,
+        body_buf: String,
         error: Option<String>,
     },
 }

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -123,6 +123,42 @@ impl AppState {
         }
     }
 
+    pub fn set_message_send_error(&mut self, msg: String) {
+        if let MessagesInput::Compose { ref mut error, .. } = self.messages_input {
+            *error = Some(msg);
+        }
+    }
+
+    pub fn unread_message_count(&self) -> usize {
+        self.messages.iter()
+            .filter(|m| m.status == crate::api::types::MessageStatus::Unread)
+            .count()
+    }
+
+    /// Message recipients reachable from the current sector: detected probes
+    /// plus inhabited planets. Returns (kind, endpoint id, display name).
+    pub fn collect_message_recipients(&self) -> Vec<(String, crate::api::types::EndpointId, String)> {
+        use crate::api::types::EndpointId;
+        let mut out = Vec::new();
+        let Some(sector) = self.probe_current_sector_scan() else { return out };
+        if let Some(probes) = sector.probes.as_ref() {
+            for p in probes {
+                out.push(("probe".to_string(), EndpointId::Probe(p.id), p.name.clone()));
+            }
+        }
+        if let Some(objects) = sector.objects.as_ref() {
+            for o in objects {
+                if o.habitability_score.unwrap_or(0.0) > 0.0 {
+                    if let Some(id) = o.id.clone() {
+                        let name = o.name.clone().unwrap_or_else(|| "planet".into());
+                        out.push(("planet".to_string(), EndpointId::Planet(id), name));
+                    }
+                }
+            }
+        }
+        out
+    }
+
     /// The probe's terminal recovery alert (dead / black-hole), if any.
     pub fn probe_terminal_alert(&self) -> Option<&crate::api::types::ProbeTerminalAlert> {
         self.probe.as_ref().and_then(|p| p.alert.as_ref())

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,6 +1,7 @@
 use crate::api::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeInventory, ProbeMovement, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
+    ProbeInventory, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork, SectorObservation,
+    StorageContainer, VisitedSector,
 };
 
 pub enum ApiMessage {
@@ -62,6 +63,11 @@ pub enum ApiMessage {
     ScutRelayTurnOnError(String),
     ScutNetworkFetched(ScutNetwork),
     ScutNetworkError(String),
+    MessagesFetched(Vec<ProbeMessage>),
+    SentMessagesFetched(Vec<ProbeSentMessage>),
+    MessageSent(ProbeMessage),
+    MessageSendError(String),
+    MessageMarkedRead(ProbeMessage),
     DropStorageContainerStarted(Manny),
     DropStorageContainerError(String),
     Error(String),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,8 +20,9 @@ pub use scan::*;
 pub use waypoints::*;
 
 use crate::api::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeInventory, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe,
+    ProbeAlert, ProbeInventory, ProbeMessage, ProbeSentMessage, ScutNetwork, SectorObservation,
+    StorageContainer, VisitedSector,
 };
 use chrono::{DateTime, Local, Utc};
 use tokio::time::Instant;
@@ -97,6 +98,9 @@ pub struct AppState {
     pub scut_network_view: Option<ScutNetwork>,
     pub missions: Vec<Mission>,
     pub missions_input: MissionsInput,
+    pub messages: Vec<ProbeMessage>,
+    pub sent_messages: Vec<ProbeSentMessage>,
+    pub messages_input: MessagesInput,
     pub deploy: DeployInput,
     pub rename_manny: RenameMannyInput,
     pub inspect: InspectInput,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -898,6 +898,23 @@ fn remote_mine_advances_to_pick_asteroid_when_sector_loads() {
 }
 
 #[test]
+fn unread_message_count_counts_only_unread() {
+    let mut state = AppState::default();
+    let mk = |id: i64, status: &str| -> crate::api::types::ProbeMessage {
+        serde_json::from_str(&format!(r#"{{
+            "id": {id},
+            "sender": {{ "type": "probe", "id": 2, "name": "nova" }},
+            "recipient": {{ "type": "probe", "id": 1, "name": "me" }},
+            "sector": {{ "relative": {{"x":0,"y":0,"z":0}} }},
+            "body": "hi", "status": "{status}", "readAt": null,
+            "createdAt": "2026-06-06T12:00:00+00:00", "updatedAt": "2026-06-06T12:00:00+00:00"
+        }}"#)).unwrap()
+    };
+    state.messages = vec![mk(1, "unread"), mk(2, "read"), mk(3, "unread")];
+    assert_eq!(state.unread_message_count(), 2);
+}
+
+#[test]
 fn scut_coverage_read_from_sector() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));

--- a/src/input/messages.rs
+++ b/src/input/messages.rs
@@ -1,0 +1,101 @@
+use crossterm::event::KeyCode;
+use tokio::sync::mpsc;
+
+use crate::api::client::ApiClient;
+use crate::api::tasks::{fetch_mark_message_read, fetch_send_message};
+use crate::app::{ApiMessage, AppState, MessagesInput};
+
+use super::geometry::list_nav;
+
+pub(super) fn handle_messages_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match &state.messages_input {
+        MessagesInput::Browsing { sent_tab, selection } => {
+            let sent_tab = *sent_tab;
+            let selection = *selection;
+            let count = if sent_tab { state.sent_messages.len() } else { state.messages.len() };
+            match code {
+                KeyCode::Esc | KeyCode::Char('Y') | KeyCode::Char('q') => {
+                    state.messages_input = MessagesInput::Inactive;
+                }
+                KeyCode::Tab | KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l') => {
+                    state.messages_input = MessagesInput::Browsing { sent_tab: !sent_tab, selection: 0 };
+                }
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, selection, count) {
+                        state.messages_input = MessagesInput::Browsing { sent_tab, selection: new_sel };
+                    }
+                }
+                KeyCode::Enter if !sent_tab => {
+                    if let Some(m) = state.messages.get(selection) {
+                        if m.status == crate::api::types::MessageStatus::Unread {
+                            fetch_mark_message_read(m.id, client.clone(), tx.clone());
+                        }
+                    }
+                }
+                KeyCode::Char('c') => {
+                    let recipients = state.collect_message_recipients();
+                    if recipients.is_empty() {
+                        state.error = Some("no reachable recipient in this sector".into());
+                    } else {
+                        state.messages_input = MessagesInput::PickRecipient { recipients, selection: 0 };
+                    }
+                }
+                _ => {}
+            }
+        }
+        MessagesInput::PickRecipient { recipients, selection } => {
+            let sel = *selection;
+            let count = recipients.len();
+            match code {
+                KeyCode::Esc => state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 },
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, sel, count) {
+                        if let MessagesInput::PickRecipient { ref mut selection, .. } = state.messages_input {
+                            *selection = new_sel;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let MessagesInput::PickRecipient { ref recipients, selection } = state.messages_input else { return };
+                    let (kind, id, name) = recipients[selection].clone();
+                    state.messages_input = MessagesInput::Compose {
+                        recipient_type: kind,
+                        recipient_id: id,
+                        recipient_name: name,
+                        body_buf: String::new(),
+                        error: None,
+                    };
+                }
+                _ => {}
+            }
+        }
+        MessagesInput::Compose { .. } => match code {
+            KeyCode::Esc => state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 },
+            KeyCode::Backspace => {
+                if let MessagesInput::Compose { ref mut body_buf, .. } = state.messages_input {
+                    body_buf.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if let MessagesInput::Compose { ref mut body_buf, .. } = state.messages_input {
+                    body_buf.push(c);
+                }
+            }
+            KeyCode::Enter => {
+                let (kind, id, body) = {
+                    let MessagesInput::Compose { ref recipient_type, ref recipient_id, ref body_buf, .. } = state.messages_input else { return };
+                    if body_buf.trim().is_empty() { return }
+                    (recipient_type.clone(), recipient_id.clone(), body_buf.clone())
+                };
+                fetch_send_message(kind, id, body, client.clone(), tx.clone());
+            }
+            _ => {}
+        },
+        MessagesInput::Inactive => {}
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -5,14 +5,15 @@ use crate::api::client::ApiClient;
 use crate::api::tasks::{
     fetch_all,
     fetch_inspect,
-    fetch_recover, fetch_scut_network, fetch_sector, fetch_storage_containers,
+    fetch_messages, fetch_recover, fetch_scut_network, fetch_sector, fetch_sent_messages,
+    fetch_storage_containers,
 };
 use crate::api::types::MannyTask;
 use crate::app::{
     AlertsInput, ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
     ContainersInput, CraftInput, DeployInput, DetachInput, DropCargoInput,
     DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
-    MissionsInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RefuelInput,
+    MessagesInput, MissionsInput, ObjectActionInput, Panel, RecallInput, RecoverInput, RefuelInput,
     RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode,
     ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
@@ -22,6 +23,7 @@ mod craft;
 mod geometry;
 mod jettison;
 mod map;
+mod messages;
 mod mine;
 mod missions;
 mod pickers;
@@ -38,6 +40,7 @@ use craft::{handle_atomic_printer_craft_event, handle_craft_event};
 use geometry::{face_d2, neighbors_d1};
 use jettison::handle_jettison_event;
 use map::handle_map_event;
+use messages::handle_messages_event;
 use mine::{handle_mine_event, handle_remote_mine_event};
 use missions::handle_missions_event;
 use pickers::{
@@ -79,6 +82,7 @@ pub fn handle_event(
     let in_scut_relay = !matches!(state.scut_relay, ScutRelayInput::Inactive);
     let in_scut_network = !matches!(state.scut_network, ScutNetworkInput::Inactive);
     let in_missions = !matches!(state.missions_input, MissionsInput::Inactive);
+    let in_messages = !matches!(state.messages_input, MessagesInput::Inactive);
     let in_rename_manny = !matches!(state.rename_manny, RenameMannyInput::Inactive);
     let in_deploy = !matches!(state.deploy, DeployInput::Inactive);
     let in_inspect = !matches!(state.inspect, InspectInput::Inactive);
@@ -174,6 +178,11 @@ pub fn handle_event(
 
     if in_missions {
         handle_missions_event(k.code, state, client, tx);
+        return;
+    }
+
+    if in_messages {
+        handle_messages_event(k.code, state, client, tx);
         return;
     }
 
@@ -320,6 +329,11 @@ pub fn handle_event(
         KeyCode::Char('b') => state.open_map(),
         KeyCode::Char('O') => {
             state.missions_input = MissionsInput::Browsing { selection: 0 };
+        }
+        KeyCode::Char('Y') => {
+            state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 };
+            fetch_messages(client.clone(), tx.clone());
+            fetch_sent_messages(client.clone(), tx.clone());
         }
         KeyCode::Char('N') => {
             let nets = state.scut_coverage();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,14 @@ use tokio::sync::mpsc;
 
 use neumann_cockpit::api::client::ApiClient;
 use neumann_cockpit::api::tasks::{
-    fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies, fetch_missions,
+    fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies, fetch_messages,
+    fetch_missions, fetch_sent_messages,
 };
 use neumann_cockpit::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
     DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput,
-    MindSnapshotInput, MineInput, MissionsInput, Phosphor, RecallInput, RecoverInput, RefuelInput,
+    MessagesInput, MindSnapshotInput, MineInput, MissionsInput, Phosphor, RecallInput, RecoverInput,
+    RefuelInput,
     RemoteMineInput,
     RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScutNetworkInput,
     ScutRelayInput, StorageMoveInput, UiTheme,
@@ -205,6 +207,20 @@ async fn run(
                     ApiMessage::ScutNetworkFetched(network) => {
                         if matches!(state.scut_network, ScutNetworkInput::Viewing { .. }) {
                             state.scut_network_view = Some(network);
+                        }
+                    }
+                    ApiMessage::MessagesFetched(m) => state.messages = m,
+                    ApiMessage::SentMessagesFetched(m) => state.sent_messages = m,
+                    ApiMessage::MessageSent(_) => {
+                        state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 };
+                        state.set_toast("message sent");
+                        fetch_messages(client.clone(), tx.clone());
+                        fetch_sent_messages(client.clone(), tx.clone());
+                    }
+                    ApiMessage::MessageSendError(e) => state.set_message_send_error(e),
+                    ApiMessage::MessageMarkedRead(m) => {
+                        if let Some(slot) = state.messages.iter_mut().find(|x| x.id == m.id) {
+                            *slot = m;
                         }
                     }
                     ApiMessage::ScutNetworkError(e) => {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -108,6 +108,11 @@ pub(crate) fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState)
         Span::styled("[O]", Style::default().fg(Color::Cyan)),
         Span::raw(" missions  "),
         Span::styled(
+            "[Y]",
+            Style::default().fg(if state.unread_message_count() > 0 { Color::Red } else { Color::Cyan }),
+        ),
+        Span::raw(if state.unread_message_count() > 0 { " msgs•  " } else { " msgs  " }),
+        Span::styled(
             "[N]",
             Style::default().fg(if state.scut_coverage().is_empty() { Color::Cyan } else { Color::LightBlue }),
         ),

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -57,6 +57,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         help_key_line("A", "alerts & damage warnings"),
         help_key_line("O", "missions"),
         help_key_line("N", "inspect SCUT network (when covered)"),
+        help_key_line("Y", "messages (inbox / sent / compose)"),
         help_key_line("?", "this help"),
         help_key_line("q", "quit"),
         help_key_line("Esc", "unfocus / close"),

--- a/src/ui/overlays/messages.rs
+++ b/src/ui/overlays/messages.rs
@@ -1,0 +1,149 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::api::types::MessageStatus;
+use crate::app::{AppState, MessagesInput};
+use super::{centered_rect, render_pick_list};
+
+fn preview(body: &str) -> String {
+    let one = body.replace('\n', " ");
+    if one.chars().count() > 48 {
+        format!("{}…", one.chars().take(48).collect::<String>())
+    } else {
+        one
+    }
+}
+
+pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match &state.messages_input {
+        MessagesInput::Browsing { sent_tab, selection } => {
+            let popup = centered_rect(76, 80, area);
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(" MESSAGES ")
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::White));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)])
+                .split(inner);
+
+            // Tabs
+            let inbox_style = if *sent_tab { Style::default().fg(Color::DarkGray) } else { Style::default().fg(Color::White).add_modifier(Modifier::BOLD) };
+            let sent_style = if *sent_tab { Style::default().fg(Color::White).add_modifier(Modifier::BOLD) } else { Style::default().fg(Color::DarkGray) };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("Inbox", inbox_style),
+                    Span::styled("   |   ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("Sent", sent_style),
+                ])),
+                rows[0],
+            );
+
+            let mut lines: Vec<Line> = Vec::new();
+            if *sent_tab {
+                if state.sent_messages.is_empty() {
+                    lines.push(Line::from(Span::styled("No sent messages.", Style::default().fg(Color::DarkGray))));
+                }
+                for (i, m) in state.sent_messages.iter().enumerate() {
+                    let marker = if i == *selection { "▸ " } else { "  " };
+                    lines.push(Line::from(vec![
+                        Span::styled(marker, Style::default().fg(Color::Cyan)),
+                        Span::styled(format!("→ {} ", m.recipient.name), Style::default().fg(Color::White)),
+                        Span::styled(preview(&m.body), Style::default().fg(Color::Gray)),
+                    ]));
+                }
+            } else {
+                if state.messages.is_empty() {
+                    lines.push(Line::from(Span::styled("No messages.", Style::default().fg(Color::DarkGray))));
+                }
+                for (i, m) in state.messages.iter().enumerate() {
+                    let marker = if i == *selection { "▸ " } else { "  " };
+                    let unread = m.status == MessageStatus::Unread;
+                    let dot = if unread { Span::styled("● ", Style::default().fg(Color::Cyan)) } else { Span::raw("  ") };
+                    let name_style = if unread { Style::default().fg(Color::White).add_modifier(Modifier::BOLD) } else { Style::default().fg(Color::Gray) };
+                    lines.push(Line::from(vec![
+                        Span::styled(marker, Style::default().fg(Color::Cyan)),
+                        dot,
+                        Span::styled(format!("{} ", m.sender.name), name_style),
+                        Span::styled(preview(&m.body), Style::default().fg(Color::DarkGray)),
+                    ]));
+                }
+            }
+            frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[1]);
+
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" inbox/sent  "),
+                    Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" read  "),
+                    Span::styled("[c]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" compose  "),
+                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" close"),
+                ])),
+                rows[2],
+            );
+        }
+
+        MessagesInput::PickRecipient { recipients, selection } => {
+            let names: Vec<String> = recipients.iter()
+                .map(|(kind, _, name)| format!("{name}  ({kind})"))
+                .collect();
+            let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+            let height = (recipients.len() as u16 + 6).min(16);
+            render_pick_list(
+                frame, area, " NEW MESSAGE — recipient ", 54, height,
+                Some("Send to:"), &refs, *selection, None, "compose",
+            );
+        }
+
+        MessagesInput::Compose { recipient_name, body_buf, error, .. } => {
+            let popup = centered_rect(60, 9, area);
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(format!(" MESSAGE → {recipient_name} "))
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(inner);
+
+            let mut lines = vec![Line::from(vec![
+                Span::styled(body_buf.clone(), Style::default().fg(Color::White)),
+                Span::styled("▏", Style::default().fg(Color::Cyan)),
+            ])];
+            if let Some(err) = error {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+            }
+            frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::raw(" send  "),
+                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::raw(" cancel"),
+                ])),
+                rows[1],
+            );
+        }
+
+        MessagesInput::Inactive => {}
+    }
+}

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod help;
 pub(crate) mod inventory_detail;
 pub(crate) mod jettison;
 pub(crate) mod map;
+pub(crate) mod messages;
 pub(crate) mod mine;
 pub(crate) mod missions;
 pub(crate) mod remote_mine;
@@ -28,6 +29,7 @@ pub(crate) use help::render_help_overlay;
 pub(crate) use inventory_detail::render_inventory_detail_overlay;
 pub(crate) use jettison::render_jettison_overlay;
 pub(crate) use map::render_map_overlay;
+pub(crate) use messages::render_messages_overlay;
 pub(crate) use mine::render_mine_overlay;
 pub(crate) use remote_mine::render_remote_mine_overlay;
 pub(crate) use missions::render_missions_overlay;
@@ -48,8 +50,8 @@ use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput, ContainersInput,
     CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput,
     JettisonInput, MineInput,
-    MindSnapshotInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
-    RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
+    MessagesInput, MindSnapshotInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput,
+    RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
     ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
 use ratatui::{
@@ -108,6 +110,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.missions_input, MissionsInput::Inactive) {
         render_missions_overlay(frame, area, state);
+    }
+    if !matches!(state.messages_input, MessagesInput::Inactive) {
+        render_messages_overlay(frame, area, state);
     }
     if !matches!(state.scut_relay, ScutRelayInput::Inactive) {
         render_scut_relay_overlay(frame, area, state);

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -1,8 +1,8 @@
 use neumann_cockpit::api::types::{
     AlertPhase, AlertStatus, AlertType, ContainerInventory, CraftingRecipe, DamageWarningRule,
     DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask, Mission, MissionStatus,
-    MannyTaskVisibility, MissionStepStatus, MovementPhase, Probe, ScutNetwork, ScutRelayStatus,
-    SectorObject,
+    EndpointId, MannyTaskVisibility, MessageStatus, MissionStepStatus, MovementPhase, Probe,
+    ProbeMessage, ScutNetwork, ScutRelayStatus, SectorObject,
     ProbeAlert, ProbeInventory, ProbeMovement, ProbeStatus, SectorObjectType, SectorObservation,
     SensorMode, StorageContainer,
 };
@@ -604,6 +604,27 @@ fn new_manny_tasks_deserialize() {
         MannyTask::TurningOnScutRelay
     );
     assert_eq!(deser::<MannyTask>(r#""unknown_too_far""#), MannyTask::UnknownTooFar);
+}
+
+#[test]
+fn probe_message_deserializes_with_mixed_endpoint_ids() {
+    let json = r#"{
+      "id": 12,
+      "sender": { "type": "probe", "id": 2, "probeId": 2, "name": "Probe of nova" },
+      "recipient": { "type": "planet", "id": "planet-abc", "planetId": "planet-abc", "name": "Pale Signal" },
+      "sector": { "relative": { "x": 0, "y": 0, "z": 0 } },
+      "body": "Signal local reçu.",
+      "status": "unread",
+      "readAt": null,
+      "createdAt": "2026-06-06T12:00:00+00:00",
+      "updatedAt": "2026-06-06T12:00:00+00:00"
+    }"#;
+    let m: ProbeMessage = deser(json);
+    assert_eq!(m.id, 12);
+    assert_eq!(m.status, MessageStatus::Unread);
+    assert_eq!(m.sender.id, EndpointId::Probe(2));
+    assert_eq!(m.recipient.id, EndpointId::Planet("planet-abc".into()));
+    assert_eq!(m.recipient.name, "Pale Signal");
 }
 
 #[test]


### PR DESCRIPTION
## What

Bloc F — inter-probe messaging. The last missing API endpoint.

- Endpoints: `GET /api/probe/messages`, `GET /api/probe/messages/sent`, `PATCH /api/probe/messages/{id}/read`, `POST /api/probe/messages`.
- New `[Y]` overlay: tabbed **inbox / sent** (`Tab` switches, `Enter` marks an inbox message read), and a **compose** flow — pick a recipient (probes detected in the sector + inhabited planets) → type the body → send.
- `EndpointId` modelled as `#[serde(untagged)] enum { Probe(i64), Planet(String) }` (the API's oneOf int|string).
- Unread badge (`•`) on `[Y]` in the status bar; inbox/sent load on open (not in `fetch_all`).

## Scope

Recipients are sector-local (detected probes + inhabited planets). SCUT-network-reachable probes as recipients can follow if wanted; the server validates range either way.

## Verification

`cargo clippy -- -D warnings` clean · `cargo test` → 154 passed (+3: message serde with mixed endpoint ids, unread count, …).