### PR TITLE
feat(cockpit): unified tiling interface scaffolding

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,6 +1,9 @@
 base_url = "https://neumann-probe.net"
 api_key  = "vng_your_api_key_here"
 
+# Layout: "classic" (default), "retro", or "cockpit" — the unified tiling
+# interface (work in progress, U-series). Takes precedence over `theme`.
+#ui = "cockpit"
 # UI theme: "classic" (default) or "retro" — phosphor CRT console with
 # idle animations. Toggle at runtime with F2.
 #theme = "retro"

--- a/src/app/anim.rs
+++ b/src/app/anim.rs
@@ -5,6 +5,9 @@ pub enum UiTheme {
     #[default]
     Classic,
     Retro,
+    /// Unified Cockpit v2 interface — opt-in preview during the U-series
+    /// migration (config `ui = "cockpit"`), becomes the default at bloc U8.
+    Cockpit,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -54,6 +57,9 @@ impl AppState {
         self.ui_theme = match self.ui_theme {
             UiTheme::Classic => UiTheme::Retro,
             UiTheme::Retro => UiTheme::Classic,
+            // Cockpit is a config-gated dev preview; F2 stays put until the
+            // color-mode cycling lands in U7.
+            UiTheme::Cockpit => UiTheme::Cockpit,
         };
     }
 

--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -1,0 +1,173 @@
+//! Pane grid model for the unified Cockpit v2 interface (bloc U1).
+//!
+//! These types back the 3×3 tiling dashboard. They are consumed by later
+//! blocs (navigation, drill-in, rendering); U1 only establishes the state
+//! that `AppState` carries, so most of it is not read yet.
+#![allow(dead_code)]
+
+/// The nine panes of the Cockpit v2 grid, laid out to match the
+/// `e r t / d f g / c v b` navigation square (identical on AZERTY and
+/// QWERTY). `Probe` is the centre — the `f` home key with the tactile bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Pane {
+    Scanner,   // e
+    Map,       // r
+    Comms,     // t
+    Sector,    // d
+    #[default]
+    Probe,     // f — centre of the square
+    Missions,  // g
+    Inventory, // c
+    Storage,   // v
+    Mannies,   // b
+}
+
+impl Pane {
+    /// All panes in grid order (row-major: e r t / d f g / c v b).
+    pub const ALL: [Pane; 9] = [
+        Pane::Scanner,
+        Pane::Map,
+        Pane::Comms,
+        Pane::Sector,
+        Pane::Probe,
+        Pane::Missions,
+        Pane::Inventory,
+        Pane::Storage,
+        Pane::Mannies,
+    ];
+
+    /// Map a bare (lowercase, unmodified) navigation key to its pane.
+    pub fn from_key(c: char) -> Option<Pane> {
+        Some(match c {
+            'e' => Pane::Scanner,
+            'r' => Pane::Map,
+            't' => Pane::Comms,
+            'd' => Pane::Sector,
+            'f' => Pane::Probe,
+            'g' => Pane::Missions,
+            'c' => Pane::Inventory,
+            'v' => Pane::Storage,
+            'b' => Pane::Mannies,
+            _ => return None,
+        })
+    }
+
+    /// The lowercase key that activates this pane (matched at input time).
+    pub fn key(self) -> char {
+        match self {
+            Pane::Scanner => 'e',
+            Pane::Map => 'r',
+            Pane::Comms => 't',
+            Pane::Sector => 'd',
+            Pane::Probe => 'f',
+            Pane::Missions => 'g',
+            Pane::Inventory => 'c',
+            Pane::Storage => 'v',
+            Pane::Mannies => 'b',
+        }
+    }
+
+    /// Uppercase key for display (keycaps, hints, menus).
+    pub fn key_label(self) -> char {
+        self.key().to_ascii_uppercase()
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Pane::Scanner => "SCANNER",
+            Pane::Map => "MAP",
+            Pane::Comms => "COMMS",
+            Pane::Sector => "SECTOR",
+            Pane::Probe => "PROBE",
+            Pane::Missions => "MISSIONS",
+            Pane::Inventory => "INVENTORY",
+            Pane::Storage => "STORAGE",
+            Pane::Mannies => "MANNIES",
+        }
+    }
+
+    /// `(row, col)` position in the 3×3 grid, both in `0..3`.
+    pub fn grid_pos(self) -> (u8, u8) {
+        match self {
+            Pane::Scanner => (0, 0),
+            Pane::Map => (0, 1),
+            Pane::Comms => (0, 2),
+            Pane::Sector => (1, 0),
+            Pane::Probe => (1, 1),
+            Pane::Missions => (1, 2),
+            Pane::Inventory => (2, 0),
+            Pane::Storage => (2, 1),
+            Pane::Mannies => (2, 2),
+        }
+    }
+
+    /// Stable index `0..9`, used to key `AppState::pane_nav`. Matches the
+    /// order of [`Pane::ALL`].
+    pub fn index(self) -> usize {
+        let (row, col) = self.grid_pos();
+        row as usize * 3 + col as usize
+    }
+}
+
+/// A level pushed onto a pane's drill-in stack. Bloc U3 consumes these; U1
+/// only establishes the type so the per-pane stack has a payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DrillLevel {
+    Container(String),
+    Mission(String),
+    ItemGroup(String),
+    Manny(String),
+    SectorObject(usize),
+    MessageThread(String),
+}
+
+/// Per-pane navigation state: the cursor at the current level plus the
+/// drill-in breadcrumb below the pane root.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PaneNav {
+    pub cursor: usize,
+    pub drill: Vec<DrillLevel>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_pane_is_probe_centre() {
+        assert_eq!(Pane::default(), Pane::Probe);
+        assert_eq!(Pane::Probe.grid_pos(), (1, 1));
+        assert_eq!(Pane::Probe.key(), 'f');
+    }
+
+    #[test]
+    fn key_round_trips_for_every_pane() {
+        for pane in Pane::ALL {
+            assert_eq!(Pane::from_key(pane.key()), Some(pane));
+            assert_eq!(pane.key_label(), pane.key().to_ascii_uppercase());
+        }
+    }
+
+    #[test]
+    fn non_grid_key_maps_to_none() {
+        for c in ['a', 'z', 'q', 'j', 'k', 'h', 'l', '1', ' '] {
+            assert_eq!(Pane::from_key(c), None);
+        }
+    }
+
+    #[test]
+    fn index_is_unique_and_matches_all_order() {
+        for (i, pane) in Pane::ALL.into_iter().enumerate() {
+            assert_eq!(pane.index(), i, "{pane:?} index");
+        }
+    }
+
+    #[test]
+    fn grid_positions_are_distinct() {
+        let mut seen = std::collections::HashSet::new();
+        for pane in Pane::ALL {
+            assert!(seen.insert(pane.grid_pos()), "duplicate pos for {pane:?}");
+        }
+        assert_eq!(seen.len(), 9);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,10 +1,12 @@
 mod anim;
 mod containers;
+mod grid;
 mod inputs;
 mod inventory;
 mod mannies;
 mod map;
 mod message;
+mod mode;
 mod scan;
 mod travel;
 mod waypoints;
@@ -12,10 +14,12 @@ mod waypoints;
 mod tests;
 
 pub use anim::*;
+pub use grid::*;
 pub use inputs::*;
 pub use inventory::*;
 pub use map::*;
 pub use message::*;
+pub use mode::*;
 pub use scan::*;
 pub use waypoints::*;
 
@@ -114,6 +118,15 @@ pub struct AppState {
     /// Render-tick animations for the retro theme (no I/O involved).
     pub animations_enabled: bool,
     pub anim: AnimState,
+    // ── Cockpit v2 (bloc U1) ────────────────────────────────────────────
+    /// Active pane in the 3×3 grid (defaults to `Probe`, the centre).
+    pub active_pane: Pane,
+    /// Whether the active pane is zoomed to full screen.
+    pub zoomed: bool,
+    /// Top-level interaction mode for the unified interface.
+    pub mode: InputMode,
+    /// Per-pane cursor + drill-in state, indexed by `Pane::index()`.
+    pub pane_nav: [PaneNav; 9],
 }
 
 impl AppState {

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -1,0 +1,79 @@
+//! Input mode state machine for the Cockpit v2 interface (bloc U1).
+//!
+//! `InputMode` is the top-level state the input router will dispatch on in
+//! later blocs. U1 only wires the state and its default (`Normal`); the
+//! `Menu`/`Command` payloads are populated by blocs U5/U6. The `Prompt`
+//! variant (wrapping the existing `*Input` wizards) is added in U5.
+#![allow(dead_code)]
+
+/// A single entry in a contextual action menu.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MenuItem {
+    pub label: String,
+    pub enabled: bool,
+    /// Reason shown (dimmed) when the item is disabled — teaches the rules
+    /// instead of hiding the action.
+    pub disabled_reason: Option<String>,
+}
+
+/// The contextual action menu opened with `Enter` on a selection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ContextMenu {
+    pub title: String,
+    pub items: Vec<MenuItem>,
+    pub cursor: usize,
+}
+
+/// The `:` command line being typed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CommandLine {
+    pub input: String,
+    /// Caret position within `input`.
+    pub cursor: usize,
+}
+
+/// Top-level interaction mode. The input router dispatches on this.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum InputMode {
+    /// Grid navigation + cursor + drill-in.
+    #[default]
+    Normal,
+    /// A contextual action menu is open.
+    Menu(ContextMenu),
+    /// The command line is being typed.
+    Command(CommandLine),
+}
+
+impl InputMode {
+    /// Short uppercase tag shown in the status bar (`NAV` / `MENU` / `CMD`).
+    pub fn tag(&self) -> &'static str {
+        match self {
+            InputMode::Normal => "NAV",
+            InputMode::Menu(_) => "MENU",
+            InputMode::Command(_) => "CMD",
+        }
+    }
+
+    pub fn is_text_entry(&self) -> bool {
+        matches!(self, InputMode::Command(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_mode_is_normal() {
+        assert_eq!(InputMode::default(), InputMode::Normal);
+        assert_eq!(InputMode::default().tag(), "NAV");
+        assert!(!InputMode::default().is_text_entry());
+    }
+
+    #[test]
+    fn command_mode_is_text_entry() {
+        let m = InputMode::Command(CommandLine::default());
+        assert!(m.is_text_entry());
+        assert_eq!(m.tag(), "CMD");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,10 @@ use std::path::PathBuf;
 pub struct Config {
     pub base_url: String,
     pub api_key: String,
+    /// Layout: "classic" (default), "retro", or "cockpit" (unified preview,
+    /// bloc U-series). Takes precedence over `theme` when set.
+    #[serde(default)]
+    pub ui: Option<String>,
     /// UI theme: "classic" (default) or "retro".
     #[serde(default)]
     pub theme: Option<String>,
@@ -24,9 +28,17 @@ fn default_true() -> bool {
 
 impl Config {
     pub fn ui_theme(&self) -> crate::app::UiTheme {
+        use crate::app::UiTheme;
+        // `ui` (layout) wins over the legacy `theme` key when set.
+        match self.ui.as_deref() {
+            Some("cockpit") => return UiTheme::Cockpit,
+            Some("retro") => return UiTheme::Retro,
+            Some("classic") => return UiTheme::Classic,
+            _ => {}
+        }
         match self.theme.as_deref() {
-            Some("retro") => crate::app::UiTheme::Retro,
-            _ => crate::app::UiTheme::Classic,
+            Some("retro") => UiTheme::Retro,
+            _ => UiTheme::Classic,
         }
     }
 
@@ -63,4 +75,35 @@ pub fn history_path() -> PathBuf {
     ProjectDirs::from("net", "neumann", "neumann-cockpit")
         .map(|d| d.config_dir().join("scan_history.json"))
         .unwrap_or_else(|| PathBuf::from("scan_history.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::UiTheme;
+
+    fn cfg(ui: Option<&str>, theme: Option<&str>) -> Config {
+        Config {
+            base_url: "x".into(),
+            api_key: "x".into(),
+            ui: ui.map(String::from),
+            theme: theme.map(String::from),
+            phosphor: None,
+            animations: true,
+        }
+    }
+
+    #[test]
+    fn ui_key_wins_over_theme() {
+        assert_eq!(cfg(Some("cockpit"), Some("retro")).ui_theme(), UiTheme::Cockpit);
+        assert_eq!(cfg(Some("retro"), None).ui_theme(), UiTheme::Retro);
+        assert_eq!(cfg(Some("classic"), Some("retro")).ui_theme(), UiTheme::Classic);
+    }
+
+    #[test]
+    fn falls_back_to_theme_when_ui_absent() {
+        assert_eq!(cfg(None, Some("retro")).ui_theme(), UiTheme::Retro);
+        assert_eq!(cfg(None, None).ui_theme(), UiTheme::Classic);
+        assert_eq!(cfg(None, Some("bogus")).ui_theme(), UiTheme::Classic);
+    }
 }

--- a/src/ui/cockpit_v2.rs
+++ b/src/ui/cockpit_v2.rs
@@ -1,0 +1,96 @@
+//! Unified Cockpit v2 interface (bloc U1 — scaffolding stub).
+//!
+//! This is the entry point for the new tiling dashboard. U1 only proves the
+//! config gate and the render dispatch are wired: it draws the 3×3 grid of
+//! pane labels with the active pane highlighted, plus a WIP banner. The real
+//! responsive layout, per-pane content, zoom, menus and command line land in
+//! blocs U2–U7.
+
+use crate::app::{AppState, Pane};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+const AMBER: Color = Color::Rgb(0xff, 0xb2, 0x4a);
+const GREEN: Color = Color::Rgb(0x5e, 0xf0, 0x8f);
+const DIM: Color = Color::Rgb(0x6f, 0x8c, 0x7d);
+
+pub fn render(frame: &mut Frame, state: &AppState) {
+    let area = frame.area();
+
+    let outer = Block::default()
+        .title(" NEUMANN COCKPIT · UNIFIED (WIP) ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(GREEN));
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    render_grid(frame, rows[0], state);
+    render_status(frame, rows[1], state);
+}
+
+fn render_grid(frame: &mut Frame, area: Rect, state: &AppState) {
+    let grid_rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Ratio(1, 3); 3])
+        .split(area);
+
+    for (r, row_area) in grid_rows.iter().enumerate() {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Ratio(1, 3); 3])
+            .split(*row_area);
+        for (c, cell) in cols.iter().enumerate() {
+            let pane = Pane::ALL[r * 3 + c];
+            render_cell(frame, *cell, pane, pane == state.active_pane);
+        }
+    }
+}
+
+fn render_cell(frame: &mut Frame, area: Rect, pane: Pane, active: bool) {
+    let color = if active { AMBER } else { DIM };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(color))
+        .title(Span::styled(
+            format!(" {} ", pane.label()),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let key = Line::from(Span::styled(
+        format!("[{}]", pane.key_label()),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    ))
+    .alignment(Alignment::Center);
+    frame.render_widget(Paragraph::new(key), inner);
+}
+
+fn render_status(frame: &mut Frame, area: Rect, state: &AppState) {
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" {} ", state.mode.tag()),
+            Style::default().fg(Color::Black).bg(AMBER).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("  {} ", state.active_pane.label()),
+            Style::default().fg(GREEN),
+        ),
+        Span::styled(
+            "· ertdfgcvb select · z zoom · U1 scaffold",
+            Style::default().fg(DIM),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod cockpit;
+pub mod cockpit_v2;
 pub(crate) mod overlays;
 pub(crate) mod panels;
 pub mod retro;
@@ -7,10 +8,12 @@ pub(crate) mod theme;
 use crate::app::{AppState, UiTheme};
 use ratatui::Frame;
 
-/// Theme dispatch: classic 4-panel cockpit or the retro phosphor console.
+/// Layout dispatch: classic 4-panel cockpit, retro phosphor console, or the
+/// unified Cockpit v2 interface (opt-in preview during the U-series).
 pub fn render(frame: &mut Frame, state: &AppState) {
     match state.ui_theme {
         UiTheme::Classic => cockpit::render(frame, state),
         UiTheme::Retro => retro::render(frame, state),
+        UiTheme::Cockpit => cockpit_v2::render(frame, state),
     }
 }


### PR DESCRIPTION
First step toward a single unified interface replacing the classic and retro themes: a 3×3 tiling dashboard ("Cockpit") with keyboard-first navigation and a per-pane zoom.

This PR is pure scaffolding — no default behaviour change. The classic layout stays the default; the new interface is an opt-in preview.

## What it adds

- **Config gate** — new `ui` key (`"classic" | "retro" | "cockpit"`), taking precedence over the legacy `theme` key. `ui = "cockpit"` selects the new layout.
- **Pane grid model** (`src/app/grid.rs`) — the 9 panes mapped to the `e r t / d f g / c v b` navigation square (identical on AZERTY and QWERTY; `Probe` is the centre `f` home key). Key round-trip, stable indices, grid positions.
- **Per-pane navigation state** — `PaneNav` (cursor + drill-in stack) and `DrillLevel`, one per pane.
- **Interaction mode state machine** (`src/app/mode.rs`) — `InputMode` (`Normal` / `Menu` / `Command`) that the input router will dispatch on.
- **Render dispatch + stub** (`src/ui/cockpit_v2.rs`) — draws the 3×3 grid of pane labels with the active pane highlighted, proving the gate and dispatch are wired.

Per-pane content, responsive layout, drill-in, zoom, contextual menus and command mode follow in later PRs.

## Verification

- `cargo build` ✓
- `cargo test` → 163 passed
- `cargo clippy` (lib) → 0 warnings; no new warnings introduced