### PR TITLE
feat(cockpit): responsive 3×3 grid with read-only pane navigation

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -129,6 +129,69 @@ pub struct PaneNav {
     pub drill: Vec<DrillLevel>,
 }
 
+impl super::AppState {
+    /// Switch the active pane to the sequential next/previous one, wrapping
+    /// around (fallback to the grid keys for `Tab`/`Shift+Tab`).
+    pub fn cycle_pane(&mut self, forward: bool) {
+        let n = Pane::ALL.len();
+        let cur = Pane::ALL
+            .iter()
+            .position(|p| *p == self.active_pane)
+            .unwrap_or(0);
+        let next = if forward {
+            (cur + 1) % n
+        } else {
+            (cur + n - 1) % n
+        };
+        self.active_pane = Pane::ALL[next];
+    }
+
+    /// Number of selectable rows in a pane. Panes reusing the classic
+    /// renderers (Inventory/Scanner/Mannies) keep their own cursors, so they
+    /// report 0 here; only the promoted panes drive `pane_nav`.
+    pub fn pane_item_count(&self, pane: Pane) -> usize {
+        match pane {
+            Pane::Comms => self.messages.len(),
+            Pane::Sector => self.scanner_objects().len(),
+            Pane::Missions => self.missions.len(),
+            Pane::Storage => self.storage_containers.len(),
+            _ => 0,
+        }
+    }
+
+    /// Move the cursor down within the active pane, routing to the pane's
+    /// backing cursor (classic panels keep their existing selection state).
+    pub fn pane_cursor_down(&mut self) {
+        match self.active_pane {
+            Pane::Inventory => self.inventory_next(),
+            Pane::Scanner => self.scan_hist_next(),
+            Pane::Mannies => self.manny_next(),
+            Pane::Probe | Pane::Map => {}
+            pane => {
+                let n = self.pane_item_count(pane);
+                if n > 0 {
+                    let nav = &mut self.pane_nav[pane.index()];
+                    nav.cursor = (nav.cursor + 1).min(n - 1);
+                }
+            }
+        }
+    }
+
+    /// Move the cursor up within the active pane.
+    pub fn pane_cursor_up(&mut self) {
+        match self.active_pane {
+            Pane::Inventory => self.inventory_prev(),
+            Pane::Scanner => self.scan_hist_prev(),
+            Pane::Mannies => self.manny_prev(),
+            Pane::Probe | Pane::Map => {}
+            pane => {
+                let nav = &mut self.pane_nav[pane.index()];
+                nav.cursor = nav.cursor.saturating_sub(1);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -1,0 +1,37 @@
+//! Input routing for the unified Cockpit v2 interface (bloc U2).
+//!
+//! Normal-mode navigation only: `ertdfgcvb` activates a pane, `jk`/arrows
+//! move the cursor within it, `Tab` cycles panes, `F5` refreshes. Drill-in,
+//! zoom, contextual menus (`Enter`) and command mode (`:`) land in later
+//! blocs; unhandled keys are ignored.
+
+use crossterm::event::KeyCode;
+use tokio::sync::mpsc;
+
+use crate::api::client::ApiClient;
+use crate::api::tasks::fetch_all;
+use crate::app::{ApiMessage, AppState, Pane};
+
+pub fn handle_cockpit_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match code {
+        KeyCode::Char('q') => state.set_quit(),
+        KeyCode::Char(c) if Pane::from_key(c).is_some() => {
+            state.active_pane = Pane::from_key(c).unwrap();
+        }
+        KeyCode::Down | KeyCode::Char('j') => state.pane_cursor_down(),
+        KeyCode::Up | KeyCode::Char('k') => state.pane_cursor_up(),
+        KeyCode::Tab => state.cycle_pane(true),
+        KeyCode::BackTab => state.cycle_pane(false),
+        KeyCode::F(5) if !state.loading => {
+            state.clear_error();
+            state.loading = true;
+            fetch_all(client.clone(), tx.clone());
+        }
+        _ => {}
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -18,6 +18,7 @@ use crate::app::{
     ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
 mod alerts;
+mod cockpit;
 mod containers;
 mod craft;
 mod geometry;
@@ -33,6 +34,7 @@ mod storage_move;
 mod travel;
 
 use alerts::handle_alerts_event;
+use cockpit::handle_cockpit_event;
 use containers::{
     handle_container_rules_event, handle_containers_event, handle_rename_container_event,
 };
@@ -109,6 +111,12 @@ pub fn handle_event(
 
     if k.code == KeyCode::F(2) {
         state.toggle_theme();
+        return;
+    }
+
+    // Unified Cockpit v2 interface has its own input router (bloc U-series).
+    if state.ui_theme == crate::app::UiTheme::Cockpit {
+        handle_cockpit_event(k.code, state, client, tx);
         return;
     }
 

--- a/src/ui/cockpit_v2/grid.rs
+++ b/src/ui/cockpit_v2/grid.rs
@@ -1,0 +1,57 @@
+//! Responsive layout for the Cockpit v2 tiling grid (bloc U2).
+//!
+//! Chooses a layout by terminal size and returns the visible panes with
+//! their `Rect`s. U2 implements the full 3×3 and a single-pane fallback for
+//! small terminals; the intermediate 2×2 + pagination tier lands in a
+//! follow-up.
+
+use crate::app::Pane;
+use ratatui::layout::{Constraint, Layout, Rect};
+
+/// Minimum size for the full 3×3 grid; below this we fall back to a single
+/// full-screen pane (the active one).
+const FULL_MIN_W: u16 = 96;
+const FULL_MIN_H: u16 = 27;
+
+/// The panes to draw this frame, each with its cell rectangle.
+///
+/// - Large terminals → all nine panes in a 3×3 grid.
+/// - Small terminals → only the active pane, full screen (navigation keys
+///   still switch which pane is shown).
+pub fn visible_panes(area: Rect, active: Pane) -> Vec<(Pane, Rect)> {
+    if area.width < FULL_MIN_W || area.height < FULL_MIN_H {
+        return vec![(active, area)];
+    }
+
+    let rows = Layout::vertical([Constraint::Ratio(1, 3); 3]).split(area);
+    let mut out = Vec::with_capacity(9);
+    for (r, row) in rows.iter().enumerate() {
+        let cols = Layout::horizontal([Constraint::Ratio(1, 3); 3]).split(*row);
+        for (c, cell) in cols.iter().enumerate() {
+            out.push((Pane::ALL[r * 3 + c], *cell));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn large_area_shows_all_nine() {
+        let panes = visible_panes(Rect::new(0, 0, 120, 40), Pane::Probe);
+        assert_eq!(panes.len(), 9);
+        // Every pane appears exactly once, in grid order.
+        for (i, (pane, _)) in panes.iter().enumerate() {
+            assert_eq!(*pane, Pane::ALL[i]);
+        }
+    }
+
+    #[test]
+    fn small_area_shows_only_active_pane() {
+        let panes = visible_panes(Rect::new(0, 0, 60, 20), Pane::Mannies);
+        assert_eq!(panes.len(), 1);
+        assert_eq!(panes[0].0, Pane::Mannies);
+    }
+}

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -1,0 +1,72 @@
+//! Unified Cockpit v2 interface — the 3×3 tiling dashboard (bloc U2).
+//!
+//! U2 delivers the responsive grid and read-only navigation: `ertdfgcvb`
+//! selects a pane, `jk` moves the cursor within it. Drill-in, zoom,
+//! contextual menus and command mode follow in later blocs. The four
+//! original panes reuse their existing renderers; the five promoted panes
+//! (Map, Comms, Sector, Missions, Storage) use the compact renderers in
+//! [`panes`].
+
+mod grid;
+mod panes;
+
+use crate::app::{AppState, Pane};
+use crate::ui::panels::{
+    render_inventory_panel, render_mannies_panel, render_probe_panel, render_scanner_panel,
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+const AMBER: Color = Color::Rgb(0xff, 0xb2, 0x4a);
+const GREEN: Color = Color::Rgb(0x5e, 0xf0, 0x8f);
+const DIM: Color = Color::Rgb(0x6f, 0x8c, 0x7d);
+
+pub fn render(frame: &mut Frame, state: &AppState) {
+    let area = frame.area();
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+
+    for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
+        render_pane(frame, rect, pane, state, pane == state.active_pane);
+    }
+    render_status(frame, rows[1], state);
+}
+
+fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, active: bool) {
+    match pane {
+        Pane::Probe => render_probe_panel(frame, area, state, active),
+        Pane::Inventory => render_inventory_panel(frame, area, state, active),
+        Pane::Scanner => render_scanner_panel(frame, area, state, active),
+        Pane::Mannies => render_mannies_panel(frame, area, state, active),
+        Pane::Map => panes::render_map(frame, area, state, active),
+        Pane::Comms => panes::render_comms(frame, area, state, active),
+        Pane::Sector => panes::render_sector(frame, area, state, active),
+        Pane::Missions => panes::render_missions(frame, area, state, active),
+        Pane::Storage => panes::render_storage(frame, area, state, active),
+    }
+}
+
+fn render_status(frame: &mut Frame, area: Rect, state: &AppState) {
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" {} ", state.mode.tag()),
+            Style::default().fg(Color::Black).bg(AMBER).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("  {} ", state.active_pane.label()),
+            Style::default().fg(GREEN),
+        ),
+        Span::styled(
+            "· ertdfgcvb select · jk move · Tab cycle · F5 refresh · q quit",
+            Style::default().fg(DIM),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -1,0 +1,170 @@
+//! Compact read-only renderers for the five panes promoted from overlays
+//! (bloc U2): Map, Comms, Sector, Missions, Storage. The four original panes
+//! (Probe, Inventory, Scanner, Mannies) reuse their existing renderers.
+//!
+//! These show a terse summary sized for a 1/3 grid cell; the rich detail and
+//! actions land in the zoom view (U3) and menus (U5).
+
+use crate::api::types::MissionStatus;
+use crate::app::{AppState, Pane};
+use crate::ui::theme::{gauge_color, object_icon, panel_block};
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+const DIM: Style = Style::new().fg(Color::DarkGray);
+
+/// Style for the selected row: highlighted only while the pane is active.
+fn row_style(active: bool, selected: bool) -> Style {
+    if active && selected {
+        Style::default().add_modifier(Modifier::REVERSED)
+    } else {
+        Style::default()
+    }
+}
+
+fn cursor(state: &AppState, pane: Pane) -> usize {
+    state.pane_nav[pane.index()].cursor
+}
+
+fn render_body(frame: &mut Frame, area: Rect, title: &str, active: bool, lines: Vec<Line>) {
+    let block = panel_block(title, active);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+pub fn render_map(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    let mut lines = Vec::new();
+    match state.probe_sector_coords() {
+        Some((x, y, z)) => lines.push(Line::from(format!("sector ({x}, {y}, {z})"))),
+        None => lines.push(Line::styled("sector unknown", DIM)),
+    }
+    lines.push(Line::from(format!("visited: {}", state.visited_sectors.len())));
+    let nets = state.scut_coverage();
+    if nets.is_empty() {
+        lines.push(Line::styled("SCUT: no coverage", DIM));
+    } else {
+        lines.push(Line::styled(
+            format!("≣ SCUT: {} network(s)", nets.len()),
+            Style::default().fg(Color::LightBlue),
+        ));
+    }
+    lines.push(Line::styled("[z] zoom for full map", DIM));
+    render_body(frame, area, " MAP ", active, lines);
+}
+
+pub fn render_comms(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    let unread_alerts = state.unread_alert_count();
+    let unread_msgs = state.unread_message_count();
+    let mut lines = vec![
+        Line::from(vec![
+            Span::raw(format!("alerts {} ", state.alerts.len())),
+            Span::styled(format!("({unread_alerts} unread)"), DIM),
+            Span::raw(format!("  warn {}", state.damage_warnings.len())),
+        ]),
+        Line::from(vec![
+            Span::raw(format!("messages {} ", state.messages.len())),
+            Span::styled(format!("({unread_msgs} unread)"), DIM),
+        ]),
+        Line::raw(""),
+    ];
+    let cur = cursor(state, Pane::Comms);
+    if state.messages.is_empty() {
+        lines.push(Line::styled("no messages", DIM));
+    } else {
+        for (i, m) in state.messages.iter().enumerate() {
+            let unread = m.status == crate::api::types::MessageStatus::Unread;
+            let mark = if unread { "✉" } else { "·" };
+            let body: String = m.body.chars().take(18).collect();
+            let span = Span::styled(
+                format!("{mark} {}: {}", m.sender.name, body),
+                row_style(active, i == cur),
+            );
+            lines.push(Line::from(span));
+        }
+    }
+    render_body(frame, area, " COMMS ", active, lines);
+}
+
+pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    let mut lines = Vec::new();
+    match state.current_sector() {
+        Some(s) => {
+            let v = &s.relative_coordinates;
+            lines.push(Line::from(format!(
+                "({}, {}, {})  d{}",
+                v.x as i32, v.y as i32, v.z as i32, s.distance
+            )));
+            let objs = state.scanner_objects();
+            lines.push(Line::styled(format!("{} object(s)", objs.len()), DIM));
+            let cur = cursor(state, Pane::Sector);
+            for (i, e) in objs.iter().enumerate() {
+                let (icon, color) = object_icon(&e.object_type);
+                let name: String = e.name.chars().take(20).collect();
+                lines.push(Line::from(vec![
+                    Span::styled(format!("{icon} "), Style::default().fg(color)),
+                    Span::styled(name, row_style(active, i == cur)),
+                ]));
+            }
+        }
+        None => lines.push(Line::styled("no sector scan yet", DIM)),
+    }
+    render_body(frame, area, " SECTOR ", active, lines);
+}
+
+pub fn render_missions(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    let mut lines = Vec::new();
+    if state.missions.is_empty() {
+        lines.push(Line::styled("no active missions", DIM));
+    } else {
+        let cur = cursor(state, Pane::Missions);
+        for (i, m) in state.missions.iter().enumerate() {
+            let color = match m.status {
+                MissionStatus::Active => Color::Cyan,
+                MissionStatus::Completed => Color::Green,
+                MissionStatus::Failed | MissionStatus::Abandoned => Color::Red,
+                MissionStatus::Unknown => Color::DarkGray,
+            };
+            let done = m.steps.iter().filter(|s| {
+                matches!(s.status, crate::api::types::MissionStepStatus::Completed)
+            }).count();
+            let title: String = m.title.chars().take(22).collect();
+            lines.push(Line::from(vec![
+                Span::styled("▸ ", Style::default().fg(color)),
+                Span::styled(title, row_style(active, i == cur)),
+                Span::styled(format!(" {done}/{}", m.steps.len()), DIM),
+            ]));
+        }
+    }
+    render_body(frame, area, " MISSIONS ", active, lines);
+}
+
+pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    let mut lines = Vec::new();
+    if state.storage_containers.is_empty() {
+        lines.push(Line::styled("no containers ([C] loads)", DIM));
+    } else {
+        let cur = cursor(state, Pane::Storage);
+        for (i, c) in state.storage_containers.iter().enumerate() {
+            let ratio = if c.capacity > 0.0 {
+                c.used_capacity / c.capacity
+            } else {
+                0.0
+            };
+            let label: String = c.label.chars().take(16).collect();
+            lines.push(Line::from(vec![
+                Span::styled(label, row_style(active, i == cur)),
+                Span::styled(
+                    format!(" {:.0}/{:.0}", c.used_capacity, c.capacity),
+                    Style::default().fg(gauge_color(1.0 - ratio)),
+                ),
+            ]));
+        }
+    }
+    render_body(frame, area, " STORAGE ", active, lines);
+}


### PR DESCRIPTION
Second bloc of the unified interface. The cockpit is now **dogfood-able read-only**: enable it with `ui = "cockpit"` in the config, navigate with the keyboard, and see live data in all nine panes.

## What it adds

- **Responsive grid** (`cockpit_v2/grid.rs`) — full 3×3 on large terminals, single full-screen pane on small ones (navigation keys still switch which pane shows). The 2×2 + pagination tier is a follow-up.
- **Keyboard navigation** (`input/cockpit.rs`) — `ertdfgcvb` activates a pane, `jk`/arrows move the cursor within it, `Tab`/`Shift+Tab` cycle panes, `F5` refreshes. Routing is gated on the cockpit layout, so classic and retro are untouched.
- **Pane content** — the four original panes (Probe, Inventory, Scanner, Mannies) reuse their existing renderers; the five promoted panes (Map, Comms, Sector, Missions, Storage) get compact summary renderers reading `pane_nav` cursors.
- **State helpers** (`app/grid.rs`) — `cycle_pane`, `pane_item_count`, `pane_cursor_down/up`.

## Not yet (later blocs)

Drill-in (`hl`, U3), zoom (`z`, U3), contextual menus (`Enter`, U5), command mode (`:`, U6). Read-only until then.

## Notes / known debt

- Reused classic panels keep their Cyan focus border and old key-hint footers inside cockpit cells — cosmetic, resolved when the theme unifies (U7).
- Small cells clip the heavier reused panels; content/sizing polish comes with the compact-render pass.

## Verification

- `cargo build` ✓
- `cargo test` → 165 passed (incl. new grid layout tests)
- `cargo clippy` → clean on the new files