### PR TITLE
feat(cockpit): drill-in, zoom and breadcrumb

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -150,10 +150,23 @@ impl super::AppState {
     /// renderers (Inventory/Scanner/Mannies) keep their own cursors, so they
     /// report 0 here; only the promoted panes drive `pane_nav`.
     pub fn pane_item_count(&self, pane: Pane) -> usize {
+        let drill = self.pane_nav[pane.index()].drill.last();
         match pane {
-            Pane::Comms => self.messages.len(),
+            // Inside a message thread there is no list to move through.
+            Pane::Comms => match drill {
+                Some(DrillLevel::MessageThread(_)) => 0,
+                _ => self.messages.len(),
+            },
             Pane::Sector => self.scanner_objects().len(),
-            Pane::Missions => self.missions.len(),
+            // Drilled into a mission, the cursor moves over its steps.
+            Pane::Missions => match drill {
+                Some(DrillLevel::Mission(id)) => self
+                    .missions
+                    .iter()
+                    .find(|m| &m.id == id)
+                    .map_or(0, |m| m.steps.len()),
+                _ => self.missions.len(),
+            },
             Pane::Storage => self.storage_containers.len(),
             _ => 0,
         }
@@ -189,6 +202,72 @@ impl super::AppState {
                 nav.cursor = nav.cursor.saturating_sub(1);
             }
         }
+    }
+
+    /// Toggle full-screen zoom of the active pane.
+    pub fn toggle_zoom(&mut self) {
+        self.zoomed = !self.zoomed;
+    }
+
+    /// Descend into the selected element of the active pane (drill-in).
+    /// U3 supports one level, for panes whose detail is already in state:
+    /// Missions (→ steps) and Comms (→ message thread). Other panes are
+    /// no-ops until their detail views land.
+    pub fn pane_drill_in(&mut self) {
+        let idx = self.active_pane.index();
+        // Only one level deep for now.
+        if !self.pane_nav[idx].drill.is_empty() {
+            return;
+        }
+        let cursor = self.pane_nav[idx].cursor;
+        let level = match self.active_pane {
+            Pane::Missions => self.missions.get(cursor).map(|m| DrillLevel::Mission(m.id.clone())),
+            Pane::Comms => self
+                .messages
+                .get(cursor)
+                .map(|m| DrillLevel::MessageThread(m.id.to_string())),
+            _ => None,
+        };
+        if let Some(level) = level {
+            let nav = &mut self.pane_nav[idx];
+            nav.drill.push(level);
+            nav.cursor = 0;
+        }
+    }
+
+    /// Ascend one drill level in the active pane. Returns true if a level was
+    /// popped (so callers can distinguish "went up" from "already at root").
+    pub fn pane_drill_out(&mut self) -> bool {
+        let idx = self.active_pane.index();
+        let popped = self.pane_nav[idx].drill.pop().is_some();
+        if popped {
+            self.pane_nav[idx].cursor = 0;
+        }
+        popped
+    }
+
+    /// Breadcrumb segments for the active pane: `COCKPIT › PANE [› detail…]`.
+    pub fn breadcrumb(&self) -> Vec<String> {
+        let mut segs = vec!["COCKPIT".to_string(), self.active_pane.label().to_string()];
+        for level in &self.pane_nav[self.active_pane.index()].drill {
+            segs.push(match level {
+                DrillLevel::Mission(id) => self
+                    .missions
+                    .iter()
+                    .find(|m| &m.id == id)
+                    .map_or_else(|| "mission".to_string(), |m| m.title.clone()),
+                DrillLevel::MessageThread(id) => self
+                    .messages
+                    .iter()
+                    .find(|m| m.id.to_string() == *id)
+                    .map_or_else(|| format!("msg {id}"), |m| m.sender.name.clone()),
+                DrillLevel::Container(id) => id.clone(),
+                DrillLevel::ItemGroup(g) => g.clone(),
+                DrillLevel::Manny(m) => m.clone(),
+                DrillLevel::SectorObject(i) => format!("object {i}"),
+            });
+        }
+        segs
     }
 }
 
@@ -232,5 +311,60 @@ mod tests {
             assert!(seen.insert(pane.grid_pos()), "duplicate pos for {pane:?}");
         }
         assert_eq!(seen.len(), 9);
+    }
+
+    #[test]
+    fn cycle_pane_wraps_both_ways() {
+        let mut s = crate::app::AppState::default();
+        s.active_pane = Pane::Mannies; // last in ALL
+        s.cycle_pane(true);
+        assert_eq!(s.active_pane, Pane::Scanner); // wrapped to first
+        s.cycle_pane(false);
+        assert_eq!(s.active_pane, Pane::Mannies); // wrapped back
+    }
+
+    #[test]
+    fn toggle_zoom_flips() {
+        let mut s = crate::app::AppState::default();
+        assert!(!s.zoomed);
+        s.toggle_zoom();
+        assert!(s.zoomed);
+        s.toggle_zoom();
+        assert!(!s.zoomed);
+    }
+
+    #[test]
+    fn drill_out_at_root_is_noop() {
+        let mut s = crate::app::AppState::default();
+        s.active_pane = Pane::Missions;
+        assert!(!s.pane_drill_out());
+        assert_eq!(s.breadcrumb(), vec!["COCKPIT", "MISSIONS"]);
+    }
+
+    #[test]
+    fn mission_drill_in_out_updates_breadcrumb() {
+        use crate::api::types::{Mission, MissionStatus};
+        let mut s = crate::app::AppState::default();
+        s.missions = vec![Mission {
+            id: "m1".into(),
+            mission_type: "survey".into(),
+            title: "Survey the rim".into(),
+            description: None,
+            status: MissionStatus::Active,
+            steps: vec![],
+        }];
+        s.active_pane = Pane::Missions;
+
+        s.pane_drill_in();
+        assert_eq!(
+            s.breadcrumb(),
+            vec!["COCKPIT", "MISSIONS", "Survey the rim"]
+        );
+        // One level deep only: a second drill-in is a no-op.
+        s.pane_drill_in();
+        assert_eq!(s.pane_nav[Pane::Missions.index()].drill.len(), 1);
+
+        assert!(s.pane_drill_out());
+        assert_eq!(s.breadcrumb(), vec!["COCKPIT", "MISSIONS"]);
     }
 }

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -1,9 +1,9 @@
-//! Input routing for the unified Cockpit v2 interface (bloc U2).
+//! Input routing for the unified Cockpit v2 interface (blocs U2–U3).
 //!
-//! Normal-mode navigation only: `ertdfgcvb` activates a pane, `jk`/arrows
-//! move the cursor within it, `Tab` cycles panes, `F5` refreshes. Drill-in,
-//! zoom, contextual menus (`Enter`) and command mode (`:`) land in later
-//! blocs; unhandled keys are ignored.
+//! Normal-mode navigation: `ertdfgcvb` activates a pane, `jk`/arrows move the
+//! cursor within it, `l`/`h` drill in/out, `z` zooms, `Tab` cycles panes,
+//! `F5` refreshes. Contextual menus (`Enter`) and command mode (`:`) land in
+//! later blocs; unhandled keys are ignored.
 
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
@@ -25,6 +25,19 @@ pub fn handle_cockpit_event(
         }
         KeyCode::Down | KeyCode::Char('j') => state.pane_cursor_down(),
         KeyCode::Up | KeyCode::Char('k') => state.pane_cursor_up(),
+        KeyCode::Right | KeyCode::Char('l') => state.pane_drill_in(),
+        KeyCode::Left | KeyCode::Char('h') => {
+            state.pane_drill_out();
+        }
+        KeyCode::Char('z') => state.toggle_zoom(),
+        // Esc backs out one step: leave zoom first, then drill up.
+        KeyCode::Esc => {
+            if state.zoomed {
+                state.zoomed = false;
+            } else {
+                state.pane_drill_out();
+            }
+        }
         KeyCode::Tab => state.cycle_pane(true),
         KeyCode::BackTab => state.cycle_pane(false),
         KeyCode::F(5) if !state.loading => {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -1,8 +1,8 @@
-//! Unified Cockpit v2 interface — the 3×3 tiling dashboard (bloc U2).
+//! Unified Cockpit v2 interface — the 3×3 tiling dashboard (blocs U2–U3).
 //!
-//! U2 delivers the responsive grid and read-only navigation: `ertdfgcvb`
-//! selects a pane, `jk` moves the cursor within it. Drill-in, zoom,
-//! contextual menus and command mode follow in later blocs. The four
+//! Responsive grid + read-only navigation: `ertdfgcvb` selects a pane, `jk`
+//! moves the cursor, `l`/`h` drill in/out, `z` zooms the active pane full
+//! screen. Contextual menus and command mode follow in later blocs. The four
 //! original panes reuse their existing renderers; the five promoted panes
 //! (Map, Comms, Sector, Missions, Storage) use the compact renderers in
 //! [`panes`].
@@ -33,8 +33,13 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(area);
 
-    for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
-        render_pane(frame, rect, pane, state, pane == state.active_pane);
+    if state.zoomed {
+        // Zoom: the active pane takes the whole content area.
+        render_pane(frame, rows[0], state.active_pane, state, true);
+    } else {
+        for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
+            render_pane(frame, rect, pane, state, pane == state.active_pane);
+        }
     }
     render_status(frame, rows[1], state);
 }
@@ -54,17 +59,20 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
 }
 
 fn render_status(frame: &mut Frame, area: Rect, state: &AppState) {
+    let (tag, tag_bg) = if state.zoomed {
+        ("ZOOM", GREEN)
+    } else {
+        (state.mode.tag(), AMBER)
+    };
+    let crumb = state.breadcrumb().join(" › ");
     let line = Line::from(vec![
         Span::styled(
-            format!(" {} ", state.mode.tag()),
-            Style::default().fg(Color::Black).bg(AMBER).add_modifier(Modifier::BOLD),
+            format!(" {tag} "),
+            Style::default().fg(Color::Black).bg(tag_bg).add_modifier(Modifier::BOLD),
         ),
+        Span::styled(format!("  {crumb}  "), Style::default().fg(GREEN)),
         Span::styled(
-            format!("  {} ", state.active_pane.label()),
-            Style::default().fg(GREEN),
-        ),
-        Span::styled(
-            "· ertdfgcvb select · jk move · Tab cycle · F5 refresh · q quit",
+            "· ertdfgcvb select · jk move · hl drill · z zoom · q quit",
             Style::default().fg(DIM),
         ),
     ]);

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -1,18 +1,19 @@
 //! Compact read-only renderers for the five panes promoted from overlays
-//! (bloc U2): Map, Comms, Sector, Missions, Storage. The four original panes
-//! (Probe, Inventory, Scanner, Mannies) reuse their existing renderers.
+//! (blocs U2–U3): Map, Comms, Sector, Missions, Storage. The four original
+//! panes (Probe, Inventory, Scanner, Mannies) reuse their existing renderers.
 //!
-//! These show a terse summary sized for a 1/3 grid cell; the rich detail and
-//! actions land in the zoom view (U3) and menus (U5).
+//! Each shows a terse summary sized for a 1/3 grid cell; drilling in (`l`)
+//! swaps a pane to its detail view (Missions → steps, Comms → message). The
+//! remaining detail views and actions land with menus (U5).
 
-use crate::api::types::MissionStatus;
-use crate::app::{AppState, Pane};
+use crate::api::types::{MissionStatus, MissionStepStatus};
+use crate::app::{AppState, DrillLevel, Pane};
 use crate::ui::theme::{gauge_color, object_icon, panel_block};
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
+    widgets::{Paragraph, Wrap},
     Frame,
 };
 
@@ -59,6 +60,9 @@ pub fn render_map(frame: &mut Frame, area: Rect, state: &AppState, active: bool)
 }
 
 pub fn render_comms(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    if let Some(DrillLevel::MessageThread(id)) = state.pane_nav[Pane::Comms.index()].drill.last() {
+        return render_message_detail(frame, area, state, id, active);
+    }
     let unread_alerts = state.unread_alert_count();
     let unread_msgs = state.unread_message_count();
     let mut lines = vec![
@@ -91,6 +95,24 @@ pub fn render_comms(frame: &mut Frame, area: Rect, state: &AppState, active: boo
     render_body(frame, area, " COMMS ", active, lines);
 }
 
+fn render_message_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool) {
+    let block = panel_block(" MESSAGE ", active);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let Some(m) = state.messages.iter().find(|m| m.id.to_string() == id) else {
+        frame.render_widget(Paragraph::new(Line::styled("message not found", DIM)), inner);
+        return;
+    };
+    let lines = vec![
+        Line::from(vec![Span::styled("from ", DIM), Span::raw(m.sender.name.clone())]),
+        Line::from(vec![Span::styled("to   ", DIM), Span::raw(m.recipient.name.clone())]),
+        Line::styled(m.created_at.clone(), DIM),
+        Line::raw(""),
+        Line::raw(m.body.clone()),
+    ];
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+}
+
 pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
     let mut lines = Vec::new();
     match state.current_sector() {
@@ -118,6 +140,9 @@ pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bo
 }
 
 pub fn render_missions(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    if let Some(DrillLevel::Mission(id)) = state.pane_nav[Pane::Missions.index()].drill.last() {
+        return render_mission_detail(frame, area, state, id, active);
+    }
     let mut lines = Vec::new();
     if state.missions.is_empty() {
         lines.push(Line::styled("no active missions", DIM));
@@ -142,6 +167,39 @@ pub fn render_missions(frame: &mut Frame, area: Rect, state: &AppState, active: 
         }
     }
     render_body(frame, area, " MISSIONS ", active, lines);
+}
+
+fn render_mission_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool) {
+    let block = panel_block(" MISSION ", active);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let Some(m) = state.missions.iter().find(|m| m.id == id) else {
+        frame.render_widget(Paragraph::new(Line::styled("mission not found", DIM)), inner);
+        return;
+    };
+    let mut lines = vec![Line::styled(
+        m.title.clone(),
+        Style::default().add_modifier(Modifier::BOLD),
+    )];
+    if let Some(d) = &m.description {
+        lines.push(Line::styled(d.clone(), DIM));
+    }
+    lines.push(Line::raw(""));
+    let cur = cursor(state, Pane::Missions);
+    for (i, step) in m.steps.iter().enumerate() {
+        let (mark, color) = match step.status {
+            MissionStepStatus::Completed => ("✓", Color::Green),
+            MissionStepStatus::Failed => ("✗", Color::Red),
+            MissionStepStatus::Skipped => ("–", Color::DarkGray),
+            MissionStepStatus::Pending => ("·", Color::Cyan),
+            MissionStepStatus::Unknown => ("?", Color::DarkGray),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("{mark} "), Style::default().fg(color)),
+            Span::styled(step.title.clone(), row_style(active, i == cur)),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }
 
 pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {


### PR DESCRIPTION
Third bloc: the drill/zoom interaction layer on top of the read-only grid.

## What it adds

- **Drill-in** — `l`/`→` descends into the selected element, `h`/`←` ascends. A per-pane drill stack drives a breadcrumb (`COCKPIT › PANE › detail`). U3 wires the two panes whose detail is already in state: **Missions** (→ steps, cursor moves over them) and **Comms** (→ full message body). Other panes are no-ops until their detail views land.
- **Zoom** — `z` toggles full-screen zoom of the active pane; `Esc` leaves zoom first, then drills up one level.
- **Status bar** — now shows the breadcrumb and a `ZOOM`/`NAV` mode tag.

## Notes

- Zoom currently gives the active pane the full content area with the same renderer (more rows visible); richer per-pane zoom detail is incremental.
- Storage/Sector/Inventory drill-in follow when their detail views (some needing a fetch) land with the menu bloc.

## Verification

- `cargo build` ✓
- `cargo test` → 169 passed (incl. new cycle/zoom/drill/breadcrumb tests)
- `cargo clippy` → no new lint categories (the field-reassign-in-tests pattern matches the existing 119 occurrences)