### PR TITLE
feat(cockpit): full status bar and contextual hints line

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -11,3 +11,5 @@ api_key  = "vng_your_api_key_here"
 #phosphor = "green"
 # Retro idle animations (render tick only, never API polling).
 #animations = true
+# Cockpit: show the contextual hints line at the bottom (F1 toggles at runtime).
+#hints = true

--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -246,6 +246,27 @@ impl super::AppState {
         popped
     }
 
+    /// Contextual key hints for the active pane and drill level (bloc U4).
+    /// Reflects only what is actionable now; actions (`Enter`) arrive in U5.
+    pub fn pane_hints(&self) -> String {
+        let pane = self.active_pane;
+        let drilled = !self.pane_nav[pane.index()].drill.is_empty();
+        let mut parts: Vec<&str> = Vec::new();
+        if drilled {
+            parts.push("h back");
+        }
+        if !matches!(pane, Pane::Probe | Pane::Map) {
+            parts.push("jk move");
+        }
+        if !drilled && matches!(pane, Pane::Missions | Pane::Comms) {
+            parts.push("l open");
+        }
+        parts.push("z zoom");
+        parts.push("ertdfgcvb pane");
+        parts.push("F1 hints");
+        parts.join(" · ")
+    }
+
     /// Breadcrumb segments for the active pane: `COCKPIT › PANE [› detail…]`.
     pub fn breadcrumb(&self) -> Vec<String> {
         let mut segs = vec!["COCKPIT".to_string(), self.active_pane.label().to_string()];
@@ -366,5 +387,28 @@ mod tests {
 
         assert!(s.pane_drill_out());
         assert_eq!(s.breadcrumb(), vec!["COCKPIT", "MISSIONS"]);
+    }
+
+    #[test]
+    fn pane_hints_are_contextual() {
+        let mut s = crate::app::AppState::default();
+
+        // Probe has no list → no movement hint.
+        s.active_pane = Pane::Probe;
+        assert!(!s.pane_hints().contains("jk move"));
+
+        // Missions at root offers drill-in, not "back".
+        s.active_pane = Pane::Missions;
+        let h = s.pane_hints();
+        assert!(h.contains("l open"));
+        assert!(!h.contains("h back"));
+
+        // Drilled in, it offers "back" and drops "open".
+        s.pane_nav[Pane::Missions.index()]
+            .drill
+            .push(DrillLevel::Mission("m1".into()));
+        let h = s.pane_hints();
+        assert!(h.contains("h back"));
+        assert!(!h.contains("l open"));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -127,6 +127,8 @@ pub struct AppState {
     pub mode: InputMode,
     /// Per-pane cursor + drill-in state, indexed by `Pane::index()`.
     pub pane_nav: [PaneNav; 9],
+    /// Whether the contextual hints line is shown (config `hints`, F1 toggles).
+    pub hints_visible: bool,
 }
 
 impl AppState {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     /// Retro idle animations (render tick only, never API polling).
     #[serde(default = "default_true")]
     pub animations: bool,
+    /// Show the contextual hints line in the cockpit interface (F1 toggles).
+    #[serde(default = "default_true")]
+    pub hints: bool,
 }
 
 fn default_true() -> bool {
@@ -90,6 +93,7 @@ mod tests {
             theme: theme.map(String::from),
             phosphor: None,
             animations: true,
+            hints: true,
         }
     }
 

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -2,8 +2,8 @@
 //!
 //! Normal-mode navigation: `ertdfgcvb` activates a pane, `jk`/arrows move the
 //! cursor within it, `l`/`h` drill in/out, `z` zooms, `Tab` cycles panes,
-//! `F5` refreshes. Contextual menus (`Enter`) and command mode (`:`) land in
-//! later blocs; unhandled keys are ignored.
+//! `F1` toggles the hints line, `F5` refreshes. Contextual menus (`Enter`)
+//! and command mode (`:`) land in later blocs; unhandled keys are ignored.
 
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
@@ -30,6 +30,7 @@ pub fn handle_cockpit_event(
             state.pane_drill_out();
         }
         KeyCode::Char('z') => state.toggle_zoom(),
+        KeyCode::F(1) => state.hints_visible = !state.hints_visible,
         // Esc backs out one step: leave zoom first, then drill up.
         KeyCode::Esc => {
             if state.zoomed {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ async fn main() -> Result<()> {
     let ui_theme = cfg.ui_theme();
     let phosphor = cfg.ui_phosphor();
     let animations = cfg.animations;
+    let hints = cfg.hints;
     let client = ApiClient::new(cfg.base_url, cfg.api_key)?;
 
     enable_raw_mode()?;
@@ -41,7 +42,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run(&client, &mut terminal, ui_theme, phosphor, animations).await;
+    let result = run(&client, &mut terminal, ui_theme, phosphor, animations, hints).await;
 
     disable_raw_mode()?;
     execute!(
@@ -60,12 +61,14 @@ async fn run(
     ui_theme: UiTheme,
     phosphor: Phosphor,
     animations: bool,
+    hints: bool,
 ) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<ApiMessage>(32);
     let mut state = AppState {
         ui_theme,
         phosphor,
         animations_enabled: animations,
+        hints_visible: hints,
         ..Default::default()
     };
     if ui_theme == UiTheme::Retro && animations {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -15,7 +15,7 @@ use crate::ui::panels::{
     render_inventory_panel, render_mannies_panel, render_probe_panel, render_scanner_panel,
 };
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
@@ -28,9 +28,11 @@ const DIM: Color = Color::Rgb(0x6f, 0x8c, 0x7d);
 
 pub fn render(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
+    // Status bar is one line, plus a second hints line when enabled.
+    let status_h = if state.hints_visible { 2 } else { 1 };
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .constraints([Constraint::Min(1), Constraint::Length(status_h)])
         .split(area);
 
     if state.zoomed {
@@ -59,22 +61,71 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
 }
 
 fn render_status(frame: &mut Frame, area: Rect, state: &AppState) {
+    // Split off the hints line (bottom) when enabled.
+    let (bar, hints) = if state.hints_visible && area.height >= 2 {
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Length(1)])
+            .split(area);
+        (rows[0], Some(rows[1]))
+    } else {
+        (area, None)
+    };
+
+    render_status_line(frame, bar, state);
+    if let Some(hints_area) = hints {
+        let line = Line::from(Span::styled(
+            format!(" {}", state.pane_hints()),
+            Style::default().fg(DIM),
+        ));
+        frame.render_widget(Paragraph::new(line), hints_area);
+    }
+}
+
+fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState) {
     let (tag, tag_bg) = if state.zoomed {
         ("ZOOM", GREEN)
     } else {
         (state.mode.tag(), AMBER)
     };
-    let crumb = state.breadcrumb().join(" › ");
-    let line = Line::from(vec![
+
+    // Left: mode tag · breadcrumb · transient toast.
+    let mut left = vec![
         Span::styled(
             format!(" {tag} "),
             Style::default().fg(Color::Black).bg(tag_bg).add_modifier(Modifier::BOLD),
         ),
-        Span::styled(format!("  {crumb}  "), Style::default().fg(GREEN)),
-        Span::styled(
-            "· ertdfgcvb select · jk move · hl drill · z zoom · q quit",
-            Style::default().fg(DIM),
-        ),
-    ]);
-    frame.render_widget(Paragraph::new(line), area);
+        Span::styled(format!("  {}", state.breadcrumb().join(" › ")), Style::default().fg(GREEN)),
+    ];
+    if let Some(toast) = state.active_toast() {
+        left.push(Span::styled(format!("  ✓ {toast}"), Style::default().fg(Color::Green)));
+    }
+
+    // Right: SCUT coverage · unread · API version · clock.
+    let mut meta = Vec::new();
+    if !state.scut_coverage().is_empty() {
+        meta.push("≣ SCUT".to_string());
+    }
+    let unread = state.unread_alert_count();
+    if unread > 0 {
+        meta.push(format!("! {unread}"));
+    }
+    if let Some(v) = state.api_version {
+        meta.push(format!("API v{v}"));
+    }
+    if let Some(t) = state.last_update {
+        meta.push(t.format("%H:%M:%S").to_string());
+    }
+    let meta = meta.join(" · ");
+    let meta_len = meta.chars().count() as u16;
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(meta_len + 1)])
+        .split(area);
+    frame.render_widget(Paragraph::new(Line::from(left)), cols[0]);
+    frame.render_widget(
+        Paragraph::new(meta).alignment(Alignment::Right).style(Style::default().fg(DIM)),
+        cols[1],
+    );
 }


### PR DESCRIPTION
Fourth bloc: the status bar becomes informative and gains a contextual hints line.

## What it adds

- **Status line** — mode tag (`NAV`/`ZOOM`), breadcrumb, transient toast, and a right-aligned meta cluster: `≣ SCUT` coverage, `! N` unread alerts, `API vN`, and the last-update clock.
- **Hints line** — a second line showing the keys that are actionable *right now* for the active pane and drill level (e.g. `l open` only on drill-capable panes at root, `h back` only when drilled). Toggled with `F1`, gated by the new `hints` config key (default `true`).

## Config

New `hints = true` key (documented in `config.example.toml`), threaded through `main` into `AppState::hints_visible`.

## Verification

- `cargo build` ✓
- `cargo test` → 170 passed (incl. new `pane_hints` contextual test)
- `cargo clippy` → clean on changed files