### PR TITLE
feat(cockpit): contextual action menu wired to the Mannies wizards

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -261,6 +261,10 @@ impl super::AppState {
         if !drilled && matches!(pane, Pane::Missions | Pane::Comms) {
             parts.push("l open");
         }
+        // Panes with a contextual action menu (bloc U5: Mannies).
+        if matches!(pane, Pane::Mannies) {
+            parts.push("Enter act");
+        }
         parts.push("z zoom");
         parts.push("ertdfgcvb pane");
         parts.push("F1 hints");

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -6,9 +6,20 @@
 //! variant (wrapping the existing `*Input` wizards) is added in U5.
 #![allow(dead_code)]
 
+/// An action a contextual menu item can fire. Each maps to launching one of
+/// the existing wizards (bloc U5 wires the Mannies pane; more panes follow).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuAction {
+    Repair,
+    Craft,
+    Recall,
+    Rename,
+}
+
 /// A single entry in a contextual action menu.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MenuItem {
+    pub action: MenuAction,
     pub label: String,
     pub enabled: bool,
     /// Reason shown (dimmed) when the item is disabled — teaches the rules
@@ -56,6 +67,59 @@ impl InputMode {
 
     pub fn is_text_entry(&self) -> bool {
         matches!(self, InputMode::Command(_))
+    }
+}
+
+impl super::AppState {
+    /// Build the contextual action menu for the active pane and selection,
+    /// or `None` when the pane has no actions yet (bloc U5: Mannies only).
+    pub fn build_context_menu(&self) -> Option<ContextMenu> {
+        match self.active_pane {
+            super::Pane::Mannies => self.mannies_context_menu(),
+            _ => None,
+        }
+    }
+
+    fn mannies_context_menu(&self) -> Option<ContextMenu> {
+        use crate::api::types::MannyTaskVisibility;
+        let manny = self.mannies.as_ref()?.get(self.mannies_selection)?;
+        let busy = (!manny.can_receive_orders).then(|| "busy".to_string());
+        let has_task = manny.current_task.is_some();
+        let remote = matches!(manny.task_visibility, Some(MannyTaskVisibility::ScutNetwork));
+
+        let items = vec![
+            MenuItem {
+                action: MenuAction::Repair,
+                label: "Repair".into(),
+                enabled: manny.can_receive_orders,
+                disabled_reason: busy.clone(),
+            },
+            MenuItem {
+                action: MenuAction::Craft,
+                label: "Craft…".into(),
+                enabled: manny.can_receive_orders,
+                disabled_reason: busy,
+            },
+            MenuItem {
+                action: MenuAction::Recall,
+                label: if remote { "Abandon".into() } else { "Recall".into() },
+                enabled: !manny.can_receive_orders && has_task,
+                disabled_reason: (manny.can_receive_orders || !has_task).then(|| "idle".to_string()),
+            },
+            MenuItem {
+                action: MenuAction::Rename,
+                label: "Rename…".into(),
+                enabled: true,
+                disabled_reason: None,
+            },
+        ];
+        // Start the cursor on the first enabled item when there is one.
+        let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
+        Some(ContextMenu {
+            title: manny.name.clone(),
+            items,
+            cursor,
+        })
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1366,3 +1366,38 @@ fn anim_hash_is_deterministic_and_spreads() {
     assert_eq!(anim_hash(42), anim_hash(42));
     assert_ne!(anim_hash(1), anim_hash(2));
 }
+
+// ── cockpit contextual menu ────────────────────────────────────────────────
+
+fn menu_item(menu: &ContextMenu, action: MenuAction) -> &MenuItem {
+    menu.items.iter().find(|i| i.action == action).expect("menu item")
+}
+
+#[test]
+fn mannies_context_menu_reflects_manny_state() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Mannies;
+
+    // Idle manny: repair/craft/rename enabled, recall disabled.
+    state.mannies = Some(vec![make_manny("m1", "probe_rack", true, None)]);
+    let menu = state.build_context_menu().expect("mannies menu");
+    assert!(menu_item(&menu, MenuAction::Repair).enabled);
+    assert!(menu_item(&menu, MenuAction::Craft).enabled);
+    assert!(menu_item(&menu, MenuAction::Rename).enabled);
+    assert!(!menu_item(&menu, MenuAction::Recall).enabled);
+    // Cursor lands on the first enabled item.
+    assert!(menu.items[menu.cursor].enabled);
+
+    // Busy manny with a task: repair/craft disabled, recall enabled.
+    state.mannies = Some(vec![make_manny("m2", "sector", false, Some("mining"))]);
+    let menu = state.build_context_menu().expect("mannies menu");
+    assert!(!menu_item(&menu, MenuAction::Repair).enabled);
+    assert!(menu_item(&menu, MenuAction::Recall).enabled);
+}
+
+#[test]
+fn context_menu_none_for_pane_without_actions() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Probe;
+    assert!(state.build_context_menu().is_none());
+}

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -1,16 +1,21 @@
-//! Input routing for the unified Cockpit v2 interface (blocs U2–U3).
+//! Input routing for the unified Cockpit v2 interface (blocs U2–U5).
 //!
 //! Normal-mode navigation: `ertdfgcvb` activates a pane, `jk`/arrows move the
 //! cursor within it, `l`/`h` drill in/out, `z` zooms, `Tab` cycles panes,
-//! `F1` toggles the hints line, `F5` refreshes. Contextual menus (`Enter`)
-//! and command mode (`:`) land in later blocs; unhandled keys are ignored.
+//! `F1` toggles the hints line, `F5` refreshes. `Enter` opens the contextual
+//! action menu, which launches the existing wizards. Command mode (`:`) lands
+//! in a later bloc; unhandled keys are ignored.
 
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_all;
-use crate::app::{ApiMessage, AppState, Pane};
+use crate::api::types::MannyTaskVisibility;
+use crate::app::{
+    ApiMessage, AppState, CraftInput, InputMode, MenuAction, Pane, RecallInput, RenameMannyInput,
+    RepairInput,
+};
 
 pub fn handle_cockpit_event(
     code: KeyCode,
@@ -18,8 +23,15 @@ pub fn handle_cockpit_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
+    // A context menu, when open, captures all input.
+    if matches!(state.mode, InputMode::Menu(_)) {
+        handle_menu_key(code, state);
+        return;
+    }
+
     match code {
         KeyCode::Char('q') => state.set_quit(),
+        KeyCode::Enter => open_context_menu(state),
         KeyCode::Char(c) if Pane::from_key(c).is_some() => {
             state.active_pane = Pane::from_key(c).unwrap();
         }
@@ -46,6 +58,98 @@ pub fn handle_cockpit_event(
             state.loading = true;
             fetch_all(client.clone(), tx.clone());
         }
+        _ => {}
+    }
+}
+
+fn open_context_menu(state: &mut AppState) {
+    match state.build_context_menu() {
+        Some(menu) if !menu.items.is_empty() => state.mode = InputMode::Menu(menu),
+        _ => state.set_toast("no actions here"),
+    }
+}
+
+fn handle_menu_key(code: KeyCode, state: &mut AppState) {
+    match code {
+        KeyCode::Esc => state.mode = InputMode::Normal,
+        KeyCode::Up | KeyCode::Char('k') => {
+            if let InputMode::Menu(m) = &mut state.mode {
+                m.cursor = m.cursor.saturating_sub(1);
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if let InputMode::Menu(m) = &mut state.mode {
+                if m.cursor + 1 < m.items.len() {
+                    m.cursor += 1;
+                }
+            }
+        }
+        KeyCode::Enter => {
+            // Read the selected action without holding the borrow across the fire.
+            let action = if let InputMode::Menu(m) = &state.mode {
+                m.items.get(m.cursor).filter(|i| i.enabled).map(|i| i.action)
+            } else {
+                None
+            };
+            if let Some(action) = action {
+                state.mode = InputMode::Normal;
+                fire_menu_action(action, state);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Launch the wizard behind a menu action for the selected Manny. The
+/// existing wizard event handlers take over on subsequent keys.
+fn fire_menu_action(action: MenuAction, state: &mut AppState) {
+    let Some(m) = state.mannies.as_ref().and_then(|v| v.get(state.mannies_selection)) else {
+        return;
+    };
+    let id = m.id.clone();
+    let name = m.name.clone();
+    let can = m.can_receive_orders;
+    let has_task = m.current_task.is_some();
+    let remote = matches!(m.task_visibility, Some(MannyTaskVisibility::ScutNetwork));
+
+    match action {
+        MenuAction::Repair if can => {
+            state.repair = RepairInput::Typing {
+                manny_id: id,
+                manny_name: name,
+                buf: String::new(),
+                error: None,
+            };
+        }
+        MenuAction::Craft if can => {
+            if state.manny_craft_recipes().is_empty() {
+                state.error = Some("recipes not loaded yet — F5 to refresh".into());
+            } else {
+                state.craft = CraftInput::PickRecipe {
+                    manny_id: id,
+                    manny_name: name,
+                    selection: 0,
+                    error: None,
+                };
+            }
+        }
+        MenuAction::Recall if !can && has_task => {
+            state.recall = RecallInput::Confirm {
+                manny_id: id,
+                manny_name: name,
+                remote,
+                error: None,
+            };
+        }
+        MenuAction::Rename => {
+            state.rename_manny = RenameMannyInput::Typing {
+                manny_id: id,
+                manny_name: name.clone(),
+                buf: name,
+                error: None,
+            };
+        }
+        // Guard mismatch (state changed since the menu was built): no-op.
         _ => {}
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -114,12 +114,6 @@ pub fn handle_event(
         return;
     }
 
-    // Unified Cockpit v2 interface has its own input router (bloc U-series).
-    if state.ui_theme == crate::app::UiTheme::Cockpit {
-        handle_cockpit_event(k.code, state, client, tx);
-        return;
-    }
-
     if state.help_open {
         if matches!(k.code, KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q')) {
             state.help_open = false;
@@ -318,6 +312,14 @@ pub fn handle_event(
             KeyCode::Char(c) => state.scan_type_char(c),
             _ => {}
         }
+        return;
+    }
+
+    // Cockpit v2 owns navigation and the contextual-menu match below; the
+    // shared wizard/overlay handlers above are reused as-is. Placed after
+    // them so an open wizard keeps receiving keys.
+    if state.ui_theme == crate::app::UiTheme::Cockpit {
+        handle_cockpit_event(k.code, state, client, tx);
         return;
     }
 

--- a/src/ui/cockpit_v2/menu.rs
+++ b/src/ui/cockpit_v2/menu.rs
@@ -1,0 +1,67 @@
+//! Contextual action menu popup for the Cockpit v2 interface (bloc U5).
+//!
+//! Rendered on top of the grid when `InputMode::Menu` is active. Enabled
+//! items are selectable; disabled ones stay visible with their reason, so
+//! the menu teaches what is (not yet) possible rather than hiding it.
+
+use crate::app::ContextMenu;
+use crate::ui::overlays::centered_rect;
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+const AMBER: Color = Color::Rgb(0xff, 0xb2, 0x4a);
+const DIM: Color = Color::Rgb(0x6f, 0x8c, 0x7d);
+
+pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu) {
+    let widest = menu
+        .items
+        .iter()
+        .map(|i| {
+            i.label.chars().count()
+                + i.disabled_reason.as_ref().map_or(0, |r| r.chars().count() + 3)
+        })
+        .max()
+        .unwrap_or(0)
+        .max(menu.title.chars().count());
+    let w = (widest as u16 + 4).clamp(18, 48);
+    let h = menu.items.len() as u16 + 2;
+    let rect = centered_rect(w, h, area);
+
+    frame.render_widget(Clear, rect);
+    let block = Block::default()
+        .title(Span::styled(
+            format!(" {} ", menu.title),
+            Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(AMBER));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    let lines: Vec<Line> = menu
+        .items
+        .iter()
+        .enumerate()
+        .map(|(i, item)| {
+            if !item.enabled {
+                let reason = item.disabled_reason.as_deref().unwrap_or("unavailable");
+                return Line::from(vec![
+                    Span::styled(format!(" {}", item.label), Style::default().fg(DIM)),
+                    Span::styled(format!(" ({reason})"), Style::default().fg(DIM)),
+                ]);
+            }
+            let style = if i == menu.cursor {
+                Style::default().fg(AMBER).add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default()
+            };
+            Line::from(Span::styled(format!(" {}", item.label), style))
+        })
+        .collect();
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -8,6 +8,7 @@
 //! [`panes`].
 
 mod grid;
+mod menu;
 mod panes;
 
 use crate::app::{AppState, Pane};
@@ -44,6 +45,12 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         }
     }
     render_status(frame, rows[1], state);
+
+    // Contextual menu popup, then any active wizard overlay on top.
+    if let crate::app::InputMode::Menu(m) = &state.mode {
+        menu::render(frame, area, m);
+    }
+    crate::ui::overlays::render_active_overlays(frame, area, state);
 }
 
 fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, active: bool) {


### PR DESCRIPTION
Fifth bloc (first slice): the cockpit becomes **actionable**. `Enter` opens a contextual action menu; actions launch the existing wizards.

## What it adds

- **Menu framework** — `Enter` builds a `ContextMenu` for the active pane + selection and enters `InputMode::Menu`. `j`/`k` move, `Enter` fires the highlighted item, `Esc` closes. Disabled actions stay visible with their reason (teaches the rules rather than hiding them).
- **Wizard reuse, no duplication** — menu items map to `MenuAction`s that set the existing wizard state. The cockpit input dispatch now runs **after** the shared wizard/overlay handlers, so an open wizard keeps receiving keys, and `cockpit_v2::render` now draws the wizard overlays + the menu popup on top of the grid.
- **Mannies pane wired** — Repair, Craft, Recall/Abandon (labelled by SCUT reachability), Rename. Enabled/disabled by the Manny’s state.
- Status bar shows `MENU` while the menu is open; hints gain `Enter act` on menu-capable panes.

## Not yet (next slice)

Candidate/fetch-based Mannies actions (mine, salvage, inspect, recover, detach, drop-cargo, refuel) and menus for the other panes (Sector objects, Inventory, Storage, Missions, Comms).

## Verification

- `cargo build` ✓
- `cargo test` → 172 passed (incl. context-menu state tests)
- `cargo clippy` → clean on changed files