### PR TITLE
feat(cockpit): color modes and phosphor palette

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -4,9 +4,11 @@ api_key  = "vng_your_api_key_here"
 # Layout: "classic" (default), "retro", or "cockpit" — the unified tiling
 # interface (work in progress, U-series). Takes precedence over `theme`.
 #ui = "cockpit"
-# UI theme: "classic" (default) or "retro" — phosphor CRT console with
-# idle animations. Toggle at runtime with F2.
-#theme = "retro"
+# theme:
+#   - classic/retro layouts: "classic" (default) or "retro" (phosphor CRT).
+#   - cockpit layout: color mode — "mono-green" (default), "mono-amber",
+#     "phosphor-semantic", or "modern-16". F2 cycles it at runtime.
+#theme = "mono-green"
 # Retro phosphor tint: "green" (default) or "amber".
 #phosphor = "green"
 # Retro idle animations (render tick only, never API polling).

--- a/src/app/anim.rs
+++ b/src/app/anim.rs
@@ -17,6 +17,38 @@ pub enum Phosphor {
     Amber,
 }
 
+/// Color mode for the unified Cockpit interface (config `theme`, F2 cycles).
+/// Mono modes are single-hue phosphor; `PhosphorSemantic` adds green/yellow/red
+/// status colours; `Modern16` uses named ANSI colours for limited terminals.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub enum ColorMode {
+    #[default]
+    MonoGreen,
+    MonoAmber,
+    PhosphorSemantic,
+    Modern16,
+}
+
+impl ColorMode {
+    pub fn cycle(self) -> Self {
+        match self {
+            ColorMode::MonoGreen => ColorMode::MonoAmber,
+            ColorMode::MonoAmber => ColorMode::PhosphorSemantic,
+            ColorMode::PhosphorSemantic => ColorMode::Modern16,
+            ColorMode::Modern16 => ColorMode::MonoGreen,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ColorMode::MonoGreen => "mono-green",
+            ColorMode::MonoAmber => "mono-amber",
+            ColorMode::PhosphorSemantic => "phosphor-semantic",
+            ColorMode::Modern16 => "modern-16",
+        }
+    }
+}
+
 /// Boot sequence length in animation frames (~10 fps → ~3.5 s).
 pub const BOOT_TOTAL_FRAMES: u64 = 36;
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -129,6 +129,8 @@ pub struct AppState {
     pub pane_nav: [PaneNav; 9],
     /// Whether the contextual hints line is shown (config `hints`, F1 toggles).
     pub hints_visible: bool,
+    /// Cockpit color mode (config `theme`, F2 cycles).
+    pub color_mode: ColorMode,
 }
 
 impl AppState {

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,18 @@ impl Config {
             _ => crate::app::Phosphor::Green,
         }
     }
+
+    /// Cockpit color mode, read from the `theme` key (distinct from the legacy
+    /// classic/retro layout selection, which uses `ui`/`theme` too).
+    pub fn color_mode(&self) -> crate::app::ColorMode {
+        use crate::app::ColorMode;
+        match self.theme.as_deref() {
+            Some("mono-amber") => ColorMode::MonoAmber,
+            Some("phosphor-semantic") => ColorMode::PhosphorSemantic,
+            Some("modern-16") => ColorMode::Modern16,
+            _ => ColorMode::MonoGreen,
+        }
+    }
 }
 
 impl Config {
@@ -109,5 +121,27 @@ mod tests {
         assert_eq!(cfg(None, Some("retro")).ui_theme(), UiTheme::Retro);
         assert_eq!(cfg(None, None).ui_theme(), UiTheme::Classic);
         assert_eq!(cfg(None, Some("bogus")).ui_theme(), UiTheme::Classic);
+    }
+
+    #[test]
+    fn color_mode_parses_from_theme() {
+        use crate::app::ColorMode;
+        assert_eq!(cfg(None, Some("mono-amber")).color_mode(), ColorMode::MonoAmber);
+        assert_eq!(cfg(None, Some("phosphor-semantic")).color_mode(), ColorMode::PhosphorSemantic);
+        assert_eq!(cfg(None, Some("modern-16")).color_mode(), ColorMode::Modern16);
+        // Legacy/unknown/absent → default mono-green.
+        assert_eq!(cfg(None, None).color_mode(), ColorMode::MonoGreen);
+        assert_eq!(cfg(None, Some("retro")).color_mode(), ColorMode::MonoGreen);
+    }
+
+    #[test]
+    fn color_mode_cycles_through_all_four() {
+        use crate::app::ColorMode;
+        let m = ColorMode::MonoGreen;
+        let m = m.cycle();
+        assert_eq!(m, ColorMode::MonoAmber);
+        let m = m.cycle().cycle();
+        assert_eq!(m, ColorMode::Modern16);
+        assert_eq!(m.cycle(), ColorMode::MonoGreen);
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -110,7 +110,14 @@ pub fn handle_event(
     }
 
     if k.code == KeyCode::F(2) {
-        state.toggle_theme();
+        // In the cockpit, F2 cycles the color mode; otherwise it toggles the
+        // classic/retro theme.
+        if state.ui_theme == crate::app::UiTheme::Cockpit {
+            state.color_mode = state.color_mode.cycle();
+            state.set_toast(format!("color mode: {}", state.color_mode.label()));
+        } else {
+            state.toggle_theme();
+        }
         return;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,8 @@ use neumann_cockpit::api::tasks::{
     fetch_missions, fetch_sent_messages,
 };
 use neumann_cockpit::app::{
-    ApiMessage, AppState, AtomicPrinterCraftInput, ContainerRulesInput, CraftInput, DeployInput,
+    ApiMessage, AppState, AtomicPrinterCraftInput, ColorMode, ContainerRulesInput, CraftInput,
+    DeployInput,
     DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput,
     MessagesInput, MindSnapshotInput, MineInput, MissionsInput, Phosphor, RecallInput, RecoverInput,
     RefuelInput,
@@ -34,6 +35,7 @@ async fn main() -> Result<()> {
     let phosphor = cfg.ui_phosphor();
     let animations = cfg.animations;
     let hints = cfg.hints;
+    let color_mode = cfg.color_mode();
     let client = ApiClient::new(cfg.base_url, cfg.api_key)?;
 
     enable_raw_mode()?;
@@ -42,7 +44,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run(&client, &mut terminal, ui_theme, phosphor, animations, hints).await;
+    let result = run(&client, &mut terminal, ui_theme, phosphor, animations, hints, color_mode).await;
 
     disable_raw_mode()?;
     execute!(
@@ -62,6 +64,7 @@ async fn run(
     phosphor: Phosphor,
     animations: bool,
     hints: bool,
+    color_mode: ColorMode,
 ) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<ApiMessage>(32);
     let mut state = AppState {
@@ -69,6 +72,7 @@ async fn run(
         phosphor,
         animations_enabled: animations,
         hints_visible: hints,
+        color_mode,
         ..Default::default()
     };
     if ui_theme == UiTheme::Retro && animations {

--- a/src/ui/cockpit_v2/menu.rs
+++ b/src/ui/cockpit_v2/menu.rs
@@ -1,23 +1,21 @@
-//! Contextual action menu popup for the Cockpit v2 interface (bloc U5).
+//! Contextual action menu popup for the Cockpit v2 interface (blocs U5, U7).
 //!
 //! Rendered on top of the grid when `InputMode::Menu` is active. Enabled
 //! items are selectable; disabled ones stay visible with their reason, so
 //! the menu teaches what is (not yet) possible rather than hiding it.
 
+use super::palette::Palette;
 use crate::app::ContextMenu;
 use crate::ui::overlays::centered_rect;
 use ratatui::{
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-const AMBER: Color = Color::Rgb(0xff, 0xb2, 0x4a);
-const DIM: Color = Color::Rgb(0x6f, 0x8c, 0x7d);
-
-pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu) {
+pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
     let widest = menu
         .items
         .iter()
@@ -36,10 +34,10 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu) {
     let block = Block::default()
         .title(Span::styled(
             format!(" {} ", menu.title),
-            Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+            Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(AMBER));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(rect);
     frame.render_widget(block, rect);
 
@@ -51,14 +49,14 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu) {
             if !item.enabled {
                 let reason = item.disabled_reason.as_deref().unwrap_or("unavailable");
                 return Line::from(vec![
-                    Span::styled(format!(" {}", item.label), Style::default().fg(DIM)),
-                    Span::styled(format!(" ({reason})"), Style::default().fg(DIM)),
+                    Span::styled(format!(" {}", item.label), Style::default().fg(p.dim)),
+                    Span::styled(format!(" ({reason})"), Style::default().fg(p.dim)),
                 ]);
             }
             let style = if i == menu.cursor {
-                Style::default().fg(AMBER).add_modifier(Modifier::REVERSED)
+                Style::default().fg(p.accent).add_modifier(Modifier::REVERSED)
             } else {
-                Style::default()
+                Style::default().fg(p.text)
             };
             Line::from(Span::styled(format!(" {}", item.label), style))
         })

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -1,20 +1,22 @@
-//! Unified Cockpit v2 interface — the 3×3 tiling dashboard (blocs U2–U3).
+//! Unified Cockpit v2 interface — the 3×3 tiling dashboard (blocs U2–U7).
 //!
-//! Responsive grid + read-only navigation: `ertdfgcvb` selects a pane, `jk`
-//! moves the cursor, `l`/`h` drill in/out, `z` zooms the active pane full
-//! screen. Contextual menus and command mode follow in later blocs. The four
-//! original panes reuse their existing renderers; the five promoted panes
-//! (Map, Comms, Sector, Missions, Storage) use the compact renderers in
-//! [`panes`].
+//! Responsive grid + navigation: `ertdfgcvb` selects a pane, `jk` moves the
+//! cursor, `l`/`h` drill in/out, `z` zooms, `Enter` opens the contextual menu.
+//! Colours come from the active [`palette`] (config `theme`, F2 cycles). The
+//! four original panes reuse their existing renderers (still on classic
+//! colours until they get cockpit-native renderers); the five promoted panes
+//! use the compact renderers in [`panes`].
 
 mod grid;
 mod menu;
+mod palette;
 mod panes;
 
 use crate::app::{AppState, Pane};
 use crate::ui::panels::{
     render_inventory_panel, render_mannies_panel, render_probe_panel, render_scanner_panel,
 };
+use palette::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -23,13 +25,9 @@ use ratatui::{
     Frame,
 };
 
-const AMBER: Color = Color::Rgb(0xff, 0xb2, 0x4a);
-const GREEN: Color = Color::Rgb(0x5e, 0xf0, 0x8f);
-const DIM: Color = Color::Rgb(0x6f, 0x8c, 0x7d);
-
 pub fn render(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
-    // Status bar is one line, plus a second hints line when enabled.
+    let p = palette(state.color_mode);
     let status_h = if state.hints_visible { 2 } else { 1 };
     let rows = Layout::default()
         .direction(Direction::Vertical)
@@ -37,38 +35,38 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         .split(area);
 
     if state.zoomed {
-        // Zoom: the active pane takes the whole content area.
-        render_pane(frame, rows[0], state.active_pane, state, true);
+        render_pane(frame, rows[0], state.active_pane, state, true, p);
     } else {
         for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
-            render_pane(frame, rect, pane, state, pane == state.active_pane);
+            render_pane(frame, rect, pane, state, pane == state.active_pane, p);
         }
     }
-    render_status(frame, rows[1], state);
+    render_status(frame, rows[1], state, p);
 
     // Contextual menu popup, then any active wizard overlay on top.
     if let crate::app::InputMode::Menu(m) = &state.mode {
-        menu::render(frame, area, m);
+        menu::render(frame, area, m, p);
     }
     crate::ui::overlays::render_active_overlays(frame, area, state);
 }
 
-fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, active: bool) {
+fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, active: bool, p: Palette) {
     match pane {
+        // Reused classic renderers keep their own colours for now.
         Pane::Probe => render_probe_panel(frame, area, state, active),
         Pane::Inventory => render_inventory_panel(frame, area, state, active),
         Pane::Scanner => render_scanner_panel(frame, area, state, active),
         Pane::Mannies => render_mannies_panel(frame, area, state, active),
-        Pane::Map => panes::render_map(frame, area, state, active),
-        Pane::Comms => panes::render_comms(frame, area, state, active),
-        Pane::Sector => panes::render_sector(frame, area, state, active),
-        Pane::Missions => panes::render_missions(frame, area, state, active),
-        Pane::Storage => panes::render_storage(frame, area, state, active),
+        // Promoted panes are palette-aware.
+        Pane::Map => panes::render_map(frame, area, state, active, p),
+        Pane::Comms => panes::render_comms(frame, area, state, active, p),
+        Pane::Sector => panes::render_sector(frame, area, state, active, p),
+        Pane::Missions => panes::render_missions(frame, area, state, active, p),
+        Pane::Storage => panes::render_storage(frame, area, state, active, p),
     }
 }
 
-fn render_status(frame: &mut Frame, area: Rect, state: &AppState) {
-    // Split off the hints line (bottom) when enabled.
+fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
     let (bar, hints) = if state.hints_visible && area.height >= 2 {
         let rows = Layout::default()
             .direction(Direction::Vertical)
@@ -79,60 +77,64 @@ fn render_status(frame: &mut Frame, area: Rect, state: &AppState) {
         (area, None)
     };
 
-    render_status_line(frame, bar, state);
+    render_status_line(frame, bar, state, p);
     if let Some(hints_area) = hints {
         let line = Line::from(Span::styled(
             format!(" {}", state.pane_hints()),
-            Style::default().fg(DIM),
+            Style::default().fg(p.dim),
         ));
         frame.render_widget(Paragraph::new(line), hints_area);
     }
 }
 
-fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState) {
-    let (tag, tag_bg) = if state.zoomed {
-        ("ZOOM", GREEN)
-    } else {
-        (state.mode.tag(), AMBER)
-    };
+fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
+    let tag = if state.zoomed { "ZOOM" } else { state.mode.tag() };
 
-    // Left: mode tag · breadcrumb · transient toast.
     let mut left = vec![
         Span::styled(
             format!(" {tag} "),
-            Style::default().fg(Color::Black).bg(tag_bg).add_modifier(Modifier::BOLD),
+            Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD),
         ),
-        Span::styled(format!("  {}", state.breadcrumb().join(" › ")), Style::default().fg(GREEN)),
+        Span::styled(format!("  {}", state.breadcrumb().join(" › ")), Style::default().fg(p.accent)),
     ];
     if let Some(toast) = state.active_toast() {
-        left.push(Span::styled(format!("  ✓ {toast}"), Style::default().fg(Color::Green)));
+        left.push(Span::styled(format!("  ✓ {toast}"), Style::default().fg(p.good)));
     }
 
-    // Right: SCUT coverage · unread · API version · clock.
     let mut meta = Vec::new();
     if !state.scut_coverage().is_empty() {
-        meta.push("≣ SCUT".to_string());
+        meta.push(("≣ SCUT".to_string(), p.accent));
     }
     let unread = state.unread_alert_count();
     if unread > 0 {
-        meta.push(format!("! {unread}"));
+        meta.push((format!("! {unread}"), p.crit));
     }
     if let Some(v) = state.api_version {
-        meta.push(format!("API v{v}"));
+        meta.push((format!("API v{v}"), p.dim));
     }
     if let Some(t) = state.last_update {
-        meta.push(t.format("%H:%M:%S").to_string());
+        meta.push((t.format("%H:%M:%S").to_string(), p.dim));
     }
-    let meta = meta.join(" · ");
-    let meta_len = meta.chars().count() as u16;
+    let meta_len: usize = meta.iter().map(|(s, _)| s.chars().count() + 3).sum();
+    let meta_spans: Vec<Span> = meta
+        .iter()
+        .enumerate()
+        .flat_map(|(i, (s, c))| {
+            let sep = if i == 0 { "" } else { " · " };
+            [
+                Span::styled(sep, Style::default().fg(p.dim)),
+                Span::styled(s.clone(), Style::default().fg(*c)),
+            ]
+        })
+        .collect();
 
     let cols = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(0), Constraint::Length(meta_len + 1)])
+        .constraints([Constraint::Min(0), Constraint::Length(meta_len as u16 + 1)])
         .split(area);
     frame.render_widget(Paragraph::new(Line::from(left)), cols[0]);
     frame.render_widget(
-        Paragraph::new(meta).alignment(Alignment::Right).style(Style::default().fg(DIM)),
+        Paragraph::new(Line::from(meta_spans)).alignment(Alignment::Right),
         cols[1],
     );
 }

--- a/src/ui/cockpit_v2/palette.rs
+++ b/src/ui/cockpit_v2/palette.rs
@@ -1,0 +1,72 @@
+//! Color palette for the unified Cockpit interface (bloc U7).
+//!
+//! One [`Palette`] per [`ColorMode`]. Mono modes are single-hue phosphor —
+//! there is no red, so `warn`/`crit` collapse to a brighter shade of the
+//! accent. `PhosphorSemantic` keeps the green base but adds real
+//! green/yellow/red status colours. `Modern16` uses named ANSI colours for
+//! terminals without truecolor.
+
+use crate::app::ColorMode;
+use ratatui::style::Color;
+
+#[derive(Clone, Copy)]
+pub struct Palette {
+    /// Active/selected accent (borders, tags, selection).
+    pub accent: Color,
+    /// Dim accent (inactive borders).
+    pub accent_dim: Color,
+    /// Primary readable text.
+    pub text: Color,
+    /// Secondary/muted text.
+    pub dim: Color,
+    pub good: Color,
+    pub warn: Color,
+    pub crit: Color,
+}
+
+pub fn palette(mode: ColorMode) -> Palette {
+    match mode {
+        ColorMode::MonoGreen => {
+            let accent = Color::Rgb(0x5e, 0xf0, 0x8f);
+            Palette {
+                accent,
+                accent_dim: Color::Rgb(0x2f, 0x7a, 0x52),
+                text: Color::Rgb(0xb6, 0xd4, 0xc2),
+                dim: Color::Rgb(0x3a, 0x5a, 0x48),
+                good: accent,
+                warn: Color::Rgb(0xc8, 0xff, 0xdd),
+                crit: accent,
+            }
+        }
+        ColorMode::MonoAmber => {
+            let accent = Color::Rgb(0xff, 0xb2, 0x4a);
+            Palette {
+                accent,
+                accent_dim: Color::Rgb(0x8a, 0x5e, 0x22),
+                text: Color::Rgb(0xf0, 0xd8, 0xb0),
+                dim: Color::Rgb(0x6e, 0x4a, 0x16),
+                good: accent,
+                warn: Color::Rgb(0xff, 0xe1, 0xad),
+                crit: accent,
+            }
+        }
+        ColorMode::PhosphorSemantic => Palette {
+            accent: Color::Rgb(0x5e, 0xf0, 0x8f),
+            accent_dim: Color::Rgb(0x2f, 0x7a, 0x52),
+            text: Color::Rgb(0xb6, 0xd4, 0xc2),
+            dim: Color::Rgb(0x3a, 0x5a, 0x48),
+            good: Color::Rgb(0x5e, 0xf0, 0x8f),
+            warn: Color::Rgb(0xff, 0xd2, 0x4a),
+            crit: Color::Rgb(0xff, 0x5d, 0x6b),
+        },
+        ColorMode::Modern16 => Palette {
+            accent: Color::Green,
+            accent_dim: Color::DarkGray,
+            text: Color::Gray,
+            dim: Color::DarkGray,
+            good: Color::Green,
+            warn: Color::Yellow,
+            crit: Color::Red,
+        },
+    }
+}

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -1,23 +1,32 @@
-//! Compact read-only renderers for the five panes promoted from overlays
-//! (blocs U2–U3): Map, Comms, Sector, Missions, Storage. The four original
-//! panes (Probe, Inventory, Scanner, Mannies) reuse their existing renderers.
+//! Compact renderers for the five panes promoted from overlays (blocs U2–U7):
+//! Map, Comms, Sector, Missions, Storage. The four original panes (Probe,
+//! Inventory, Scanner, Mannies) reuse their existing renderers.
 //!
 //! Each shows a terse summary sized for a 1/3 grid cell; drilling in (`l`)
-//! swaps a pane to its detail view (Missions → steps, Comms → message). The
-//! remaining detail views and actions land with menus (U5).
+//! swaps a pane to its detail view (Missions → steps, Comms → message).
+//! Colours come from the active [`Palette`].
 
+use super::palette::Palette;
 use crate::api::types::{MissionStatus, MissionStepStatus};
 use crate::app::{AppState, DrillLevel, Pane};
-use crate::ui::theme::{gauge_color, object_icon, panel_block};
+use crate::ui::theme::object_icon;
 use ratatui::{
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Paragraph, Wrap},
+    widgets::{Block, Borders, Paragraph, Wrap},
     Frame,
 };
 
-const DIM: Style = Style::new().fg(Color::DarkGray);
+/// Palette-aware pane border/title, replacing the classic `theme::panel_block`.
+fn pane_block(title: &str, active: bool, p: Palette) -> Block<'_> {
+    let color = if active { p.accent } else { p.accent_dim };
+    let modifier = if active { Modifier::BOLD } else { Modifier::empty() };
+    Block::default()
+        .title(Span::styled(title, Style::default().fg(color).add_modifier(modifier)))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(color))
+}
 
 /// Style for the selected row: highlighted only while the pane is active.
 fn row_style(active: bool, selected: bool) -> Style {
@@ -28,201 +37,215 @@ fn row_style(active: bool, selected: bool) -> Style {
     }
 }
 
+/// Fill colour for a "how full" ratio, mapped through the palette so mono
+/// modes stay single-hue.
+fn fill_color(p: Palette, ratio: f64) -> ratatui::style::Color {
+    if ratio > 0.5 {
+        p.good
+    } else if ratio > 0.25 {
+        p.warn
+    } else {
+        p.crit
+    }
+}
+
 fn cursor(state: &AppState, pane: Pane) -> usize {
     state.pane_nav[pane.index()].cursor
 }
 
-fn render_body(frame: &mut Frame, area: Rect, title: &str, active: bool, lines: Vec<Line>) {
-    let block = panel_block(title, active);
+fn render_body(frame: &mut Frame, area: Rect, title: &str, active: bool, p: Palette, lines: Vec<Line>) {
+    let block = pane_block(title, active, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
     frame.render_widget(Paragraph::new(lines), inner);
 }
 
-pub fn render_map(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+pub fn render_map(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {
+    let dim = Style::default().fg(p.dim);
     let mut lines = Vec::new();
     match state.probe_sector_coords() {
-        Some((x, y, z)) => lines.push(Line::from(format!("sector ({x}, {y}, {z})"))),
-        None => lines.push(Line::styled("sector unknown", DIM)),
+        Some((x, y, z)) => lines.push(Line::styled(format!("sector ({x}, {y}, {z})"), Style::default().fg(p.text))),
+        None => lines.push(Line::styled("sector unknown", dim)),
     }
-    lines.push(Line::from(format!("visited: {}", state.visited_sectors.len())));
+    lines.push(Line::styled(format!("visited: {}", state.visited_sectors.len()), Style::default().fg(p.text)));
     let nets = state.scut_coverage();
     if nets.is_empty() {
-        lines.push(Line::styled("SCUT: no coverage", DIM));
+        lines.push(Line::styled("SCUT: no coverage", dim));
     } else {
-        lines.push(Line::styled(
-            format!("≣ SCUT: {} network(s)", nets.len()),
-            Style::default().fg(Color::LightBlue),
-        ));
+        lines.push(Line::styled(format!("≣ SCUT: {} network(s)", nets.len()), Style::default().fg(p.accent)));
     }
-    lines.push(Line::styled("[z] zoom for full map", DIM));
-    render_body(frame, area, " MAP ", active, lines);
+    lines.push(Line::styled("[z] zoom for full map", dim));
+    render_body(frame, area, " MAP ", active, p, lines);
 }
 
-pub fn render_comms(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+pub fn render_comms(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {
     if let Some(DrillLevel::MessageThread(id)) = state.pane_nav[Pane::Comms.index()].drill.last() {
-        return render_message_detail(frame, area, state, id, active);
+        return render_message_detail(frame, area, state, id, active, p);
     }
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
     let unread_alerts = state.unread_alert_count();
     let unread_msgs = state.unread_message_count();
     let mut lines = vec![
         Line::from(vec![
-            Span::raw(format!("alerts {} ", state.alerts.len())),
-            Span::styled(format!("({unread_alerts} unread)"), DIM),
-            Span::raw(format!("  warn {}", state.damage_warnings.len())),
+            Span::styled(format!("alerts {} ", state.alerts.len()), text),
+            Span::styled(format!("({unread_alerts} unread)"), dim),
+            Span::styled(format!("  warn {}", state.damage_warnings.len()), text),
         ]),
         Line::from(vec![
-            Span::raw(format!("messages {} ", state.messages.len())),
-            Span::styled(format!("({unread_msgs} unread)"), DIM),
+            Span::styled(format!("messages {} ", state.messages.len()), text),
+            Span::styled(format!("({unread_msgs} unread)"), dim),
         ]),
         Line::raw(""),
     ];
     let cur = cursor(state, Pane::Comms);
     if state.messages.is_empty() {
-        lines.push(Line::styled("no messages", DIM));
+        lines.push(Line::styled("no messages", dim));
     } else {
         for (i, m) in state.messages.iter().enumerate() {
             let unread = m.status == crate::api::types::MessageStatus::Unread;
             let mark = if unread { "✉" } else { "·" };
             let body: String = m.body.chars().take(18).collect();
-            let span = Span::styled(
+            lines.push(Line::from(Span::styled(
                 format!("{mark} {}: {}", m.sender.name, body),
-                row_style(active, i == cur),
-            );
-            lines.push(Line::from(span));
+                row_style(active, i == cur).patch(text),
+            )));
         }
     }
-    render_body(frame, area, " COMMS ", active, lines);
+    render_body(frame, area, " COMMS ", active, p, lines);
 }
 
-fn render_message_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool) {
-    let block = panel_block(" MESSAGE ", active);
+fn render_message_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool, p: Palette) {
+    let block = pane_block(" MESSAGE ", active, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
+    let dim = Style::default().fg(p.dim);
     let Some(m) = state.messages.iter().find(|m| m.id.to_string() == id) else {
-        frame.render_widget(Paragraph::new(Line::styled("message not found", DIM)), inner);
+        frame.render_widget(Paragraph::new(Line::styled("message not found", dim)), inner);
         return;
     };
     let lines = vec![
-        Line::from(vec![Span::styled("from ", DIM), Span::raw(m.sender.name.clone())]),
-        Line::from(vec![Span::styled("to   ", DIM), Span::raw(m.recipient.name.clone())]),
-        Line::styled(m.created_at.clone(), DIM),
+        Line::from(vec![Span::styled("from ", dim), Span::styled(m.sender.name.clone(), Style::default().fg(p.text))]),
+        Line::from(vec![Span::styled("to   ", dim), Span::styled(m.recipient.name.clone(), Style::default().fg(p.text))]),
+        Line::styled(m.created_at.clone(), dim),
         Line::raw(""),
-        Line::raw(m.body.clone()),
+        Line::styled(m.body.clone(), Style::default().fg(p.text)),
     ];
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }
 
-pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {
+    let dim = Style::default().fg(p.dim);
     let mut lines = Vec::new();
     match state.current_sector() {
         Some(s) => {
             let v = &s.relative_coordinates;
-            lines.push(Line::from(format!(
-                "({}, {}, {})  d{}",
-                v.x as i32, v.y as i32, v.z as i32, s.distance
-            )));
+            lines.push(Line::styled(
+                format!("({}, {}, {})  d{}", v.x as i32, v.y as i32, v.z as i32, s.distance),
+                Style::default().fg(p.text),
+            ));
             let objs = state.scanner_objects();
-            lines.push(Line::styled(format!("{} object(s)", objs.len()), DIM));
+            lines.push(Line::styled(format!("{} object(s)", objs.len()), dim));
             let cur = cursor(state, Pane::Sector);
             for (i, e) in objs.iter().enumerate() {
                 let (icon, color) = object_icon(&e.object_type);
                 let name: String = e.name.chars().take(20).collect();
                 lines.push(Line::from(vec![
                     Span::styled(format!("{icon} "), Style::default().fg(color)),
-                    Span::styled(name, row_style(active, i == cur)),
+                    Span::styled(name, row_style(active, i == cur).patch(Style::default().fg(p.text))),
                 ]));
             }
         }
-        None => lines.push(Line::styled("no sector scan yet", DIM)),
+        None => lines.push(Line::styled("no sector scan yet", dim)),
     }
-    render_body(frame, area, " SECTOR ", active, lines);
+    render_body(frame, area, " SECTOR ", active, p, lines);
 }
 
-pub fn render_missions(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+pub fn render_missions(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {
     if let Some(DrillLevel::Mission(id)) = state.pane_nav[Pane::Missions.index()].drill.last() {
-        return render_mission_detail(frame, area, state, id, active);
+        return render_mission_detail(frame, area, state, id, active, p);
     }
+    let dim = Style::default().fg(p.dim);
     let mut lines = Vec::new();
     if state.missions.is_empty() {
-        lines.push(Line::styled("no active missions", DIM));
+        lines.push(Line::styled("no active missions", dim));
     } else {
         let cur = cursor(state, Pane::Missions);
         for (i, m) in state.missions.iter().enumerate() {
             let color = match m.status {
-                MissionStatus::Active => Color::Cyan,
-                MissionStatus::Completed => Color::Green,
-                MissionStatus::Failed | MissionStatus::Abandoned => Color::Red,
-                MissionStatus::Unknown => Color::DarkGray,
+                MissionStatus::Active => p.accent,
+                MissionStatus::Completed => p.good,
+                MissionStatus::Failed | MissionStatus::Abandoned => p.crit,
+                MissionStatus::Unknown => p.dim,
             };
-            let done = m.steps.iter().filter(|s| {
-                matches!(s.status, crate::api::types::MissionStepStatus::Completed)
-            }).count();
+            let done = m
+                .steps
+                .iter()
+                .filter(|s| matches!(s.status, MissionStepStatus::Completed))
+                .count();
             let title: String = m.title.chars().take(22).collect();
             lines.push(Line::from(vec![
                 Span::styled("▸ ", Style::default().fg(color)),
-                Span::styled(title, row_style(active, i == cur)),
-                Span::styled(format!(" {done}/{}", m.steps.len()), DIM),
+                Span::styled(title, row_style(active, i == cur).patch(Style::default().fg(p.text))),
+                Span::styled(format!(" {done}/{}", m.steps.len()), dim),
             ]));
         }
     }
-    render_body(frame, area, " MISSIONS ", active, lines);
+    render_body(frame, area, " MISSIONS ", active, p, lines);
 }
 
-fn render_mission_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool) {
-    let block = panel_block(" MISSION ", active);
+fn render_mission_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool, p: Palette) {
+    let block = pane_block(" MISSION ", active, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
+    let dim = Style::default().fg(p.dim);
     let Some(m) = state.missions.iter().find(|m| m.id == id) else {
-        frame.render_widget(Paragraph::new(Line::styled("mission not found", DIM)), inner);
+        frame.render_widget(Paragraph::new(Line::styled("mission not found", dim)), inner);
         return;
     };
     let mut lines = vec![Line::styled(
         m.title.clone(),
-        Style::default().add_modifier(Modifier::BOLD),
+        Style::default().fg(p.text).add_modifier(Modifier::BOLD),
     )];
     if let Some(d) = &m.description {
-        lines.push(Line::styled(d.clone(), DIM));
+        lines.push(Line::styled(d.clone(), dim));
     }
     lines.push(Line::raw(""));
     let cur = cursor(state, Pane::Missions);
     for (i, step) in m.steps.iter().enumerate() {
         let (mark, color) = match step.status {
-            MissionStepStatus::Completed => ("✓", Color::Green),
-            MissionStepStatus::Failed => ("✗", Color::Red),
-            MissionStepStatus::Skipped => ("–", Color::DarkGray),
-            MissionStepStatus::Pending => ("·", Color::Cyan),
-            MissionStepStatus::Unknown => ("?", Color::DarkGray),
+            MissionStepStatus::Completed => ("✓", p.good),
+            MissionStepStatus::Failed => ("✗", p.crit),
+            MissionStepStatus::Skipped => ("–", p.dim),
+            MissionStepStatus::Pending => ("·", p.accent),
+            MissionStepStatus::Unknown => ("?", p.dim),
         };
         lines.push(Line::from(vec![
             Span::styled(format!("{mark} "), Style::default().fg(color)),
-            Span::styled(step.title.clone(), row_style(active, i == cur)),
+            Span::styled(step.title.clone(), row_style(active, i == cur).patch(Style::default().fg(p.text))),
         ]));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }
 
-pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {
+    let dim = Style::default().fg(p.dim);
     let mut lines = Vec::new();
     if state.storage_containers.is_empty() {
-        lines.push(Line::styled("no containers ([C] loads)", DIM));
+        lines.push(Line::styled("no containers ([C] loads)", dim));
     } else {
         let cur = cursor(state, Pane::Storage);
         for (i, c) in state.storage_containers.iter().enumerate() {
-            let ratio = if c.capacity > 0.0 {
-                c.used_capacity / c.capacity
-            } else {
-                0.0
-            };
+            let ratio = if c.capacity > 0.0 { c.used_capacity / c.capacity } else { 0.0 };
             let label: String = c.label.chars().take(16).collect();
             lines.push(Line::from(vec![
-                Span::styled(label, row_style(active, i == cur)),
+                Span::styled(label, row_style(active, i == cur).patch(Style::default().fg(p.text))),
                 Span::styled(
                     format!(" {:.0}/{:.0}", c.used_capacity, c.capacity),
-                    Style::default().fg(gauge_color(1.0 - ratio)),
+                    Style::default().fg(fill_color(p, 1.0 - ratio)),
                 ),
             ]));
         }
     }
-    render_body(frame, area, " STORAGE ", active, lines);
+    render_body(frame, area, " STORAGE ", active, p, lines);
 }


### PR DESCRIPTION
Theme bloc (done before U5b/U6, as requested — it only depends on U4): the cockpit gets a proper phosphor identity with switchable color modes.

## What it adds

- **Color modes** — `mono-green` (default), `mono-amber`, `phosphor-semantic` (green base + real green/yellow/red status), `modern-16` (named ANSI for limited terminals). Read from the `theme` config key, cycled at runtime with **F2** (which still toggles classic/retro outside the cockpit).
- **Palette module** — resolves every cockpit-owned colour per mode. Applied to: status bar (mode tag, breadcrumb, toast, meta), hints line, contextual menu popup, and the five promoted panes (borders, text, mission/step status, storage fill). Mono modes stay single-hue; `phosphor-semantic` adds status colours.

## Scope / known debt

- The four reused classic panels (Probe, Inventory, Scanner, Mannies) keep their classic colours until they get cockpit-native renderers — so their borders/hints are not yet phosphor. Tracked; resolved with the compact-render pass / U8 cleanup.
- Truecolor→256→16 auto-degradation is deferred; `modern-16` is the manual fallback for terminals without truecolor.

## Verification

- `cargo build` ✓
- `cargo test` → 174 passed (incl. color-mode parse + cycle tests)
- `cargo clippy` → clean