### PR TITLE
feat(cockpit): complete the Mannies action menu

### DIFF
--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -10,8 +10,15 @@
 /// the existing wizards (bloc U5 wires the Mannies pane; more panes follow).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MenuAction {
-    Repair,
+    Mine,
     Craft,
+    Repair,
+    Salvage,
+    Inspect,
+    Recover,
+    Detach,
+    Refuel,
+    DropCargo,
     Recall,
     Rename,
 }
@@ -81,30 +88,59 @@ impl super::AppState {
     }
 
     fn mannies_context_menu(&self) -> Option<ContextMenu> {
-        use crate::api::types::MannyTaskVisibility;
+        use crate::api::types::{MannyTask, MannyTaskVisibility};
         let manny = self.mannies.as_ref()?.get(self.mannies_selection)?;
-        let busy = (!manny.can_receive_orders).then(|| "busy".to_string());
+        let can = manny.can_receive_orders;
+        let busy = (!can).then(|| "busy".to_string());
         let has_task = manny.current_task.is_some();
         let remote = matches!(manny.task_visibility, Some(MannyTaskVisibility::ScutNetwork));
+        let remote_minable = self.manny_remote_minable(manny);
+        let waiting_space = manny.current_task == Some(MannyTask::WaitingForSpace);
+        let has_station = self.deuterium_station_in_current_sector();
+
+        // `orders`: an action needs the Manny to be idle/orderable, with a
+        // shared "busy" reason when it isn't.
+        let orders = |action, label: &str| MenuItem {
+            action,
+            label: label.into(),
+            enabled: can,
+            disabled_reason: busy.clone(),
+        };
 
         let items = vec![
             MenuItem {
-                action: MenuAction::Repair,
-                label: "Repair".into(),
-                enabled: manny.can_receive_orders,
-                disabled_reason: busy.clone(),
+                action: MenuAction::Mine,
+                label: "Mine…".into(),
+                enabled: can || remote_minable,
+                disabled_reason: (!can && !remote_minable).then(|| "busy".to_string()),
+            },
+            orders(MenuAction::Craft, "Craft…"),
+            orders(MenuAction::Repair, "Repair"),
+            orders(MenuAction::Salvage, "Salvage…"),
+            orders(MenuAction::Inspect, "Inspect…"),
+            orders(MenuAction::Recover, "Recover container…"),
+            orders(MenuAction::Detach, "Detach container…"),
+            MenuItem {
+                action: MenuAction::Refuel,
+                label: "Refill deuterium".into(),
+                enabled: can && has_station,
+                disabled_reason: if !can {
+                    Some("busy".to_string())
+                } else {
+                    (!has_station).then(|| "no station".to_string())
+                },
             },
             MenuItem {
-                action: MenuAction::Craft,
-                label: "Craft…".into(),
-                enabled: manny.can_receive_orders,
-                disabled_reason: busy,
+                action: MenuAction::DropCargo,
+                label: "Drop cargo".into(),
+                enabled: waiting_space,
+                disabled_reason: (!waiting_space).then(|| "not waiting".to_string()),
             },
             MenuItem {
                 action: MenuAction::Recall,
                 label: if remote { "Abandon".into() } else { "Recall".into() },
-                enabled: !manny.can_receive_orders && has_task,
-                disabled_reason: (manny.can_receive_orders || !has_task).then(|| "idle".to_string()),
+                enabled: !can && has_task,
+                disabled_reason: (can || !has_task).then(|| "idle".to_string()),
             },
             MenuItem {
                 action: MenuAction::Rename,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1378,20 +1378,27 @@ fn mannies_context_menu_reflects_manny_state() {
     let mut state = AppState::default();
     state.active_pane = Pane::Mannies;
 
-    // Idle manny: repair/craft/rename enabled, recall disabled.
+    // Idle manny: order-requiring actions enabled, recall disabled, and
+    // conditional actions (refuel/drop-cargo) disabled without their context.
     state.mannies = Some(vec![make_manny("m1", "probe_rack", true, None)]);
     let menu = state.build_context_menu().expect("mannies menu");
+    assert!(menu_item(&menu, MenuAction::Mine).enabled);
     assert!(menu_item(&menu, MenuAction::Repair).enabled);
     assert!(menu_item(&menu, MenuAction::Craft).enabled);
+    assert!(menu_item(&menu, MenuAction::Salvage).enabled);
+    assert!(menu_item(&menu, MenuAction::Inspect).enabled);
     assert!(menu_item(&menu, MenuAction::Rename).enabled);
     assert!(!menu_item(&menu, MenuAction::Recall).enabled);
+    assert!(!menu_item(&menu, MenuAction::Refuel).enabled); // no station
+    assert!(!menu_item(&menu, MenuAction::DropCargo).enabled); // not waiting
     // Cursor lands on the first enabled item.
     assert!(menu.items[menu.cursor].enabled);
 
-    // Busy manny with a task: repair/craft disabled, recall enabled.
+    // Busy manny with a task: order-requiring actions disabled, recall enabled.
     state.mannies = Some(vec![make_manny("m2", "sector", false, Some("mining"))]);
     let menu = state.build_context_menu().expect("mannies menu");
     assert!(!menu_item(&menu, MenuAction::Repair).enabled);
+    assert!(!menu_item(&menu, MenuAction::Salvage).enabled);
     assert!(menu_item(&menu, MenuAction::Recall).enabled);
 }
 

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -10,11 +10,12 @@ use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
-use crate::api::tasks::fetch_all;
-use crate::api::types::MannyTaskVisibility;
+use crate::api::tasks::{fetch_all, fetch_inspect, fetch_recover, fetch_sector};
+use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
-    ApiMessage, AppState, CraftInput, InputMode, MenuAction, Pane, RecallInput, RenameMannyInput,
-    RepairInput,
+    ApiMessage, AppState, CraftInput, DetachInput, DropCargoInput, InputMode, InspectInput,
+    MenuAction, MineInput, Pane, RecallInput, RecoverInput, RefuelInput, RemoteMineInput,
+    RenameMannyInput, RepairInput, SalvageInput,
 };
 
 pub fn handle_cockpit_event(
@@ -25,7 +26,7 @@ pub fn handle_cockpit_event(
 ) {
     // A context menu, when open, captures all input.
     if matches!(state.mode, InputMode::Menu(_)) {
-        handle_menu_key(code, state);
+        handle_menu_key(code, state, client, tx);
         return;
     }
 
@@ -69,7 +70,12 @@ fn open_context_menu(state: &mut AppState) {
     }
 }
 
-fn handle_menu_key(code: KeyCode, state: &mut AppState) {
+fn handle_menu_key(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
     match code {
         KeyCode::Esc => state.mode = InputMode::Normal,
         KeyCode::Up | KeyCode::Char('k') => {
@@ -85,7 +91,6 @@ fn handle_menu_key(code: KeyCode, state: &mut AppState) {
             }
         }
         KeyCode::Enter => {
-            // Read the selected action without holding the borrow across the fire.
             let action = if let InputMode::Menu(m) = &state.mode {
                 m.items.get(m.cursor).filter(|i| i.enabled).map(|i| i.action)
             } else {
@@ -93,16 +98,21 @@ fn handle_menu_key(code: KeyCode, state: &mut AppState) {
             };
             if let Some(action) = action {
                 state.mode = InputMode::Normal;
-                fire_menu_action(action, state);
+                fire_menu_action(action, state, client, tx);
             }
         }
         _ => {}
     }
 }
 
-/// Launch the wizard behind a menu action for the selected Manny. The
-/// existing wizard event handlers take over on subsequent keys.
-fn fire_menu_action(action: MenuAction, state: &mut AppState) {
+/// Launch the wizard behind a menu action for the selected Manny. Mirrors the
+/// classic single-key launches; the shared wizard handlers take over next.
+fn fire_menu_action(
+    action: MenuAction,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
     let Some(m) = state.mannies.as_ref().and_then(|v| v.get(state.mannies_selection)) else {
         return;
     };
@@ -110,44 +120,114 @@ fn fire_menu_action(action: MenuAction, state: &mut AppState) {
     let name = m.name.clone();
     let can = m.can_receive_orders;
     let has_task = m.current_task.is_some();
-    let remote = matches!(m.task_visibility, Some(MannyTaskVisibility::ScutNetwork));
+    let waiting_space = m.current_task == Some(MannyTask::WaitingForSpace);
+    let remote_recall = matches!(m.task_visibility, Some(MannyTaskVisibility::ScutNetwork));
+    let remote_minable = state.manny_remote_minable(m);
+    let coords = state.manny_sector_coords(m).unwrap_or((0, 0, 0));
 
     match action {
         MenuAction::Repair if can => {
-            state.repair = RepairInput::Typing {
-                manny_id: id,
-                manny_name: name,
-                buf: String::new(),
-                error: None,
-            };
+            state.repair = RepairInput::Typing { manny_id: id, manny_name: name, buf: String::new(), error: None };
         }
         MenuAction::Craft if can => {
             if state.manny_craft_recipes().is_empty() {
                 state.error = Some("recipes not loaded yet — F5 to refresh".into());
             } else {
-                state.craft = CraftInput::PickRecipe {
-                    manny_id: id,
-                    manny_name: name,
-                    selection: 0,
-                    error: None,
-                };
+                state.craft = CraftInput::PickRecipe { manny_id: id, manny_name: name, selection: 0, error: None };
             }
         }
+        MenuAction::Mine => {
+            if remote_minable {
+                state.remote_mine = RemoteMineInput::Loading {
+                    manny_id: id,
+                    manny_name: name,
+                    x: coords.0,
+                    y: coords.1,
+                    z: coords.2,
+                };
+                state.set_toast("fetching remote sector…");
+                fetch_sector(Some(coords), client.clone(), tx.clone());
+            } else if can {
+                let candidates = state.collect_mineable_candidates();
+                match candidates.len() {
+                    0 => state.error = Some("no mineable objects in current sector — scan first".into()),
+                    1 => {
+                        let (object_id, object_name) = candidates.into_iter().next().unwrap();
+                        state.mine = MineInput::Configure {
+                            manny_id: id,
+                            manny_name: name,
+                            object_id,
+                            object_name,
+                            resources: [false, true, false, false],
+                            amount_buf: "0.30".into(),
+                            amount_mode: false,
+                            target_container: None,
+                            error: None,
+                        };
+                    }
+                    _ => state.mine = MineInput::PickAsteroid { manny_id: id, manny_name: name, candidates, selection: 0 },
+                }
+            }
+        }
+        MenuAction::Salvage if can => {
+            let candidates = state.collect_salvage_candidates();
+            match candidates.len() {
+                0 => state.error = Some("no salvageable objects in current sector — scan first".into()),
+                1 => {
+                    let (object_id, object_name) = candidates.into_iter().next().unwrap();
+                    state.salvage = SalvageInput::Confirm { manny_id: id, manny_name: name, object_id, object_name, error: None };
+                }
+                _ => state.salvage = SalvageInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0 },
+            }
+        }
+        MenuAction::Inspect if can => {
+            let candidates = state.collect_asteroid_candidates();
+            match candidates.len() {
+                0 => state.error = Some("no asteroids in current sector — scan first".into()),
+                1 => {
+                    let (object_id, _) = candidates.into_iter().next().unwrap();
+                    fetch_inspect(id, object_id, client.clone(), tx.clone());
+                }
+                _ => state.inspect = InspectInput::PickAsteroid { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
+            }
+        }
+        MenuAction::Recover if can => {
+            let candidates = state.collect_detached_containers();
+            match candidates.len() {
+                0 => state.error = Some("no detached containers in current sector — scan first".into()),
+                1 => {
+                    let (object_id, _) = candidates.into_iter().next().unwrap();
+                    fetch_recover(id, object_id, client.clone(), tx.clone());
+                }
+                _ => state.recover = RecoverInput::PickContainer { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
+            }
+        }
+        MenuAction::Detach if can => {
+            let containers = state.collect_detachable_containers();
+            match containers.len() {
+                0 => state.error = Some("no detachable containers in inventory".into()),
+                1 => {
+                    let (container_id, container_name) = containers.into_iter().next().unwrap();
+                    state.detach = DetachInput::PickMode { manny_id: id, manny_name: name, container_id, container_name, selection: 0, error: None };
+                }
+                _ => state.detach = DetachInput::PickContainer { manny_id: id, manny_name: name, containers, selection: 0 },
+            }
+        }
+        MenuAction::Refuel if can => {
+            if state.deuterium_station_in_current_sector() {
+                state.refuel = RefuelInput::Confirm { manny_id: id, manny_name: name, error: None };
+            } else {
+                state.error = Some("no deuterium refuel station in this sector".into());
+            }
+        }
+        MenuAction::DropCargo if waiting_space => {
+            state.drop_cargo = DropCargoInput::Confirm { manny_id: id, manny_name: name, error: None };
+        }
         MenuAction::Recall if !can && has_task => {
-            state.recall = RecallInput::Confirm {
-                manny_id: id,
-                manny_name: name,
-                remote,
-                error: None,
-            };
+            state.recall = RecallInput::Confirm { manny_id: id, manny_name: name, remote: remote_recall, error: None };
         }
         MenuAction::Rename => {
-            state.rename_manny = RenameMannyInput::Typing {
-                manny_id: id,
-                manny_name: name.clone(),
-                buf: name,
-                error: None,
-            };
+            state.rename_manny = RenameMannyInput::Typing { manny_id: id, manny_name: name.clone(), buf: name, error: None };
         }
         // Guard mismatch (state changed since the menu was built): no-op.
         _ => {}


### PR DESCRIPTION
U5 slice 2: finishes the Mannies contextual menu so the flagship pane is fully actionable.

## What it adds

Adds the remaining Mannies actions to the `Enter` menu, each mirroring the classic single-key launch (candidate collection, 0/1/many branching, direct fetches) and enabled/disabled with a reason from the Manny state:

- **Mine** — local candidates, or remote via SCUT (fetches the remote sector first)
- **Salvage**, **Inspect** (direct fetch on a single asteroid)
- **Recover container** (direct fetch on a single detached container), **Detach container**
- **Refill deuterium** (needs a station in-sector), **Drop cargo** (only while waiting for space)

Together with slice 1 (repair/craft/recall/rename) the Mannies pane now exposes its full action set.

## Not yet

Drop-*storage*-container (`P`, needs planet + drop-kit context) is deferred; and the other panes’ menus (Sector objects, Inventory, Storage, Missions, Comms) are the next step.

## Verification

- `cargo build` ✓
- `cargo test` → 174 passed (menu-state test extended for the new actions)
- `cargo clippy` → clean on changed files