### PR TITLE
feat(cockpit): actions for the remaining panes

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -261,8 +261,11 @@ impl super::AppState {
         if !drilled && matches!(pane, Pane::Missions | Pane::Comms) {
             parts.push("l open");
         }
-        // Panes with a contextual action menu (bloc U5: Mannies).
-        if matches!(pane, Pane::Mannies) {
+        // Panes that expose actions on Enter (menu or reused overlay).
+        if matches!(
+            pane,
+            Pane::Mannies | Pane::Inventory | Pane::Missions | Pane::Comms | Pane::Storage | Pane::Sector
+        ) {
             parts.push("Enter act");
         }
         parts.push("z zoom");

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -21,6 +21,10 @@ pub enum MenuAction {
     DropCargo,
     Recall,
     Rename,
+    // Inventory pane
+    Jettison,
+    AtomicCraft,
+    MoveStock,
 }
 
 /// A single entry in a contextual action menu.
@@ -83,8 +87,37 @@ impl super::AppState {
     pub fn build_context_menu(&self) -> Option<ContextMenu> {
         match self.active_pane {
             super::Pane::Mannies => self.mannies_context_menu(),
+            super::Pane::Inventory => Some(self.inventory_context_menu()),
             _ => None,
         }
+    }
+
+    fn inventory_context_menu(&self) -> ContextMenu {
+        let has_row = self.selected_inventory_row().is_some();
+        let has_printer = self.has_atomic_printer();
+        let idle_manny = !self.collect_idle_onboard_mannies().is_empty();
+        let items = vec![
+            MenuItem {
+                action: MenuAction::Jettison,
+                label: "Jettison…".into(),
+                enabled: has_row,
+                disabled_reason: (!has_row).then(|| "no item selected".to_string()),
+            },
+            MenuItem {
+                action: MenuAction::AtomicCraft,
+                label: "Atomic craft…".into(),
+                enabled: has_printer,
+                disabled_reason: (!has_printer).then(|| "no atomic printer".to_string()),
+            },
+            MenuItem {
+                action: MenuAction::MoveStock,
+                label: "Move stock…".into(),
+                enabled: idle_manny,
+                disabled_reason: (!idle_manny).then(|| "no idle manny".to_string()),
+            },
+        ];
+        let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
+        ContextMenu { title: "INVENTORY".into(), items, cursor }
     }
 
     fn mannies_context_menu(&self) -> Option<ContextMenu> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1408,3 +1408,13 @@ fn context_menu_none_for_pane_without_actions() {
     state.active_pane = Pane::Probe;
     assert!(state.build_context_menu().is_none());
 }
+
+#[test]
+fn inventory_context_menu_present_but_disabled_when_empty() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Inventory;
+    let menu = state.build_context_menu().expect("inventory menu");
+    assert_eq!(menu.items.len(), 3);
+    // Nothing loaded → every action disabled with a reason.
+    assert!(menu.items.iter().all(|i| !i.enabled && i.disabled_reason.is_some()));
+}

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -10,12 +10,16 @@ use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
-use crate::api::tasks::{fetch_all, fetch_inspect, fetch_recover, fetch_sector};
+use crate::api::tasks::{
+    fetch_all, fetch_inspect, fetch_messages, fetch_recover, fetch_sector, fetch_sent_messages,
+    fetch_storage_containers,
+};
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
-    ApiMessage, AppState, CraftInput, DetachInput, DropCargoInput, InputMode, InspectInput,
-    MenuAction, MineInput, Pane, RecallInput, RecoverInput, RefuelInput, RemoteMineInput,
-    RenameMannyInput, RepairInput, SalvageInput,
+    ApiMessage, AppState, AtomicPrinterCraftInput, ContainersInput, CraftInput, DetachInput,
+    DropCargoInput, InputMode, InspectInput, MenuAction, MessagesInput, MineInput, MissionsInput,
+    ObjectActionInput, Pane, RecallInput, RecoverInput, RefuelInput, RemoteMineInput,
+    RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput,
 };
 
 pub fn handle_cockpit_event(
@@ -32,7 +36,7 @@ pub fn handle_cockpit_event(
 
     match code {
         KeyCode::Char('q') => state.set_quit(),
-        KeyCode::Enter => open_context_menu(state),
+        KeyCode::Enter => open_actions(state, client, tx),
         KeyCode::Char(c) if Pane::from_key(c).is_some() => {
             state.active_pane = Pane::from_key(c).unwrap();
         }
@@ -63,11 +67,54 @@ pub fn handle_cockpit_event(
     }
 }
 
-fn open_context_menu(state: &mut AppState) {
-    match state.build_context_menu() {
-        Some(menu) if !menu.items.is_empty() => state.mode = InputMode::Menu(menu),
+/// `Enter` action for the active pane: panes with a discrete action set open
+/// the contextual menu; panes backed by a rich wizard reuse its overlay.
+fn open_actions(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
+    match state.active_pane {
+        Pane::Mannies | Pane::Inventory => match state.build_context_menu() {
+            Some(menu) if !menu.items.is_empty() => state.mode = InputMode::Menu(menu),
+            _ => state.set_toast("no actions here"),
+        },
+        Pane::Missions => {
+            if state.missions.is_empty() {
+                state.set_toast("no missions");
+            } else {
+                let selection = state.pane_nav[Pane::Missions.index()].cursor;
+                state.missions_input = MissionsInput::Browsing { selection };
+            }
+        }
+        Pane::Comms => {
+            state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 };
+            fetch_messages(client.clone(), tx.clone());
+            fetch_sent_messages(client.clone(), tx.clone());
+        }
+        Pane::Storage => {
+            fetch_storage_containers(client.clone(), tx.clone());
+            state.containers_input = ContainersInput::Browsing { selection: 0 };
+        }
+        Pane::Sector => open_sector_object_actions(state),
         _ => state.set_toast("no actions here"),
     }
+}
+
+fn open_sector_object_actions(state: &mut AppState) {
+    let entries = state.scanner_objects();
+    let cur = state.pane_nav[Pane::Sector.index()].cursor;
+    let Some(entry) = entries.get(cur) else {
+        state.set_toast("no object selected");
+        return;
+    };
+    let actions = state.actions_for_object(entry);
+    if actions.is_empty() {
+        state.set_toast(format!("no actions for {}", entry.name));
+        return;
+    }
+    state.object_action = ObjectActionInput::PickAction {
+        object_id: entry.id.clone(),
+        object_name: entry.name.clone(),
+        actions,
+        selection: 0,
+    };
 }
 
 fn handle_menu_key(
@@ -113,6 +160,44 @@ fn fire_menu_action(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
+    // Inventory-pane actions operate on the selected inventory row, not a Manny.
+    match action {
+        MenuAction::Jettison => {
+            match state.jettison_for_selected() {
+                Ok(input) => state.jettison = input,
+                Err(msg) => state.error = Some(msg),
+            }
+            return;
+        }
+        MenuAction::AtomicCraft => {
+            if !state.has_atomic_printer() {
+                state.error = Some("no atomic printer in inventory".into());
+            } else if state.atomic_printer_recipes().is_empty() {
+                state.error = Some("recipes not loaded yet — F5 to refresh".into());
+            } else {
+                state.atomic_printer_craft = AtomicPrinterCraftInput::PickRecipe { selection: 0, error: None };
+            }
+            return;
+        }
+        MenuAction::MoveStock => {
+            let mannies = state.collect_idle_onboard_mannies();
+            match mannies.len() {
+                0 => state.error = Some("no idle Manny on board".into()),
+                1 => {
+                    let (id, name) = mannies.into_iter().next().unwrap();
+                    state.storage_move = StorageMoveInput::PickKind {
+                        actor_manny_id: id,
+                        actor_manny_name: name,
+                        selection: 0,
+                    };
+                }
+                _ => state.storage_move = StorageMoveInput::PickManny { mannies, selection: 0 },
+            }
+            return;
+        }
+        _ => {}
+    }
+
     let Some(m) = state.mannies.as_ref().and_then(|v| v.get(state.mannies_selection)) else {
         return;
     };


### PR DESCRIPTION
U5 slice 3: every pane is now actionable on `Enter`, completing the contextual-action layer.

## What it adds

- **Inventory** — contextual menu (like Mannies): Jettison, Atomic craft, Move stock, each enabled/disabled with a reason.
- **Missions / Comms / Storage / Sector** — reuse their existing rich wizards rather than duplicating them:
  - Missions → opens the mission browser (browse + abandon)
  - Comms → opens the messaging inbox (fetches inbox + sent; read/reply/compose)
  - Storage → opens the storage-container browser (fetches; rename/rules/recover/detach/move)
  - Sector → opens the object-action picker for the selected object (mine/inspect/salvage/recover/deploy/turn-on-relay)
- Hints show `Enter act` on every pane that offers actions.

With slices 1–3 the cockpit is fully actionable across all nine panes.

## Not yet

- Inventory `deploy waypoint` and `drop-storage-container` remain on their classic keys only (niche, multi-branch); to be folded in later.
- Sector/Storage reuse the legacy centered overlays rather than the anchored menu popup — a cosmetic unification for later.

## Verification

- `cargo build` ✓
- `cargo test` → 175 passed (inventory-menu test added)
- `cargo clippy` → clean