### PR TITLE
feat(cockpit): surface errors, refresh spinner, drop stale hint footers

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -60,8 +60,9 @@ pub fn handle_event(
 ) {
     let Event::Key(k) = event else { return };
     if k.kind != KeyEventKind::Press { return };
-    // Toasts are transient: any keypress dismisses the current one.
+    // Toasts and inline errors are transient: any keypress dismisses them.
     state.toast = None;
+    state.error = None;
     let ctrl = k.modifiers.contains(KeyModifiers::CONTROL);
     let in_scan_input = matches!(state.scan_mode, ScanMode::Input(_));
     let in_direction_pick = matches!(state.scan_mode, ScanMode::DirectionPick);

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -97,11 +97,17 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
         ),
         Span::styled(format!("  {}", state.breadcrumb().join(" › ")), Style::default().fg(p.accent)),
     ];
-    if let Some(toast) = state.active_toast() {
+    // An error takes over the line until dismissed; otherwise a success toast.
+    if let Some(err) = &state.error {
+        left.push(Span::styled(format!("  ✗ {err}"), Style::default().fg(p.crit)));
+    } else if let Some(toast) = state.active_toast() {
         left.push(Span::styled(format!("  ✓ {toast}"), Style::default().fg(p.good)));
     }
 
     let mut meta = Vec::new();
+    if state.loading {
+        meta.push(("⟳".to_string(), p.accent));
+    }
     if !state.scut_coverage().is_empty() {
         meta.push(("≣ SCUT".to_string(), p.accent));
     }

--- a/src/ui/panels/inventory.rs
+++ b/src/ui/panels/inventory.rs
@@ -15,40 +15,9 @@ pub(crate) fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppS
     let full_inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let (inner, hint_area_opt) = if focused {
-        let split = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(1), Constraint::Length(1)])
-            .split(full_inner);
-        (split[0], Some(split[1]))
-    } else {
-        (full_inner, None)
-    };
-
-    if let Some(hint_area) = hint_area_opt {
-        let mut hint_spans = vec![
-            Span::styled("[↑↓]", Style::default().fg(Color::Cyan)),
-            Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
-            Span::raw(" detail  "),
-            Span::styled("[j]", Style::default().fg(Color::Cyan)),
-            Span::raw(" jettison"),
-        ];
-        if state.inventory_waypoint_bookmark_id().is_some() {
-            hint_spans.push(Span::raw("  "));
-            hint_spans.push(Span::styled("[d]", Style::default().fg(Color::Cyan)));
-            hint_spans.push(Span::raw(" deploy"));
-        }
-        if state.has_atomic_printer() {
-            hint_spans.push(Span::raw("  "));
-            hint_spans.push(Span::styled("[a]", Style::default().fg(Color::Cyan)));
-            hint_spans.push(Span::raw(" atomic craft"));
-        }
-        frame.render_widget(
-            Paragraph::new(Line::from(hint_spans)),
-            hint_area,
-        );
-    }
+    // Action hints come from the cockpit's shared hints line (F1); the pane
+    // uses its whole area for content.
+    let inner = full_inner;
 
     let Some(probe) = &state.probe else {
         frame.render_widget(

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -3,7 +3,7 @@ use crate::api::types::{
 };
 use crate::app::AppState;
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{List, ListItem, ListState, Paragraph},
@@ -18,99 +18,12 @@ pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppSta
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let rows = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(inner);
-    let list_area = rows[0];
-    let hint_area = rows[1];
-
-    // Hint bar
-    if focused {
-        let selected_manny = state.mannies.as_ref()
-            .and_then(|m| m.get(state.mannies_selection));
-        let can_order = selected_manny.map(|m| m.can_receive_orders).unwrap_or(false);
-        let is_busy = selected_manny.map(|m| !m.can_receive_orders && m.current_task.is_some()).unwrap_or(false);
-        if can_order {
-            let has_detachable = !state.collect_detachable_containers().is_empty();
-            let has_detached = !state.collect_detached_containers().is_empty();
-            let mut spans = vec![
-                Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
-                Span::raw(" repair  "),
-                Span::styled("[e]", Style::default().fg(Color::Cyan)),
-                Span::raw(" mine  "),
-                Span::styled("[c]", Style::default().fg(Color::Cyan)),
-                Span::raw(" craft  "),
-                Span::styled("[s]", Style::default().fg(Color::Cyan)),
-                Span::raw(" salvage  "),
-                Span::styled("[x]", Style::default().fg(Color::Cyan)),
-                Span::raw(" inspect"),
-            ];
-            if has_detachable {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled("[D]", Style::default().fg(Color::Cyan)));
-                spans.push(Span::raw(" detach"));
-            }
-            if has_detachable && state.has_atmospheric_drop_kit() {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled("[P]", Style::default().fg(Color::Cyan)));
-                spans.push(Span::raw(" drop on planet"));
-            }
-            if has_detached {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled("[v]", Style::default().fg(Color::Cyan)));
-                spans.push(Span::raw(" recover"));
-            }
-            spans.push(Span::raw("  "));
-            spans.push(Span::styled("[n]", Style::default().fg(Color::Cyan)));
-            spans.push(Span::raw(" rename"));
-            if state.deuterium_station_in_current_sector() {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled("[F]", Style::default().fg(Color::Green)));
-                spans.push(Span::raw(" refuel"));
-            }
-            if is_busy {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled("[R]", Style::default().fg(Color::Yellow)));
-                spans.push(Span::raw(" recall"));
-            }
-            frame.render_widget(Paragraph::new(Line::from(spans)), hint_area);
-        } else if is_busy {
-            let is_waiting = selected_manny
-                .map(|m| m.current_task == Some(MannyTask::WaitingForSpace))
-                .unwrap_or(false);
-            let remote = selected_manny
-                .map(|m| matches!(m.task_visibility, Some(MannyTaskVisibility::ScutNetwork)))
-                .unwrap_or(false);
-            let mut spans = vec![
-                Span::styled(if remote { "via SCUT  " } else { "busy  " }, Style::default().fg(Color::DarkGray)),
-                Span::styled("[R]", Style::default().fg(Color::Yellow)),
-                Span::raw(if remote { " abandon  " } else { " recall  " }),
-                Span::styled("[n]", Style::default().fg(Color::Cyan)),
-                Span::raw(" rename"),
-            ];
-            if is_waiting {
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled("[X]", Style::default().fg(Color::Red)));
-                spans.push(Span::raw(" drop cargo"));
-            }
-            frame.render_widget(Paragraph::new(Line::from(spans)), hint_area);
-        } else {
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("busy — cannot receive orders  ", Style::default().fg(Color::DarkGray)),
-                    Span::styled("[n]", Style::default().fg(Color::Cyan)),
-                    Span::raw(" rename"),
-                ])),
-                hint_area,
-            );
-        }
-    }
-
+    // Action hints come from the cockpit's shared hints line (F1), so the
+    // pane gives its whole area to the list.
     let Some(mannies) = &state.mannies else {
         frame.render_widget(
             Paragraph::new("No data").style(Style::default().fg(Color::DarkGray)),
-            list_area,
+            inner,
         );
         return;
     };
@@ -118,7 +31,7 @@ pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppSta
     if mannies.is_empty() {
         frame.render_widget(
             Paragraph::new("No mannies aboard").style(Style::default().fg(Color::DarkGray)),
-            list_area,
+            inner,
         );
         return;
     }
@@ -140,7 +53,7 @@ pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppSta
         list_state.select(Some(state.mannies_selection));
     }
 
-    frame.render_stateful_widget(list, list_area, &mut list_state);
+    frame.render_stateful_widget(list, inner, &mut list_state);
 }
 
 pub(crate) fn manny_list_item(m: &Manny) -> ListItem<'_> {

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -27,7 +27,7 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
 
     let Some(probe) = &state.probe else {
         frame.render_widget(
-            Paragraph::new("No data — press r to refresh")
+            Paragraph::new("No data — press F5 to refresh")
                 .style(Style::default().fg(Color::DarkGray)),
             inner,
         );

--- a/src/ui/panels/scanner.rs
+++ b/src/ui/panels/scanner.rs
@@ -1,7 +1,7 @@
 use crate::api::types::{
     DangerLevel, SectorObject, SectorObjectType, SensorMode,
 };
-use crate::app::{AppState, ScanMode};
+use crate::app::AppState;
 use chrono::Utc;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -11,7 +11,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::theme::{format_age, format_duration, freshness_color, freshness_label, gauge_color, knowledge_color, knowledge_label, make_line_gauge, map_cell_symbol, object_icon, panel_block, sensor_dot, sensor_style};
+use crate::ui::theme::{format_age, format_duration, freshness_color, freshness_label, gauge_color, knowledge_color, knowledge_label, map_cell_symbol, object_icon, panel_block, sensor_dot, sensor_style};
 // ── Scanner panel ─────────────────────────────────────────────────────────────
 
 pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused: bool) {
@@ -27,126 +27,17 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
         return;
     };
 
-    // Outer vertical split: content row + hint bar
-    let rows = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(inner);
-    let content_area = rows[0];
-    let hint_area = rows[1];
-
     let is_blind = probe.sensor_mode == SensorMode::Blind;
 
-    // Hint bar
-    match &state.scan_mode {
-        ScanMode::Input(buf) => {
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("coords (x y z): ", Style::default().fg(Color::Cyan)),
-                    Span::raw(buf.as_str()),
-                    Span::styled("█", Style::default().fg(Color::Cyan)),
-                ])),
-                hint_area,
-            );
-        }
-        ScanMode::DirectionPick => {
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("deep scan axis: ", Style::default().fg(Color::Cyan)),
-                    Span::styled("[x]", Style::default().fg(Color::Yellow)),
-                    Span::raw("  "),
-                    Span::styled("[y]", Style::default().fg(Color::Yellow)),
-                    Span::raw("  "),
-                    Span::styled("[z]", Style::default().fg(Color::Yellow)),
-                    Span::raw("  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
-                    Span::raw(" cancel"),
-                ])),
-                hint_area,
-            );
-        }
-        ScanMode::Current => {
-            if let Some(remaining) = state.scan_batch {
-                let total = state.scan_batch_total.max(1);
-                let done = total.saturating_sub(remaining);
-                let ratio = (done as f64 / total as f64).clamp(0.0, 1.0);
-                frame.render_widget(
-                    make_line_gauge(
-                        &format!("⟳ scanning {done}/{total}"),
-                        ratio,
-                        Color::Yellow,
-                    ),
-                    hint_area,
-                );
-            } else if focused {
-                let spans = if state.scanner_obj_selection.is_some() {
-                    vec![
-                        Span::styled("[↑↓/jk]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" object  "),
-                        Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-                        Span::raw(" actions  "),
-                        Span::styled("[Esc/o]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" back"),
-                    ]
-                } else if is_blind {
-                    vec![
-                        Span::styled("● SENSORS BLIND", Style::default().fg(Color::Red)),
-                        Span::raw("  "),
-                        Span::styled("[↑↓/jk]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" history  "),
-                        Span::styled("[JK]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" scroll"),
-                    ]
-                } else {
-                    let mut s = vec![
-                        Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" rescan  "),
-                        Span::styled("[c]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" custom  "),
-                        Span::styled("[n]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" neighbors  "),
-                        Span::styled("[d]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" deep  "),
-                        Span::styled("[↑↓/jk]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" history  "),
-                        Span::styled("[JK]", Style::default().fg(Color::Cyan)),
-                        Span::raw(" scroll"),
-                    ];
-                    if !state.scanner_objects().is_empty() {
-                        s.push(Span::raw("  "));
-                        s.push(Span::styled("[o]", Style::default().fg(Color::Yellow)));
-                        s.push(Span::raw(" objects"));
-                    }
-                    s.push(Span::raw("  "));
-                    s.push(Span::styled("[f]", Style::default().fg(Color::Cyan)));
-                    if state.scan_filter == crate::app::ScanFilter::All {
-                        s.push(Span::raw(" filter"));
-                    } else {
-                        s.push(Span::styled(
-                            format!(" {}", state.scan_filter.label()),
-                            Style::default().fg(Color::Yellow),
-                        ));
-                    }
-                    if state.current_sector().is_some() {
-                        s.push(Span::raw("  "));
-                        s.push(Span::styled("[g]", Style::default().fg(Color::Yellow)));
-                        s.push(Span::raw(" go"));
-                    }
-                    s
-                };
-                frame.render_widget(Paragraph::new(Line::from(spans)), hint_area);
-            }
-        }
-    }
-
-    // Horizontal split: detail on left, history list on right
+    // Action hints come from the cockpit's shared hints line (F1); the pane
+    // uses its whole area for the sector detail + history.
     let filtered = state.filtered_history_indices();
     let history_len = filtered.len();
     let history_width: u16 = if history_len > 0 { 22 } else { 0 };
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Min(1), Constraint::Length(history_width)])
-        .split(content_area);
+        .split(inner);
     let detail_area = cols[0];
     let history_area = cols[1];
 
@@ -204,7 +95,7 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
         let (msg, color) = if is_blind {
             ("● sensors blind — history available →", Color::Red)
         } else if focused {
-            ("Press [Enter] to scan current sector", Color::DarkGray)
+            ("No scan data — F5 to refresh", Color::DarkGray)
         } else {
             ("No scan data", Color::DarkGray)
         };


### PR DESCRIPTION
Polish pass — states & hints (the loading *screen* is deferred for a design discussion; this covers errors, the refresh spinner, and hint cleanup).

## What it fixes

- **Errors were invisible.** The cockpit status bar never rendered `state.error`, so a failed action (Mine with no asteroids, Craft with no recipes, an API rejection) gave *no feedback*. Now the error shows in the status bar in the `crit` colour, taking priority over the success toast, and clears on the next keypress (like toasts).
- **Refresh spinner.** A `⟳` appears in the status meta while `state.loading` (a refresh is in flight).
- **Stale hint footers removed.** The Mannies / Inventory / Scanner panels each rendered their own bottom hint line listing the *old* classic keybindings (`[e]` mine, `[c]` craft, `[Enter]` repair…) — all wrong in the cockpit. Removed; the shared `F1` hints line is the single source of truth, and the panes reclaim the line for content. Fixed `press r` placeholders to `F5`.

## Deferred (as agreed)

- **Initial loading screen** — held for a design discussion (currently a tiny "Fetching…" that flashes because `state.loading` clears on the first of 7 parallel fetches).
- Empty-state placeholders are mostly in place; a consistent pass comes with the cockpit-native panels / palette work.

## Verification

- `cargo build` ✓ (no warnings)
- `cargo test` → 164 passed
- `cargo clippy` → no new warnings (pre-existing test-only lints unchanged)