### PR TITLE
feat(cockpit): adaptive responsive grid + position mini-map

### DIFF
--- a/src/ui/cockpit_v2/grid.rs
+++ b/src/ui/cockpit_v2/grid.rs
@@ -1,34 +1,37 @@
-//! Responsive layout for the Cockpit v2 tiling grid (bloc U2).
+//! Responsive layout for the Cockpit v2 tiling grid.
 //!
-//! Chooses a layout by terminal size and returns the visible panes with
-//! their `Rect`s. U2 implements the full 3×3 and a single-pane fallback for
-//! small terminals; the intermediate 2×2 + pagination tier lands in a
-//! follow-up.
+//! Adapts to the terminal: it fits as many whole panes as the area allows
+//! (a `rows × cols` window, each dimension 1..=3 based on a minimum cell
+//! size) and slides that window so the active pane is always visible. Large
+//! terminals show the full 3×3; a half-screen shows 2×2; a short wide split
+//! shows a single row; a tiny terminal shows just the active pane.
 
 use crate::app::Pane;
 use ratatui::layout::{Constraint, Layout, Rect};
 
-/// Minimum size for the full 3×3 grid; below this we fall back to a single
-/// full-screen pane (the active one).
-const FULL_MIN_W: u16 = 96;
-const FULL_MIN_H: u16 = 27;
+/// Minimum readable cell size (double border + a few content lines). Drives
+/// how many pane columns/rows fit.
+const MIN_CELL_W: u16 = 30;
+const MIN_CELL_H: u16 = 9;
 
-/// The panes to draw this frame, each with its cell rectangle.
-///
-/// - Large terminals → all nine panes in a 3×3 grid.
-/// - Small terminals → only the active pane, full screen (navigation keys
-///   still switch which pane is shown).
+/// The panes to draw this frame, each with its cell rectangle. Always
+/// includes the active pane; navigation slides the window to keep it visible.
 pub fn visible_panes(area: Rect, active: Pane) -> Vec<(Pane, Rect)> {
-    if area.width < FULL_MIN_W || area.height < FULL_MIN_H {
-        return vec![(active, area)];
-    }
+    let cols = (area.width / MIN_CELL_W).clamp(1, 3) as usize;
+    let rows = (area.height / MIN_CELL_H).clamp(1, 3) as usize;
 
-    let rows = Layout::vertical([Constraint::Ratio(1, 3); 3]).split(area);
-    let mut out = Vec::with_capacity(9);
-    for (r, row) in rows.iter().enumerate() {
-        let cols = Layout::horizontal([Constraint::Ratio(1, 3); 3]).split(*row);
-        for (c, cell) in cols.iter().enumerate() {
-            out.push((Pane::ALL[r * 3 + c], *cell));
+    // Slide the window so the active pane sits inside it.
+    let (ar, ac) = active.grid_pos();
+    let r0 = (ar as usize).min(3 - rows);
+    let c0 = (ac as usize).min(3 - cols);
+
+    let row_rects = Layout::vertical(vec![Constraint::Ratio(1, rows as u32); rows]).split(area);
+    let mut out = Vec::with_capacity(rows * cols);
+    for (i, rr) in row_rects.iter().enumerate() {
+        let col_rects =
+            Layout::horizontal(vec![Constraint::Ratio(1, cols as u32); cols]).split(*rr);
+        for (j, cr) in col_rects.iter().enumerate() {
+            out.push((Pane::ALL[(r0 + i) * 3 + (c0 + j)], *cr));
         }
     }
     out
@@ -39,19 +42,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn large_area_shows_all_nine() {
+    fn large_area_shows_all_nine_in_order() {
         let panes = visible_panes(Rect::new(0, 0, 120, 40), Pane::Probe);
         assert_eq!(panes.len(), 9);
-        // Every pane appears exactly once, in grid order.
         for (i, (pane, _)) in panes.iter().enumerate() {
             assert_eq!(*pane, Pane::ALL[i]);
         }
     }
 
     #[test]
-    fn small_area_shows_only_active_pane() {
-        let panes = visible_panes(Rect::new(0, 0, 60, 20), Pane::Mannies);
+    fn tiny_area_shows_only_active_pane() {
+        let panes = visible_panes(Rect::new(0, 0, 20, 8), Pane::Mannies);
         assert_eq!(panes.len(), 1);
         assert_eq!(panes[0].0, Pane::Mannies);
+    }
+
+    #[test]
+    fn medium_area_shows_a_2x2_window_around_active() {
+        // 60×20 → 2 cols, 2 rows.
+        let panes = visible_panes(Rect::new(0, 0, 60, 20), Pane::Mannies);
+        assert_eq!(panes.len(), 4);
+        // The active pane must be in the window…
+        assert!(panes.iter().any(|(p, _)| *p == Pane::Mannies));
+        // …and Mannies is bottom-right, so the window is the bottom-right 2×2.
+        let set: Vec<Pane> = panes.iter().map(|(p, _)| *p).collect();
+        for expected in [Pane::Probe, Pane::Missions, Pane::Storage, Pane::Mannies] {
+            assert!(set.contains(&expected), "{expected:?} should be visible");
+        }
+    }
+
+    #[test]
+    fn short_wide_area_shows_a_single_row() {
+        // 200×10 → 3 cols, 1 row.
+        let panes = visible_panes(Rect::new(0, 0, 200, 10), Pane::Scanner);
+        assert_eq!(panes.len(), 3);
+        // Scanner is top-left → top row visible.
+        let set: Vec<Pane> = panes.iter().map(|(p, _)| *p).collect();
+        assert_eq!(set, vec![Pane::Scanner, Pane::Map, Pane::Comms]);
     }
 }

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -33,14 +33,17 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         .constraints([Constraint::Min(1), Constraint::Length(status_h)])
         .split(area);
 
-    if state.zoomed {
+    let visible: Vec<Pane> = if state.zoomed {
         render_pane(frame, rows[0], state.active_pane, state, true, p);
+        vec![state.active_pane]
     } else {
-        for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
-            render_pane(frame, rect, pane, state, pane == state.active_pane, p);
+        let panes = grid::visible_panes(rows[0], state.active_pane);
+        for (pane, rect) in &panes {
+            render_pane(frame, *rect, *pane, state, *pane == state.active_pane, p);
         }
-    }
-    render_status(frame, rows[1], state, p);
+        panes.iter().map(|(pane, _)| *pane).collect()
+    };
+    render_status(frame, rows[1], state, p, &visible);
 
     // Contextual menu popup, then any active wizard overlay on top.
     if let crate::app::InputMode::Menu(m) = &state.mode {
@@ -65,7 +68,7 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
     }
 }
 
-fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
+fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette, visible: &[Pane]) {
     let (bar, hints) = if state.hints_visible && area.height >= 2 {
         let rows = Layout::default()
             .direction(Direction::Vertical)
@@ -76,7 +79,7 @@ fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
         (area, None)
     };
 
-    render_status_line(frame, bar, state, p);
+    render_status_line(frame, bar, state, p, visible);
     if let Some(hints_area) = hints {
         let line = Line::from(Span::styled(
             format!(" {}", state.pane_hints()),
@@ -86,7 +89,7 @@ fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
     }
 }
 
-fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
+fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palette, visible: &[Pane]) {
     let tag = if state.zoomed { "ZOOM" } else { state.mode.tag() };
 
     let mut left = vec![
@@ -96,6 +99,26 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
         ),
         Span::styled(format!("  {}", state.breadcrumb().join(" › ")), Style::default().fg(p.accent)),
     ];
+    // Position mini-map: shown only when the grid is reduced (not all 9 panes
+    // visible), so you know where the active pane sits. Groups of three keys
+    // evoke the 3×3 rows on a single line.
+    if visible.len() < Pane::ALL.len() {
+        left.push(Span::styled("   ", Style::default()));
+        for (i, pane) in Pane::ALL.iter().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                left.push(Span::styled(" ", Style::default().fg(p.dim)));
+            }
+            let key = pane.key_label().to_string();
+            let style = if *pane == state.active_pane {
+                Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD)
+            } else if visible.contains(pane) {
+                Style::default().fg(p.text)
+            } else {
+                Style::default().fg(p.dim)
+            };
+            left.push(Span::styled(key, style));
+        }
+    }
     // An error takes over the line until dismissed; otherwise a success toast.
     if let Some(err) = &state.error {
         left.push(Span::styled(format!("  ✗ {err}"), Style::default().fg(p.crit)));


### PR DESCRIPTION
Polish — responsive layout. Replaces the binary "full 3×3 or single pane" with an adaptive, sliding-window grid, and adds a position mini-map.

## Behaviour

- **Adaptive fit.** From a minimum readable cell size (~30×9), fit `rows × cols` whole panes, each dimension clamped to 1..=3:
  - large terminal → **3×3**
  - half-screen → **2×2**
  - short wide split (e.g. 200×10) → **single row 1×3**
  - tiny → **1×1** (active pane)
- **Sliding window follows the active pane.** No pagination, no new keys — `ertdfgcvb`/`Tab` move the active pane and the window slides to keep it visible.
- **Position mini-map** in the status bar, shown whenever the grid is reduced (including zoom): the nine pane keys in three groups (evoking the 3×3 rows), with the **active** key highlighted, **visible** keys in text colour, and off-screen keys dimmed. Always know where you are.

## Verification

- `cargo build` ✓ (no warnings)
- `cargo test` → 166 passed (grid layout tests: 3×3, tiny→1, 2×2 window around active, short-wide→single row)
- `cargo clippy` → clean on changed files