### PR TITLE
feat(cockpit): GUPPI boot self-check (Bobiverse)

### DIFF
--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -1,0 +1,91 @@
+//! Boot sequence for the cockpit interface.
+//!
+//! On startup the grid assembles centre-out (border trace), then each pane
+//! fills from its own fetch as it returns. Driven by a short-lived animation
+//! tick that only runs while `booting` — steady state stays event-driven.
+
+use super::{AppState, Pane};
+
+/// Frames (at the ~90 ms boot tick) between each pane's border tracing in.
+const TRACE_STEP: u64 = 1;
+/// Frame by which all nine panes have traced in (~0.8 s).
+const TRACE_TOTAL: u64 = 9 * TRACE_STEP;
+/// Safety cap: end the boot even if the initial probe fetch never returns.
+const BOOT_MAX_FRAMES: u64 = 40; // ~3.6 s
+
+/// Reveal order, centre-out: Probe (centre), then the axial neighbours, then
+/// the corners.
+const REVEAL: [Pane; 9] = [
+    Pane::Probe,
+    Pane::Map,
+    Pane::Missions,
+    Pane::Storage,
+    Pane::Sector,
+    Pane::Scanner,
+    Pane::Comms,
+    Pane::Mannies,
+    Pane::Inventory,
+];
+
+/// Boot frame at which a pane's border traces in.
+fn boot_reveal_frame(pane: Pane) -> u64 {
+    REVEAL.iter().position(|p| *p == pane).unwrap_or(0) as u64 * TRACE_STEP
+}
+
+impl AppState {
+    /// Advance the boot animation one frame. Ends the boot once the trace has
+    /// played and the probe has loaded, or after the safety timeout.
+    pub fn boot_tick(&mut self) {
+        self.boot_frame = self.boot_frame.saturating_add(1);
+        let trace_done = self.boot_frame >= TRACE_TOTAL;
+        if (trace_done && self.probe.is_some()) || self.boot_frame >= BOOT_MAX_FRAMES {
+            self.booting = false;
+        }
+    }
+
+    /// Skip the boot screen (any key).
+    pub fn skip_boot(&mut self) {
+        self.booting = false;
+    }
+
+    /// Whether a pane's border has traced in yet this boot frame.
+    pub fn boot_revealed(&self, pane: Pane) -> bool {
+        self.boot_frame >= boot_reveal_frame(pane)
+    }
+
+    /// The pane tracing in on exactly this frame — the leading edge of the
+    /// sweep, drawn with the bright accent.
+    pub fn boot_leading(&self, pane: Pane) -> bool {
+        self.boot_frame == boot_reveal_frame(pane)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_reveals_first_corners_last() {
+        assert_eq!(boot_reveal_frame(Pane::Probe), 0);
+        assert!(boot_reveal_frame(Pane::Inventory) > boot_reveal_frame(Pane::Map));
+    }
+
+    #[test]
+    fn boot_waits_for_probe_after_trace() {
+        let mut s = AppState { booting: true, ..Default::default() };
+        // Play out the whole trace with no probe → still booting.
+        for _ in 0..=TRACE_TOTAL {
+            s.boot_tick();
+        }
+        assert!(s.booting, "trace done but no probe → keep waiting");
+    }
+
+    #[test]
+    fn boot_times_out_without_a_probe() {
+        let mut s = AppState { booting: true, ..Default::default() };
+        for _ in 0..BOOT_MAX_FRAMES {
+            s.boot_tick();
+        }
+        assert!(!s.booting, "safety timeout ends the boot");
+    }
+}

--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -8,10 +8,12 @@ use super::{AppState, Pane};
 
 /// Frames (at the ~90 ms boot tick) between each pane's border tracing in.
 const TRACE_STEP: u64 = 1;
-/// Frame by which all nine panes have traced in (~0.8 s).
-const TRACE_TOTAL: u64 = 9 * TRACE_STEP;
+/// Minimum boot duration — the loading bars run at least this long so the
+/// assembly is enjoyable and doesn't just flash by (~1.6 s). Must exceed the
+/// trace so the trace always completes first.
+const BOOT_MIN_FRAMES: u64 = 18;
 /// Safety cap: end the boot even if the initial probe fetch never returns.
-const BOOT_MAX_FRAMES: u64 = 40; // ~3.6 s
+const BOOT_MAX_FRAMES: u64 = 55; // ~5 s
 
 /// Reveal order, centre-out: Probe (centre), then the axial neighbours, then
 /// the corners.
@@ -37,10 +39,15 @@ impl AppState {
     /// played and the probe has loaded, or after the safety timeout.
     pub fn boot_tick(&mut self) {
         self.boot_frame = self.boot_frame.saturating_add(1);
-        let trace_done = self.boot_frame >= TRACE_TOTAL;
-        if (trace_done && self.probe.is_some()) || self.boot_frame >= BOOT_MAX_FRAMES {
+        let min_played = self.boot_frame >= BOOT_MIN_FRAMES;
+        if (min_played && self.probe.is_some()) || self.boot_frame >= BOOT_MAX_FRAMES {
             self.booting = false;
         }
+    }
+
+    /// Overall boot progress in `0.0..=1.0` (for the global loading bar).
+    pub fn boot_progress(&self) -> f64 {
+        (self.boot_frame as f64 / BOOT_MIN_FRAMES as f64).clamp(0.0, 1.0)
     }
 
     /// Skip the boot screen (any key).
@@ -71,13 +78,15 @@ mod tests {
     }
 
     #[test]
-    fn boot_waits_for_probe_after_trace() {
+    fn boot_progress_fills_over_min_duration() {
         let mut s = AppState { booting: true, ..Default::default() };
-        // Play out the whole trace with no probe → still booting.
-        for _ in 0..=TRACE_TOTAL {
+        assert_eq!(s.boot_progress(), 0.0);
+        for _ in 0..BOOT_MIN_FRAMES {
             s.boot_tick();
         }
-        assert!(s.booting, "trace done but no probe → keep waiting");
+        assert_eq!(s.boot_progress(), 1.0);
+        // No probe yet, so despite the min duration it keeps waiting.
+        assert!(s.booting);
     }
 
     #[test]

--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -15,12 +15,9 @@ pub const BOOT_CHARS_PER_FRAME: usize = 3;
 /// The probe (centre) boots first and takes its time; only after this lead do
 /// the eight subsystems come online, centre-out, at the fast cadence.
 const PROBE_LEAD: u64 = 12;
-/// Minimum boot duration. Long enough for the full self-check to play out
-/// (~frame 32) plus a ~1 s hold on the completed screen before the live
-/// content loads in. The boot never ends before this.
-const BOOT_MIN_FRAMES: u64 = 43;
-/// Safety cap: end the boot even if the initial probe fetch never returns.
-const BOOT_MAX_FRAMES: u64 = 70;
+/// Frame by which the whole self-check has typed out. Past this the boot is
+/// "complete" and waits on a keypress to continue.
+const BOOT_SEQUENCE_END: u64 = 34;
 
 /// The eight non-probe panes in centre-out order: axial neighbours, then
 /// corners.
@@ -46,24 +43,22 @@ fn boot_reveal_frame(pane: Pane) -> u64 {
 }
 
 impl AppState {
-    /// Advance the boot animation one frame. Ends the boot once the trace has
-    /// played and the probe has loaded, or after the safety timeout.
+    /// Advance the boot animation one frame. The boot never ends on its own —
+    /// it plays the self-check, then waits for a keypress (see `skip_boot`).
     pub fn boot_tick(&mut self) {
         self.boot_frame = self.boot_frame.saturating_add(1);
-        let min_played = self.boot_frame >= BOOT_MIN_FRAMES;
-        if (min_played && self.probe.is_some()) || self.boot_frame >= BOOT_MAX_FRAMES {
-            self.booting = false;
-        }
     }
 
-    /// Overall boot progress in `0.0..=1.0` (for the global loading bar).
-    pub fn boot_progress(&self) -> f64 {
-        (self.boot_frame as f64 / BOOT_MIN_FRAMES as f64).clamp(0.0, 1.0)
-    }
-
-    /// Skip the boot screen (any key).
+    /// Leave the boot screen — either skipping the animation or continuing
+    /// once it has finished. Any key triggers this.
     pub fn skip_boot(&mut self) {
         self.booting = false;
+    }
+
+    /// Whether the self-check has fully typed out (drives the "any key to
+    /// continue" prompt).
+    pub fn boot_complete(&self) -> bool {
+        self.boot_frame >= BOOT_SEQUENCE_END
     }
 
     /// Whether a pane's border has traced in yet this boot frame.
@@ -88,72 +83,72 @@ impl AppState {
         let s = |x: &str| x.to_string();
         match pane {
             Pane::Probe => vec![
-                ("CPU", s("OK")),
-                ("RAM 64K", s("OK")),
+                ("MATRIX", s("OK")),
                 ("REACTOR", s("NOMINAL")),
-                ("MIND CORE", s("LOADED")),
-                ("HULL", s("SYNC")),
-                ("FUEL LINE", s("OK")),
+                ("SURGE DRIVE", s("ONLINE")),
+                ("VR CORE", s("LOADED")),
+                ("DEUTERIUM", s("SYNC")),
+                ("GUPPI", s("READY")),
                 ("CLOCK", s("2337")),
             ],
             Pane::Scanner => vec![
-                ("SENSOR ARRAY", s("6/6")),
-                ("PHASE LOCK", s("OK")),
+                ("SUDDAR ARRAY", s("6/6")),
+                ("SUBSPACE PING", s("OK")),
                 ("RANGE", s("MAX")),
                 ("ARCHIVE", format!("{} SEC", self.scan_history.len())),
-                ("CALIBRATION", s("OK")),
+                ("RESOLUTION", s("OK")),
             ],
             Pane::Map => vec![
-                ("NAV CHART", s("LOCKED")),
-                ("STELLAR IDX", s("OK")),
+                ("STAR CHART", s("LOCKED")),
+                ("SUDDAR MAP", s("OK")),
                 ("WAYPOINTS", s("SYNC")),
-                ("VISITED", format!("{}", self.visited_sectors.len())),
+                ("SYSTEMS", format!("{}", self.visited_sectors.len())),
                 ("GRID", s("ALIGNED")),
             ],
             Pane::Comms => vec![
                 (
-                    "COMMLINK",
+                    "SCUT LINK",
                     self.api_version.map(|v| format!("v{v}")).unwrap_or_else(|| s("SYNC")),
                 ),
+                ("SUBSPACE NET", s("SCAN")),
                 ("INBOX", s("SYNC")),
-                ("RELAY NET", s("SCAN")),
-                ("ANTENNA", s("OK")),
+                ("RELAY", s("OK")),
                 ("CRYPTO", s("OK")),
             ],
             Pane::Sector => vec![
-                ("LOCAL SWEEP", s("OK")),
-                ("GRAV FIELD", s("CLEAR")),
+                ("SUDDAR SWEEP", s("OK")),
+                ("GRAV WELL", s("CLEAR")),
                 ("HAZARDS", s("NONE")),
-                ("OBJECTS", s("SCAN")),
+                ("CONTACTS", s("SCAN")),
                 ("LOCK", s("OK")),
             ],
             Pane::Missions => vec![
                 ("DIRECTIVES", s("SYNCED")),
-                ("ORDERS", s("OK")),
+                ("PROJECTS", s("OK")),
                 ("STEPS", s("OK")),
                 ("PRIORITY", s("SET")),
                 ("LOG", s("OK")),
             ],
             Pane::Inventory => vec![
-                ("MANIFEST", s("SEALED")),
+                ("AUTOFACTORY", s("IDLE")),
+                ("FEEDSTOCK", s("SYNC")),
                 ("CARGO", s("SYNC")),
-                ("PRINTER", s("IDLE")),
-                ("RESOURCES", s("OK")),
-                ("SEALS", s("OK")),
+                ("MATTER PRINTER", s("OK")),
+                ("MANIFEST", s("SEALED")),
             ],
             Pane::Storage => vec![
-                ("REGISTRY", s("INDEXED")),
+                ("HOLDS", s("INDEXED")),
                 ("BINS", s("SYNC")),
                 ("ROUTING", s("OK")),
                 ("CAPACITY", s("OK")),
-                ("LOCKS", s("OK")),
+                ("SEALS", s("OK")),
             ],
             Pane::Mannies => vec![
                 ("MANNY BAY", s("UNLOCKED")),
                 ("ROSTER", s("SYNC")),
+                ("ROAMERS", s("OK")),
                 ("INTERLOCKS", s("OK")),
                 ("POWER", s("OK")),
-                ("DIAGNOSTICS", s("OK")),
             ],
         }
     }
@@ -170,23 +165,24 @@ mod tests {
     }
 
     #[test]
-    fn boot_progress_fills_over_min_duration() {
+    fn boot_completes_after_the_sequence_then_waits() {
         let mut s = AppState { booting: true, ..Default::default() };
-        assert_eq!(s.boot_progress(), 0.0);
-        for _ in 0..BOOT_MIN_FRAMES {
+        assert!(!s.boot_complete());
+        for _ in 0..BOOT_SEQUENCE_END {
             s.boot_tick();
         }
-        assert_eq!(s.boot_progress(), 1.0);
-        // No probe yet, so despite the min duration it keeps waiting.
-        assert!(s.booting);
+        assert!(s.boot_complete());
+        // Ticking never ends the boot on its own — it waits for a key.
+        for _ in 0..50 {
+            s.boot_tick();
+        }
+        assert!(s.booting, "boot waits for a keypress");
     }
 
     #[test]
-    fn boot_times_out_without_a_probe() {
+    fn any_key_leaves_the_boot() {
         let mut s = AppState { booting: true, ..Default::default() };
-        for _ in 0..BOOT_MAX_FRAMES {
-            s.boot_tick();
-        }
-        assert!(!s.booting, "safety timeout ends the boot");
+        s.skip_boot();
+        assert!(!s.booting);
     }
 }

--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -15,9 +15,10 @@ pub const BOOT_CHARS_PER_FRAME: usize = 3;
 /// The probe (centre) boots first and takes its time; only after this lead do
 /// the eight subsystems come online, centre-out, at the fast cadence.
 const PROBE_LEAD: u64 = 12;
-/// Minimum boot duration — long enough for the full self-check to play out
-/// (~3 s at the ~90 ms tick). The boot never ends before this.
-const BOOT_MIN_FRAMES: u64 = 35;
+/// Minimum boot duration. Long enough for the full self-check to play out
+/// (~frame 32) plus a ~1 s hold on the completed screen before the live
+/// content loads in. The boot never ends before this.
+const BOOT_MIN_FRAMES: u64 = 43;
 /// Safety cap: end the boot even if the initial probe fetch never returns.
 const BOOT_MAX_FRAMES: u64 = 70;
 

--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -1,24 +1,29 @@
 //! Boot sequence for the cockpit interface.
 //!
-//! On startup the grid assembles centre-out (border trace), then each pane
-//! fills from its own fetch as it returns. Driven by a short-lived animation
-//! tick that only runs while `booting` — steady state stays event-driven.
+//! On startup the probe's core computer boots first (centre pane), then the
+//! eight subsystems come online centre-out, each running its own themed
+//! teletype self-check. Driven by a short-lived animation tick that only runs
+//! while `booting` — steady state stays event-driven.
 
 use super::{AppState, Pane};
 
-/// Frames (at the ~90 ms boot tick) between each pane's border tracing in.
-const TRACE_STEP: u64 = 1;
-/// Minimum boot duration — the loading bars run at least this long so the
-/// assembly is enjoyable and doesn't just flash by (~1.6 s). Must exceed the
-/// trace so the trace always completes first.
-const BOOT_MIN_FRAMES: u64 = 18;
-/// Safety cap: end the boot even if the initial probe fetch never returns.
-const BOOT_MAX_FRAMES: u64 = 55; // ~5 s
+/// Frames (at the ~90 ms boot tick) between each line of a pane's self-check.
+pub const BOOT_LINE_STRIDE: u64 = 2;
+/// Characters revealed per frame on the active line (teletype effect).
+pub const BOOT_CHARS_PER_FRAME: usize = 3;
 
-/// Reveal order, centre-out: Probe (centre), then the axial neighbours, then
-/// the corners.
-const REVEAL: [Pane; 9] = [
-    Pane::Probe,
+/// The probe (centre) boots first and takes its time; only after this lead do
+/// the eight subsystems come online, centre-out, at the fast cadence.
+const PROBE_LEAD: u64 = 12;
+/// Minimum boot duration — long enough for the full self-check to play out
+/// (~3 s at the ~90 ms tick). The boot never ends before this.
+const BOOT_MIN_FRAMES: u64 = 35;
+/// Safety cap: end the boot even if the initial probe fetch never returns.
+const BOOT_MAX_FRAMES: u64 = 70;
+
+/// The eight non-probe panes in centre-out order: axial neighbours, then
+/// corners.
+const OTHER_ORDER: [Pane; 8] = [
     Pane::Map,
     Pane::Missions,
     Pane::Storage,
@@ -29,9 +34,14 @@ const REVEAL: [Pane; 9] = [
     Pane::Inventory,
 ];
 
-/// Boot frame at which a pane's border traces in.
+/// Boot frame at which a pane comes online: the probe immediately, the rest
+/// after the probe's lead, staggered centre-out.
 fn boot_reveal_frame(pane: Pane) -> u64 {
-    REVEAL.iter().position(|p| *p == pane).unwrap_or(0) as u64 * TRACE_STEP
+    if pane == Pane::Probe {
+        return 0;
+    }
+    let rank = OTHER_ORDER.iter().position(|p| *p == pane).unwrap_or(0) as u64;
+    PROBE_LEAD + rank
 }
 
 impl AppState {
@@ -60,10 +70,91 @@ impl AppState {
         self.boot_frame >= boot_reveal_frame(pane)
     }
 
-    /// The pane tracing in on exactly this frame — the leading edge of the
-    /// sweep, drawn with the bright accent.
+    /// The pane coming online on exactly this frame — drawn with the bright
+    /// accent as it lights up.
     pub fn boot_leading(&self, pane: Pane) -> bool {
         self.boot_frame == boot_reveal_frame(pane)
+    }
+
+    /// Frames elapsed since a pane came online (drives its teletype).
+    pub fn boot_elapsed(&self, pane: Pane) -> u64 {
+        self.boot_frame.saturating_sub(boot_reveal_frame(pane))
+    }
+
+    /// The themed self-check lines for a pane — `(label, result)`. Real values
+    /// where we already have them, thematic placeholders otherwise.
+    pub fn boot_check_lines(&self, pane: Pane) -> Vec<(&'static str, String)> {
+        let s = |x: &str| x.to_string();
+        match pane {
+            Pane::Probe => vec![
+                ("CPU", s("OK")),
+                ("RAM 64K", s("OK")),
+                ("REACTOR", s("NOMINAL")),
+                ("MIND CORE", s("LOADED")),
+                ("HULL", s("SYNC")),
+                ("FUEL LINE", s("OK")),
+                ("CLOCK", s("2337")),
+            ],
+            Pane::Scanner => vec![
+                ("SENSOR ARRAY", s("6/6")),
+                ("PHASE LOCK", s("OK")),
+                ("RANGE", s("MAX")),
+                ("ARCHIVE", format!("{} SEC", self.scan_history.len())),
+                ("CALIBRATION", s("OK")),
+            ],
+            Pane::Map => vec![
+                ("NAV CHART", s("LOCKED")),
+                ("STELLAR IDX", s("OK")),
+                ("WAYPOINTS", s("SYNC")),
+                ("VISITED", format!("{}", self.visited_sectors.len())),
+                ("GRID", s("ALIGNED")),
+            ],
+            Pane::Comms => vec![
+                (
+                    "COMMLINK",
+                    self.api_version.map(|v| format!("v{v}")).unwrap_or_else(|| s("SYNC")),
+                ),
+                ("INBOX", s("SYNC")),
+                ("RELAY NET", s("SCAN")),
+                ("ANTENNA", s("OK")),
+                ("CRYPTO", s("OK")),
+            ],
+            Pane::Sector => vec![
+                ("LOCAL SWEEP", s("OK")),
+                ("GRAV FIELD", s("CLEAR")),
+                ("HAZARDS", s("NONE")),
+                ("OBJECTS", s("SCAN")),
+                ("LOCK", s("OK")),
+            ],
+            Pane::Missions => vec![
+                ("DIRECTIVES", s("SYNCED")),
+                ("ORDERS", s("OK")),
+                ("STEPS", s("OK")),
+                ("PRIORITY", s("SET")),
+                ("LOG", s("OK")),
+            ],
+            Pane::Inventory => vec![
+                ("MANIFEST", s("SEALED")),
+                ("CARGO", s("SYNC")),
+                ("PRINTER", s("IDLE")),
+                ("RESOURCES", s("OK")),
+                ("SEALS", s("OK")),
+            ],
+            Pane::Storage => vec![
+                ("REGISTRY", s("INDEXED")),
+                ("BINS", s("SYNC")),
+                ("ROUTING", s("OK")),
+                ("CAPACITY", s("OK")),
+                ("LOCKS", s("OK")),
+            ],
+            Pane::Mannies => vec![
+                ("MANNY BAY", s("UNLOCKED")),
+                ("ROSTER", s("SYNC")),
+                ("INTERLOCKS", s("OK")),
+                ("POWER", s("OK")),
+                ("DIAGNOSTICS", s("OK")),
+            ],
+        }
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14,6 +14,7 @@ mod waypoints;
 #[cfg(test)]
 mod tests;
 
+pub use boot::{BOOT_CHARS_PER_FRAME, BOOT_LINE_STRIDE};
 pub use color::*;
 pub use grid::*;
 pub use inputs::*;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod boot;
 mod color;
 mod containers;
 mod grid;
@@ -126,6 +127,10 @@ pub struct AppState {
     pub hints_visible: bool,
     /// Cockpit color mode (config `theme`, F2 cycles).
     pub color_mode: ColorMode,
+    /// Boot sequence: true while the grid assembles on startup (see `boot.rs`).
+    pub booting: bool,
+    /// Frame counter for the boot trace, advanced by the boot tick.
+    pub boot_frame: u64,
 }
 
 impl AppState {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -98,6 +98,12 @@ pub fn handle_event(
         return;
     }
 
+    // Any key skips the boot assembly and drops into the live cockpit.
+    if state.booting {
+        state.skip_boot();
+        return;
+    }
+
     if k.code == KeyCode::F(2) {
         // F2 cycles the cockpit color mode.
         state.color_mode = state.color_mode.cycle();

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,11 +64,16 @@ async fn run(
     let mut state = AppState {
         hints_visible: hints,
         color_mode,
+        booting: true,
         ..Default::default()
     };
     let scan_history_path = config::history_path();
     state.load_scan_history(&scan_history_path);
     let mut events = EventStream::new();
+
+    // Short-lived tick that drives the boot assembly; runs only while booting.
+    let mut boot_tick = tokio::time::interval(std::time::Duration::from_millis(90));
+    boot_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // Initial data fetch
     fetch_all(client.clone(), tx.clone());
@@ -84,6 +89,10 @@ async fn run(
         tokio::select! {
             Some(event) = events.next() => {
                 handle_event(event?, &mut state, client, &tx);
+            }
+
+            _ = boot_tick.tick(), if state.booting => {
+                state.boot_tick();
             }
 
             Some(msg) = rx.recv() => {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -15,7 +15,7 @@ use crate::app::{AppState, Pane};
 use crate::ui::panels::{
     render_inventory_panel, render_mannies_panel, render_probe_panel, render_scanner_panel,
 };
-use crate::ui::theme::{palette, Palette};
+use crate::ui::theme::{palette, pane_block, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -27,6 +27,12 @@ use ratatui::{
 pub fn render(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     let p = palette(state.color_mode);
+
+    if state.booting {
+        render_boot(frame, area, state, p);
+        return;
+    }
+
     let status_h = if state.hints_visible { 2 } else { 1 };
     let rows = Layout::default()
         .direction(Direction::Vertical)
@@ -50,6 +56,43 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         menu::render(frame, area, m, p);
     }
     crate::ui::overlays::render_active_overlays(frame, area, state);
+}
+
+/// Boot assembly: the grid traces in centre-out; revealed panes render their
+/// real content as it arrives, pending panes show a faint placeholder.
+fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+
+    for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
+        if state.boot_revealed(pane) {
+            // The pane tracing in this frame glows (leading edge of the sweep).
+            render_pane(frame, rect, pane, state, state.boot_leading(pane), p);
+        } else {
+            let title = format!(" {} ", pane.label());
+            let block = pane_block(&title, false, p);
+            let inner = block.inner(rect);
+            frame.render_widget(block, rect);
+            frame.render_widget(
+                Paragraph::new(Line::styled("· · ·", Style::default().fg(p.dim)))
+                    .alignment(Alignment::Center),
+                inner,
+            );
+        }
+    }
+
+    let spin = ["◜", "◝", "◞", "◟"][(state.boot_frame % 4) as usize];
+    let line = Line::from(vec![
+        Span::styled(
+            " BOOT ",
+            Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("  {spin} assembling cockpit…"), Style::default().fg(p.accent)),
+        Span::styled("   · any key to skip", Style::default().fg(p.dim)),
+    ]);
+    frame.render_widget(Paragraph::new(line), rows[1]);
 }
 
 fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, active: bool, p: Palette) {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -67,14 +67,20 @@ fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
         .split(area);
 
     for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
+        // Border traces in centre-out; the pane arriving this frame glows.
+        let title = format!(" {} ", pane.label());
+        let block = pane_block(&title, state.boot_leading(pane), p);
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
         if state.boot_revealed(pane) {
-            // The pane tracing in this frame glows (leading edge of the sweep).
-            render_pane(frame, rect, pane, state, state.boot_leading(pane), p);
+            // A loading bar sweeps in each revealed pane (per-pane phase so
+            // the bars are out of sync, like the retro self-check).
+            let phase = state.boot_frame + pane.index() as u64 * 2;
+            frame.render_widget(
+                Paragraph::new(loading_bar(inner.width, phase, p)),
+                center_row(inner),
+            );
         } else {
-            let title = format!(" {} ", pane.label());
-            let block = pane_block(&title, false, p);
-            let inner = block.inner(rect);
-            frame.render_widget(block, rect);
             frame.render_widget(
                 Paragraph::new(Line::styled("· · ·", Style::default().fg(p.dim)))
                     .alignment(Alignment::Center),
@@ -83,16 +89,36 @@ fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
         }
     }
 
-    let spin = ["◜", "◝", "◞", "◟"][(state.boot_frame % 4) as usize];
-    let line = Line::from(vec![
-        Span::styled(
-            " BOOT ",
-            Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(format!("  {spin} assembling cockpit…"), Style::default().fg(p.accent)),
-        Span::styled("   · any key to skip", Style::default().fg(p.dim)),
-    ]);
-    frame.render_widget(Paragraph::new(line), rows[1]);
+    // Global progress bar along the bottom.
+    let gauge = crate::ui::theme::make_line_gauge(
+        " BOOT  assembling cockpit… · any key to skip ",
+        state.boot_progress(),
+        p.accent,
+    );
+    frame.render_widget(gauge, rows[1]);
+}
+
+/// A one-row rect centred vertically inside `area` (for the pane loading bar).
+fn center_row(area: Rect) -> Rect {
+    let y = area.y + area.height / 2;
+    Rect::new(area.x, y, area.width, 1)
+}
+
+/// An indeterminate loading bar: a lit segment sweeping across a dim track.
+fn loading_bar(width: u16, phase: u64, p: Palette) -> Line<'static> {
+    let w = (width as usize).max(4);
+    let seg = (w / 3).max(2);
+    let head = (phase as usize) % w;
+    let mut spans = Vec::with_capacity(w);
+    for i in 0..w {
+        // Lit window [head, head+seg), wrapping around the track.
+        let lit = (i + w - head % w) % w < seg;
+        spans.push(Span::styled(
+            if lit { "█" } else { "░" },
+            Style::default().fg(if lit { p.accent } else { p.dim }),
+        ));
+    }
+    Line::from(spans)
 }
 
 fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, active: bool, p: Palette) {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -112,26 +112,35 @@ fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
                 lines.push(Line::from(Span::styled(partial, Style::default().fg(p.dim))));
             }
         }
+        // Once the self-check is done, invite the pilot to continue — in the
+        // centre probe pane.
+        if pane == Pane::Probe && state.boot_complete() {
+            let cur = if (state.boot_frame / 3).is_multiple_of(2) { "▌" } else { " " };
+            lines.push(Line::raw(""));
+            lines.push(Line::from(Span::styled(
+                "— WE ARE LEGION —",
+                Style::default().fg(p.dim),
+            )));
+            lines.push(Line::from(Span::styled(
+                format!("{cur} ANY KEY TO CONTINUE"),
+                Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+            )));
+        }
         frame.render_widget(Paragraph::new(lines), inner);
     }
 
-    // Bottom banner with a blinking cursor + skip hint.
-    let cur = if (state.boot_frame / 3).is_multiple_of(2) { "▌" } else { " " };
-    let cols = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(0), Constraint::Length(17)])
-        .split(rows[1]);
+    // Bottom banner — GUPPI reporting.
+    let status = if state.boot_complete() {
+        "all systems online"
+    } else {
+        "self-check…"
+    };
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            format!(" {cur} NEUMANN PROBE COMPUTER — booting…"),
+            format!(" GUPPI — {status}"),
             Style::default().fg(p.accent),
         ))),
-        cols[0],
-    );
-    frame.render_widget(
-        Paragraph::new(Line::styled("any key to skip ", Style::default().fg(p.dim)))
-            .alignment(Alignment::Right),
-        cols[1],
+        rows[1],
     );
 }
 

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -58,67 +58,81 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     crate::ui::overlays::render_active_overlays(frame, area, state);
 }
 
-/// Boot assembly: the grid traces in centre-out; revealed panes render their
-/// real content as it arrives, pending panes show a faint placeholder.
+/// Boot self-check: the probe boots first, then each subsystem pane comes
+/// online centre-out and types out its own themed check lines.
 fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
+    use crate::app::{BOOT_CHARS_PER_FRAME, BOOT_LINE_STRIDE};
+
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(area);
 
     for (pane, rect) in grid::visible_panes(rows[0], state.active_pane) {
-        // Border traces in centre-out; the pane arriving this frame glows.
+        // The pane coming online this frame glows (bright accent border).
         let title = format!(" {} ", pane.label());
         let block = pane_block(&title, state.boot_leading(pane), p);
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
-        if state.boot_revealed(pane) {
-            // A loading bar sweeps in each revealed pane (per-pane phase so
-            // the bars are out of sync, like the retro self-check).
-            let phase = state.boot_frame + pane.index() as u64 * 2;
-            frame.render_widget(
-                Paragraph::new(loading_bar(inner.width, phase, p)),
-                center_row(inner),
-            );
-        } else {
+
+        if !state.boot_revealed(pane) {
             frame.render_widget(
                 Paragraph::new(Line::styled("· · ·", Style::default().fg(p.dim)))
                     .alignment(Alignment::Center),
                 inner,
             );
+            continue;
         }
+
+        // Type out the pane's self-check lines, one after another.
+        let elapsed = state.boot_elapsed(pane);
+        let width = inner.width as usize;
+        let mut lines: Vec<Line> = Vec::new();
+        for (i, (label, result)) in state.boot_check_lines(pane).iter().enumerate() {
+            let start = i as u64 * BOOT_LINE_STRIDE;
+            if elapsed < start {
+                break;
+            }
+            let base_len = label.chars().count() + 1;
+            let pad = width
+                .saturating_sub(base_len + result.chars().count() + 1)
+                .max(1);
+            let dotted = format!("{label} {}", "·".repeat(pad));
+            let revealed = (elapsed - start) as usize * BOOT_CHARS_PER_FRAME;
+            if revealed >= dotted.chars().count() {
+                lines.push(Line::from(vec![
+                    Span::styled(dotted, Style::default().fg(p.dim)),
+                    Span::styled(
+                        format!(" {result}"),
+                        Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+                    ),
+                ]));
+            } else {
+                let partial: String = dotted.chars().take(revealed).collect();
+                lines.push(Line::from(Span::styled(partial, Style::default().fg(p.dim))));
+            }
+        }
+        frame.render_widget(Paragraph::new(lines), inner);
     }
 
-    // Global progress bar along the bottom.
-    let gauge = crate::ui::theme::make_line_gauge(
-        " BOOT  assembling cockpit… · any key to skip ",
-        state.boot_progress(),
-        p.accent,
+    // Bottom banner with a blinking cursor + skip hint.
+    let cur = if (state.boot_frame / 3) % 2 == 0 { "▌" } else { " " };
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(17)])
+        .split(rows[1]);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!(" {cur} NEUMANN PROBE COMPUTER — booting…"),
+            Style::default().fg(p.accent),
+        ))),
+        cols[0],
     );
-    frame.render_widget(gauge, rows[1]);
-}
-
-/// A one-row rect centred vertically inside `area` (for the pane loading bar).
-fn center_row(area: Rect) -> Rect {
-    let y = area.y + area.height / 2;
-    Rect::new(area.x, y, area.width, 1)
-}
-
-/// An indeterminate loading bar: a lit segment sweeping across a dim track.
-fn loading_bar(width: u16, phase: u64, p: Palette) -> Line<'static> {
-    let w = (width as usize).max(4);
-    let seg = (w / 3).max(2);
-    let head = (phase as usize) % w;
-    let mut spans = Vec::with_capacity(w);
-    for i in 0..w {
-        // Lit window [head, head+seg), wrapping around the track.
-        let lit = (i + w - head % w) % w < seg;
-        spans.push(Span::styled(
-            if lit { "█" } else { "░" },
-            Style::default().fg(if lit { p.accent } else { p.dim }),
-        ));
-    }
-    Line::from(spans)
+    frame.render_widget(
+        Paragraph::new(Line::styled("any key to skip ", Style::default().fg(p.dim)))
+            .alignment(Alignment::Right),
+        cols[1],
+    );
 }
 
 fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, active: bool, p: Palette) {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -116,7 +116,7 @@ fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
     }
 
     // Bottom banner with a blinking cursor + skip hint.
-    let cur = if (state.boot_frame / 3) % 2 == 0 { "▌" } else { " " };
+    let cur = if (state.boot_frame / 3).is_multiple_of(2) { "▌" } else { " " };
     let cols = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Min(0), Constraint::Length(17)])


### PR DESCRIPTION
The cockpit boot: a GUPPI-narrated, Bobiverse-flavoured self-check that waits for the pilot.

## Behaviour

- **Probe boots first.** The centre pane runs the replicant core self-check — `MATRIX`, `REACTOR`, `SURGE DRIVE`, `VR CORE`, `DEUTERIUM`, `GUPPI`, `CLOCK` — and takes a lead.
- **Subsystems come online centre-out**, each typing its own themed check: `SUDDAR ARRAY` (Scanner), `SCUT LINK` (Comms), `STAR CHART`/`SUDDAR MAP` (Map), `SUDDAR SWEEP` (Sector), `DIRECTIVES` (Missions), `AUTOFACTORY`/`MATTER PRINTER` (Inventory), `HOLDS` (Storage), `MANNY BAY`/`ROAMERS` (Mannies). Teletype reveal, results lit in accent.
- **Real values** where we have them: `SCUT LINK v{api}`, `ARCHIVE {n} SEC`, `SYSTEMS {visited}`.
- **Waits for the pilot.** Once the self-check finishes it holds and shows `— WE ARE LEGION —` / **`ANY KEY TO CONTINUE`** in the centre probe pane (blinking cursor). Any key drops into the live cockpit; a key during the animation skips it. GUPPI reports along the bottom (`self-check…` → `all systems online`).
- **Bounded tick** (~90 ms) runs only while booting; steady state stays event-driven.

## Implementation

- `app/boot.rs`: probe-lead reveal schedule (centre-out), `boot_check_lines` per pane (Bobiverse vernacular + real values), `boot_elapsed`/`boot_revealed`/`boot_leading`/`boot_complete`, teletype constants. No auto-end — `skip_boot` (any key) leaves.
- `main`: bounded tick guarded by `state.booting`. `input`: any key skips/continues. `cockpit_v2`: `render_boot` teletype + continue prompt.

## Verification

- `cargo build` ✓ (no warnings) · `cargo test` → 169 passed · `cargo clippy` → clean

Design references: the animated concept artifacts.