### PR TITLE
docs: refresh CLAUDE.md and README for the unified cockpit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,14 @@ The binary reads `~/.config/neumann-cockpit/config.toml` at startup:
 ```toml
 base_url = "https://neumann-probe.net"
 api_key  = "vng_..."
+theme    = "mono-green"   # color mode (optional)
+hints    = true           # show the contextual hints line (optional)
 ```
+
+- `theme` — cockpit color mode: `mono-green` (default), `mono-amber`, `phosphor-semantic` (green base + green/yellow/red status), or `modern-16` (named ANSI for terminals without truecolor). `F2` cycles it at runtime.
+- `hints` — show the contextual hints line at the bottom (`F1` toggles at runtime). Defaults `true`.
+
+Unknown keys are ignored, so legacy configs (`ui`, `phosphor`, `animations`, `theme = "retro"`) still load.
 
 Copy `config.example.toml` to that path and fill in the API key (generated once via the web UI).
 
@@ -36,15 +43,20 @@ Single `tokio::select!` loop over three sources:
 - **`mpsc::Receiver<ApiMessage>`** — results from spawned API tasks
 - **`tokio::time::sleep_until(deadline)`** — auto-refresh timer
 
-The timer deadline is set to `movement.arrival_at` (ISO 8601) converted to a `tokio::time::Instant`. When no movement is in progress the deadline is 24 h away — no polling, no tick loop.
+The timer deadline is set to `movement.arrival_at` (ISO 8601) converted to a `tokio::time::Instant`. When no movement is in progress the deadline is 24 h away — no polling.
+
+A fourth `select!` branch is a **short-lived ~90 ms boot tick**, guarded by `state.booting`: it only runs during the startup boot sequence (see UI › Boot), then stops. Steady state stays fully event-driven — no tick.
 
 `fetch_all()` spawns **seven** independent `tokio::spawn` tasks: probe, mannies, sector, visited sectors, alerts, damage warnings, and missions. All but probe are non-fatal.
 
-All other API calls (move, repair, mine, craft, storage container CRUD, storage moves, etc.) are also spawned tasks that send results back via the `mpsc::Sender<ApiMessage>`. Keyboard handlers live in `src/input/` (`mod.rs` holds `handle_event` — overlay dispatch + global key match; one module per wizard handler — `pickers.rs` groups the manny pick-list/confirm ones, `containers.rs` the storage-container ones, `storage_move.rs`, `alerts.rs`, `geometry.rs` for the scan offset helpers); fetch spawners live in `src/api/tasks.rs`. `main.rs` only contains the select loop and the `ApiMessage` dispatch (which also sets the success toasts).
+All other API calls (move, repair, mine, craft, storage container CRUD, storage moves, etc.) are also spawned tasks that send results back via the `mpsc::Sender<ApiMessage>`. Keyboard handlers live in `src/input/` (`mod.rs` holds `handle_event`, which runs the shared wizard/overlay handlers then dispatches navigation to `cockpit.rs`; one module per wizard handler — `pickers.rs` groups the manny pick-list/confirm ones, `containers.rs` the storage-container ones, `storage_move.rs`, `alerts.rs`, `geometry.rs` for the scan offset helpers); fetch spawners live in `src/api/tasks.rs`. `main.rs` only contains the select loop and the `ApiMessage` dispatch (which also sets the success toasts).
 
 ### State (`src/app/`)
 
-`AppState` is the single source of truth passed to the renderer. Split by domain: `mod.rs` (struct `Panel` + `AppState`, core impl — updates, focus, toasts, refresh deadline — and `pub use` re-exports keeping `crate::app::*` paths stable), `inputs.rs` (all wizard input enums + constants), `scan.rs`, `travel.rs`, `inventory.rs`, `mannies.rs`, `containers.rs` (storage-container/move helpers), `map.rs`, `waypoints.rs`, `message.rs` (`ApiMessage`), `tests.rs` (unit tests). Key design choices:
+`AppState` is the single source of truth passed to the renderer. Split by domain: `mod.rs` (struct `AppState`, core impl — updates, toasts, refresh deadline — and `pub use` re-exports keeping `crate::app::*` paths stable), `grid.rs` (`Pane` — the 9 cockpit panes — + `PaneNav` per-pane cursor/drill state + grid navigation helpers), `mode.rs` (`InputMode`, `ContextMenu`, `MenuAction`, `MenuItem`), `boot.rs` (startup self-check schedule), `color.rs` (`ColorMode`), `inputs.rs` (all wizard input enums + constants), `scan.rs`, `travel.rs`, `inventory.rs`, `mannies.rs`, `containers.rs` (storage-container/move helpers), `map.rs`, `waypoints.rs`, `message.rs` (`ApiMessage`), `tests.rs` (unit tests). Key design choices:
+
+- **Cockpit v2 state**: `active_pane: Pane`, `zoomed: bool`, `mode: InputMode` (`Normal` / `Menu` / `Command`), `pane_nav: [PaneNav; 9]` (cursor + drill-in stack per pane), `hints_visible`, `color_mode`, and `booting` / `boot_frame` for the startup sequence. `build_context_menu()` produces the `Enter` menu for the active pane; menu items map to `MenuAction`s that launch the existing wizards.
+- The legacy `Panel` enum + `focused` field remain, still used by the four reused panel renderers to mark the active pane; the classic single-key action handlers are gone.
 
 - Each interactive action (travel, repair, mine, craft, jettison, salvage, recall, rename, deploy, inspect, recover, detach, atomic printer craft, object actions, waypoints, alerts, storage containers + rename + routing rules, storage moves, drop cargo) has its own input state enum (`TravelInput`, `RepairInput`, `ObjectActionInput`, `AlertsInput`, `ContainersInput`, `ContainerRulesInput`, `StorageMoveInput`, etc.) with variants for each wizard step. All start as `Inactive`.
 - `update_probe()` extracts `movement_arrival` from the response and stores it separately so the event loop can compute the next deadline without re-reading the full probe struct.
@@ -52,78 +64,64 @@ All other API calls (move, repair, mine, craft, storage container CRUD, storage 
 - Panel cursors: `mannies_selection`, `inventory_selection` (rows built by `inventory_rows()` — stocks, active items, passive groups), `scan_history_idx` (moves within `filtered_history_indices()` when a `ScanFilter` is active), `scanner_obj_selection` (object-browsing mode, entries from `scanner_objects()`).
 - `jettison_for_selected()` builds the jettison wizard from the selected inventory row; `actions_for_object()` maps a `ScannerObjectEntry` to its available `ObjectAction`s, mirroring the manny-first candidate sets (`collect_*_candidates`).
 - Transient success toasts: `set_toast()` / `active_toast()` (5 s expiry, dismissed by any keypress).
-- `RESOURCE_TYPES`, `MOVE_RESOURCE_TYPES`, and `DETACH_MODES` constants live here (not in `main.rs` or `cockpit.rs`).
+- `RESOURCE_TYPES`, `MOVE_RESOURCE_TYPES`, and `DETACH_MODES` constants live here (not in `main.rs` or the UI).
 
 ### API layer (`src/api/`)
 
 - `types.rs` — all OpenAPI types. Structs use `#[serde(rename_all = "camelCase")]`; enums use `#[serde(rename_all = "snake_case")]` with `#[serde(other)] Unknown` fallbacks. `#![allow(dead_code)]` suppresses warnings on fields not yet consumed by the UI.
 - `client.rs` — `ApiClient` (cloneable, wraps `reqwest::Client`). Each endpoint has a typed wrapper with an inline `struct Resp` that deserializes the envelope and returns the inner value. HTTP errors extract `error.message` from the JSON body; 401 produces a specific "check your api_key" message.
 
-### Retro theme (`src/ui/retro/`)
+### Theme & colours (`src/ui/theme.rs`)
 
-Optional phosphor-CRT skin (Alien-style), selected with `theme = "retro"` in config or toggled at runtime with `F2`. Entirely self-contained: `ui::render` dispatches on `AppState::ui_theme` between `cockpit::render` (classic, default) and `retro::render`. Components: `palette.rs` (4-intensity monochrome, green or amber via `phosphor`), `banner.rs`, `systems.rs` (block gauges + probe schematic LEDs), `radar.rs` (sweeping dial, blips for `scanner_objects()`), `drones.rs`, `ticker.rs` (COMMS + pseudo-telemetry), `boot.rs` (teletype boot sequence, any key skips).
-
-Animations are driven by a 100 ms render tick in the main `select!`, guarded by `anim_tick_active()` — it only advances `AnimState::frame` and redraws, **never** triggers API calls; with the classic theme or `animations = false` the branch is disabled and behaviour is exactly the pre-existing event-driven one. All animations are pure functions of the frame counter (`app/anim.rs`, `anim_hash` for deterministic noise). Wizard overlays are shared between themes via `overlays::render_active_overlays`.
+One unified phosphor theme (there is no classic/retro split any more). `theme.rs` holds the shared helpers: `Palette` + `palette(ColorMode)` (accent / dim / text / good / warn / crit per color mode), `pane_block(title, active, palette)` — the double-line (`BorderType::Double`) pane frame used by every pane, coloured accent when active and dim-accent otherwise — plus icons, labels, gauges (`make_line_gauge`, `gauge_color`), and `format_duration` / `format_age`. Color modes: `mono-green` (default), `mono-amber`, `phosphor-semantic`, `modern-16`; `F2` cycles them.
 
 ### UI (`src/ui/`)
 
-`cockpit::render(frame, state)` is the single render entry point called every loop iteration. Module layout: `cockpit.rs` (entry point, 4-panel layout, status bar), `panels/` (one file per panel, each with its height helper), `overlays/` (one file per wizard overlay; `pickers.rs` groups the manny pick-list/confirm ones, `containers.rs` the storage-container ones, plus `alerts.rs` / `storage_move.rs`; `mod.rs` hosts `centered_rect` + `render_pick_list`), `theme.rs` (colours, icons, labels, `format_duration`/`format_age`). Layout — two rows, each split into two columns:
+`ui::render` → `cockpit_v2::render(frame, state)` is the single render entry point. Module layout: `cockpit_v2/` (`mod.rs` entry point — grid layout, status bar, boot screen; `grid.rs` responsive window; `panes.rs` compact renderers for the five promoted panes; `menu.rs` contextual-menu popup), `panels/` (the four original panel renderers, reused by the grid: `probe`, `inventory`, `scanner`, `mannies`), `overlays/` (one file per wizard overlay; `pickers.rs` groups the manny pick-list/confirm ones, `containers.rs` the storage-container ones, plus `alerts.rs` / `storage_move.rs`; `mod.rs` hosts `centered_rect` + `render_pick_list`), `theme.rs`.
+
+**The grid** — a 3×3 tiling dashboard of nine panes, each addressable by a key in the `e r t / d f g / c v b` square (identical on AZERTY and QWERTY; centre `f` = Probe). Model: *navigate then act*.
 
 ```
-┌─ NEUMANN COCKPIT ─────────────────────────────────────────────┐
-│  ┌─ PROBE ─────────────────┐  ┌─ INVENTORY ─────────────────┐ │
-│  │ name · status · sector  │  │ capacity gauge              │ │
-│  │ movement phase + ETA    │  │ resource stocks (cursor)    │ │
-│  │ progress gauge          │  │ items list (expandable)     │ │
-│  │ speed gauge             │  │ containers + tanks gauges   │ │
-│  │ fuel gauge              │  │ [↑↓] select [Enter] detail  │ │
-│  │ integrity gauge         │  │ [j] jettison [d] deploy     │ │
-│  │ [!] alert badge         │  │ [a] atomic [C] containers   │ │
-│  └─────────────────────────┘  │ [M] move stock              │ │
-│                               └─────────────────────────────┘ │
-│  ┌─ SCANNER ───────────────┐  ┌─ MANNIES ───────────────────┐ │
-│  │ sector detail │ history │  │ ● manny-1  idle             │ │
-│  │ [↑↓/jk] history [JK]    │  │ ◌ manny-2  mining   42%     │ │
-│  │ [Enter] rescan [c] coord│  │ [Enter] repair [e] mine     │ │
-│  │ [n] neighbors [d] deep  │  │ [c] craft  [s] salvage      │ │
-│  │ [f] filter  [o] objects │  │ [x] inspect [D] detach      │ │
-│  │ [g] go to sector        │  │ [v] recover [n] rename      │ │
-│  └─────────────────────────┘  │ [R] recall [X] drop cargo   │ │
-│                               └─────────────────────────────┘ │
-│ [r] refresh [p][i][m][s]/Tab focus [t] travel [b] map         │
-│ [w] waypoints [A] alerts [?] help [q] quit  v23.x  API v63    │
-└───────────────────────────────────────────────────────────────┘
+┌═ SCANNER ═════┐┌═ MAP ═════════┐┌═ COMMS ═══════┐
+│ scan history  ││ sector coords ││ alerts / msgs │
+│ + distances   ││ ≣ SCUT        ││ unread count  │
+└═══════════════┘└═══════════════┘└═══════════════┘
+┌═ SECTOR ══════┐┌═ PROBE ═══════┐┌═ MISSIONS ════┐
+│ objects here  ││ status · fuel ││ active list   │
+│ (drill → obj) ││ integrity · ETA││ (drill → steps)│
+└═══════════════┘└═══════════════┘└═══════════════┘
+┌═ INVENTORY ═══┐┌═ STORAGE ═════┐┌═ MANNIES ═════┐
+│ cargo · stocks││ containers    ││ ● manny list  │
+│ items         ││ + capacity    ││ task + %      │
+└═══════════════┘└═══════════════┘└═══════════════┘
+ NAV  COCKPIT › MANNIES        ⟳ · ≣ SCUT · ! 2 · API v63 · 14:09
+ ↑↓ move · hl drill · z zoom · Enter act · ertdfgcvb pane · F1 hints
 ```
 
-Top row height is dynamic: `max(probe_panel_height, inventory_panel_height)`. The focused panel gets a white border; others are dimmed.
+**Keys** — `e r t d f g c v b` activate a pane · `j`/`k` (`↑`/`↓`) move the cursor · `l`/`→` drill in, `h`/`←` drill out (Missions → steps, Comms → message) · `Enter` opens the contextual action menu · `z` zooms the active pane full-screen · `Tab`/`Shift+Tab` cycle panes · `:` command mode (planned) · `F1` toggle hints · `F2` cycle color mode · `F5` refresh · `?` help · `q` quit · `Esc` closes menu / leaves zoom / drills up.
 
-Gauge colors: green > 50 %, yellow 25–50 %, red < 25 %. Probe status and sensor mode are colour-coded.
+**Contextual menu** (`Enter`) — built per active pane + selection (`build_context_menu` → `Vec<MenuItem>`, disabled items shown with a reason). Firing an item launches the existing wizard (`MenuAction` → the matching `*Input`). Panes with rich wizards (Missions, Comms, Storage, Sector objects) reuse their legacy overlays instead of the popup.
 
-Movement progress is derived from `started_at` / `arrival_at` timestamps client-side (more accurate than the API's `secondsRemaining` snapshot).
+**Responsive** — `grid::visible_panes` fits `rows × cols` whole panes (each 1..=3 from a minimum cell size) and slides the window to keep the active pane visible: 3×3 on a large terminal, 2×2 on a half-screen, a single row on a short wide split, one pane when tiny. A position mini-map in the status bar (the nine keys in three groups) shows where the active pane sits whenever the grid is reduced.
 
-Scanner specifics: the history column shows symbol + coords + distance, scrolls with the selection (`List`/`ListState`), and `[f]` cycles a filter (all → objects → minable → danger). `[o]` enters object-browsing mode on the probe's current sector: `Enter` on an object opens a contextual action menu (mine / inspect / salvage / recover / deploy waypoint) that reuses the existing wizards.
+**Status bar** — `[MODE]` tag (NAV / MENU / CMD, or ZOOM) · breadcrumb (`COCKPIT › PANE › …`) · transient error (crit) or success toast · right-aligned meta (`⟳` while loading, `≣ SCUT`, unread `! n`, `API vN`, clock). A second **hints line** (toggle `F1`) shows the keys valid for the active pane.
 
-**Overlays** (rendered on top of the 4-panel layout):
-- Travel (`[t]`) — coordinate input (absolute, or relative with a leading `+`) with live parity check, fuel cost preview + confirmation
-- Repair / Mine / Craft / Atomic printer craft — manny/target/recipe pickers. The Mine wizard's `[c]` cycles an optional detached target container in the current sector (`targetContainerId`; default = probe).
-- Jettison / Salvage / Recall / Rename / Inspect / Recover / Detach — inventory/sector object pickers
-- Deploy waypoint — 3-step wizard: pick manny → pick object → enter bookmark name
-- Object actions — action picker for the selected scanner object (+ manny picker when several idle). An inactive `scut_relay` object offers **turn on relay** (pick manny → optional network name → `turn-on-relay`; needs a star in the sector + an integrated_circuit) and salvage.
-- Jettison a `scut_relay` inventory item (Inventory `[j]` on the SCUT-relay group) — confirmation; deploys an inactive relay into the current sector
-- Alerts (`[A]`) — tabbed Alerts / Damage-warnings list, `Tab` switches tab, `Enter` marks read; `[!]` badge on the probe panel + status bar when unread
-- Missions (`[O]`) — active-mission list with steps and status; `[a]` abandons the selected active mission (confirmation sub-popup)
-- Messaging (`[Y]`) — tabbed inbox / sent list (`Tab` switches), `Enter` marks an inbox message read, `[c]` composes: pick a recipient (probes detected in the sector + inhabited planets) → type the body → send. Inbox/sent are loaded on open (not in `fetch_all`); a `•` on `[Y]` in the status bar signals unread. `EndpointId` is an untagged int|string (probe id | planet object id).
-- SCUT network (`[N]`) — inspect a network covering the current sector (`scutNetworks` in the sector scan): relays (status, position, coverage) and probes. When several networks cover the sector, a picker precedes the detail view. A `≣ SCUT` badge on the probe panel + a lit `[N]` in the status bar signal active coverage.
-- Remote mannies via SCUT — `Manny.taskVisibility` (`local` / `scut_network` / `too_far`) drives display: a Manny in a different sector reachable via a shared SCUT network shows `≣ via SCUT` and its `[R]` action is labelled **abandon** (the recall cancels the task and leaves it forgotten, it does not return); out-of-range tasks render as `too far` (`unknown_too_far`).
-- Remote mine (`[e]` on an idle SCUT-reachable Manny — API v60) — fetches the Manny's sector, then a wizard: pick asteroid → resources/amount → **pick detached container** (mandatory; the dropped mining stays in the Manny's sector). Drives the same `mine` endpoint with `targetContainerId`. `RemoteMineInput` advances to asteroid selection when the awaited sector scan arrives.
-- Storage containers (`[C]` in Inventory) — container browser with capacity bars; `Enter` content view, `[n]` rename, `[e]` routing-rules editor (cycle each type none → priority → exclusion → strict)
-- Storage move (`[M]` in Inventory) — pick actor manny → kind (resource / item) → source/destination + amount, or multi-select items + destination
-- Drop cargo (`[X]` on a Manny waiting for space) — one-step confirmation (resource cargo is lost)
-- Mind-snapshot reassign (`Ctrl+R`, only when the probe is dead or trapped by a black hole — `probe.alert` present) — confirmation; reassigns the mind snapshot to a fresh probe and resets the local frame to 0,0,0
-- Waypoints (`[w]`) — known destinations from scan history (bookmarks, stars, minable), `Enter` → travel confirmation
-- Inventory detail (`Enter` in inventory) — read-only detail of the selected row
-- Map (`[b]`) — isometric sector overview: pan (`[hjkl/←↓↑→]`), `[u/d]` y±1, `[0]` recenter on probe, `[c]` jump to coords, `[g]` travel to center; info line (distance, ETA, sector summary) + legend; visited-but-unscanned sectors shown as `○`
-- Help (`[?]`) — all keybindings grouped by context
+**Boot** (`src/app/boot.rs` + `cockpit_v2::render_boot`) — on startup the probe core boots first (centre pane self-check), then the eight subsystems come online centre-out, each typing a themed teletype self-check (SUDDAR array, SCUT link, autofactory, manny bay…). Once done it holds on `ANY KEY TO CONTINUE` in the centre pane; any key drops into the live cockpit (or skips the animation). Driven by the bounded boot tick.
+
+The four reused panels (Probe / Inventory / Scanner / Mannies) keep their internal content colours; gauge colors: green > 50 %, yellow 25–50 %, red < 25 %. Movement progress is derived from `started_at` / `arrival_at` client-side. Scanner history shows symbol + coords + distance and scrolls with the selection.
+
+**Overlays** (wizards, rendered on top of the grid; launched from the contextual menu or the reused panels):
+- **Mannies pane menu** (`Enter`) — Repair, Mine, Craft, Salvage, Inspect, Recover/Detach container, Refill deuterium, Drop cargo, Recall/Abandon, Rename. Each launches its wizard (`*Input`). Remote mine (SCUT-reachable manny) fetches the manny's sector first, then picks asteroid → resources/amount → mandatory detached container. Recall on a SCUT-remote manny is labelled **abandon**.
+- **Inventory pane menu** (`Enter`) — Jettison, Atomic printer craft, Move stock.
+- **Missions pane** (`Enter`) — active-mission list with steps/status; abandon (confirmation).
+- **Comms pane** (`Enter`) — messaging inbox/sent (mark read, compose to a probe/planet recipient); alerts + damage-warnings live in the same pane.
+- **Storage pane** (`Enter`) — container browser with capacity bars; content view, rename, routing-rules editor (none → priority → exclusion → strict).
+- **Sector pane** (`Enter` on an object) — object-action picker (mine / inspect / salvage / recover / deploy waypoint); an inactive `scut_relay` offers **turn on relay** (needs a star + integrated_circuit) and salvage.
+- **Travel** wizard — coordinate input (absolute, or relative with a leading `+`), live parity check, fuel/ETA preview + confirmation.
+- **Mind-snapshot reassign** — only when the probe is dead or trapped by a black hole (`probe.alert`); reassigns the snapshot to a fresh probe.
+- Shared bits: `EndpointId` is an untagged int|string (probe id | planet object id). `Manny.taskVisibility` (`local` / `scut_network` / `too_far`) drives remote display (`≣ via SCUT` / `too far`).
+
+**Not yet wired into the cockpit** (wizards that exist but have no launcher in the new interface — follow-ups): Travel, the full isometric Map overlay (the Map pane is a compact summary), Waypoints, SCUT-network inspect, mind-snapshot reassign, deploy-waypoint from Inventory, and drop-storage-container. Command mode (`:`) will cover several of these.
 
 ## Implemented API endpoints (API v63)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ cp config.example.toml ~/.config/neumann-cockpit/config.toml
 ```toml
 base_url = "https://neumann-probe.net"
 api_key  = "vng_your_api_key_here"
+# theme = "mono-green"   # color mode: mono-green | mono-amber | phosphor-semantic | modern-16
+# hints = true           # show the contextual hints line
 ```
 
 **3. Run**
@@ -42,14 +44,27 @@ api_key  = "vng_your_api_key_here"
 neumann-cockpit
 ```
 
+## Interface
+
+A single **phosphor cockpit**: a 3×3 tiling dashboard of nine panes, keyboard-first, *navigate then act*.
+
+- **Navigate** — `e r t / d f g / c v b` (a square on the keyboard) jump to a pane; `j`/`k` (or `↑`/`↓`) move the cursor; `l`/`h` drill in/out.
+- **Act** — `Enter` opens the pane's contextual action menu.
+- **Zoom** — `z` blows the active pane up to full screen.
+- **Adapts** — the grid shrinks to 2×2 or a single pane on smaller terminals, following the active pane; a mini-map shows where you are.
+- **`F1`** toggle hints · **`F2`** cycle color mode · **`F5`** refresh · **`?`** help · **`q`** quit.
+
+Startup plays a GUPPI self-check that assembles the cockpit centre-out; any key continues.
+
 ## Features
 
 - **Probe** — status, fuel, integrity, movement ETA and speed gauges
 - **Inventory** — cargo stocks, onboard items; jettison resources or eject mannies; deploy waypoint bookmarks
 - **Mannies** — per-manny status and progress; repair, mine, craft, salvage, recall, rename
-- **Scanner** — scan current sector or arbitrary coordinates, neighbor sweep, deep scan; browsable history
-- **Sector map** — isometric overview of scanned sectors, pan and travel from the map
-- **Auto-travel** — fuel and ETA preview before committing a jump
+- **Scanner / Sector** — scan the current sector or arbitrary coordinates, neighbor sweep, deep scan; browsable history
+- **Comms** — inter-probe messaging (inbox / sent / compose), alerts and damage warnings
+- **Missions & Storage** — track directives; browse storage containers with capacity and routing rules
+- **Colour modes** — mono-green, mono-amber, phosphor-semantic, or a 16-colour fallback
 
 ## Auto-refresh
 


### PR DESCRIPTION
Bring the docs in line with the unified cockpit (they still described the classic 4-panel layout + retro theme).

## CLAUDE.md

- **Config** — `theme` is now a color mode (`mono-green` / `mono-amber` / `phosphor-semantic` / `modern-16`), `hints` toggle; legacy keys (`ui`, `phosphor`, `animations`, `theme = "retro"`) noted as ignored.
- **Event loop** — the bounded boot tick.
- **State** — Cockpit v2 fields (`active_pane`, `zoomed`, `mode`, `pane_nav`, `color_mode`, `booting`/`boot_frame`), new modules (`grid`, `mode`, `boot`, `color`); `Panel`/`focused` noted as legacy.
- **Theme** — one phosphor theme; `Palette` + double-border `pane_block`.
- **UI** — replaced the 4-panel diagram with the 3×3 grid; new keymap (`ertdfgcvb`/`jk`/`hl`/`z`/`Enter`/`F1`/`F2`/`F5`), contextual menus, responsive window + mini-map, status bar, GUPPI boot. Overlays list rewritten to how theyre launched now, plus an honest **"not yet wired into the cockpit"** list (Travel, full Map, Waypoints, SCUT-network inspect, mind-snapshot, deploy, drop-storage-container).
- Dropped the Retro-theme section. Endpoints table unchanged.

## README

Config example gains `theme`/`hints`; new **Interface** section (navigate-then-act, keymap, adaptive grid, GUPPI boot); Features list trimmed to what the cockpit currently exposes.

No code changes.