### PR TITLE
feat(cockpit): probe & mannies pane rework

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -261,11 +261,15 @@ impl super::AppState {
         if !drilled && matches!(pane, Pane::Missions | Pane::Comms) {
             parts.push("l open");
         }
-        // Panes that expose actions on Enter (menu or reused overlay).
-        if matches!(
-            pane,
-            Pane::Mannies | Pane::Inventory | Pane::Missions | Pane::Comms | Pane::Storage | Pane::Sector
-        ) {
+        // Panes that expose actions on Enter (menu or reused overlay). Probe
+        // only acts when a recovery alert is present.
+        let probe_recovery = pane == Pane::Probe && self.probe_terminal_alert().is_some();
+        if probe_recovery
+            || matches!(
+                pane,
+                Pane::Mannies | Pane::Inventory | Pane::Missions | Pane::Comms | Pane::Storage | Pane::Sector
+            )
+        {
             parts.push("Enter act");
         }
         parts.push("z zoom");

--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -178,7 +178,9 @@ impl super::AppState {
         match self.active_pane {
             Pane::Inventory => self.inventory_next(),
             Pane::Scanner => self.scan_hist_next(),
-            Pane::Mannies => self.manny_next(),
+            // Frozen while viewing a single manny's detail (drilled in).
+            Pane::Mannies if self.pane_nav[Pane::Mannies.index()].drill.is_empty() => self.manny_next(),
+            Pane::Mannies => {}
             Pane::Probe | Pane::Map => {}
             pane => {
                 let n = self.pane_item_count(pane);
@@ -195,7 +197,8 @@ impl super::AppState {
         match self.active_pane {
             Pane::Inventory => self.inventory_prev(),
             Pane::Scanner => self.scan_hist_prev(),
-            Pane::Mannies => self.manny_prev(),
+            Pane::Mannies if self.pane_nav[Pane::Mannies.index()].drill.is_empty() => self.manny_prev(),
+            Pane::Mannies => {}
             Pane::Probe | Pane::Map => {}
             pane => {
                 let nav = &mut self.pane_nav[pane.index()];
@@ -226,6 +229,12 @@ impl super::AppState {
                 .messages
                 .get(cursor)
                 .map(|m| DrillLevel::MessageThread(m.id.to_string())),
+            // Mannies uses its own selection cursor, not `pane_nav.cursor`.
+            Pane::Mannies => self
+                .mannies
+                .as_ref()
+                .and_then(|v| v.get(self.mannies_selection))
+                .map(|m| DrillLevel::Manny(m.id.clone())),
             _ => None,
         };
         if let Some(level) = level {
@@ -295,7 +304,11 @@ impl super::AppState {
                     .map_or_else(|| format!("msg {id}"), |m| m.sender.name.clone()),
                 DrillLevel::Container(id) => id.clone(),
                 DrillLevel::ItemGroup(g) => g.clone(),
-                DrillLevel::Manny(m) => m.clone(),
+                DrillLevel::Manny(id) => self
+                    .mannies
+                    .as_ref()
+                    .and_then(|v| v.iter().find(|m| &m.id == id))
+                    .map_or_else(|| "manny".to_string(), |m| m.name.clone()),
                 DrillLevel::SectorObject(i) => format!("object {i}"),
             });
         }

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -27,6 +27,8 @@ pub enum MenuAction {
     MoveStock,
     // Probe pane
     MindSnapshot,
+    // Mannies pane (extra)
+    DropStorageContainer,
 }
 
 /// A single entry in a contextual action menu.
@@ -171,6 +173,27 @@ impl super::AppState {
             orders(MenuAction::Inspect, "Inspect…"),
             orders(MenuAction::Recover, "Recover container…"),
             orders(MenuAction::Detach, "Detach container…"),
+            {
+                let has_kit = self.has_atmospheric_drop_kit();
+                let has_container = !self.collect_detachable_containers().is_empty();
+                let has_planet = !self.collect_planet_candidates().is_empty();
+                MenuItem {
+                    action: MenuAction::DropStorageContainer,
+                    label: "Drop container on planet…".into(),
+                    enabled: can && has_kit && has_container && has_planet,
+                    disabled_reason: if !can {
+                        Some("busy".to_string())
+                    } else if !has_kit {
+                        Some("no drop-kit".to_string())
+                    } else if !has_container {
+                        Some("no container".to_string())
+                    } else if !has_planet {
+                        Some("no planet".to_string())
+                    } else {
+                        None
+                    },
+                }
+            },
             MenuItem {
                 action: MenuAction::Refuel,
                 label: "Refill deuterium".into(),

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -25,6 +25,8 @@ pub enum MenuAction {
     Jettison,
     AtomicCraft,
     MoveStock,
+    // Probe pane
+    MindSnapshot,
 }
 
 /// A single entry in a contextual action menu.
@@ -88,8 +90,24 @@ impl super::AppState {
         match self.active_pane {
             super::Pane::Mannies => self.mannies_context_menu(),
             super::Pane::Inventory => Some(self.inventory_context_menu()),
+            super::Pane::Probe => self.probe_context_menu(),
             _ => None,
         }
+    }
+
+    fn probe_context_menu(&self) -> Option<ContextMenu> {
+        // The only probe action is recovery, and only for a dead/trapped probe.
+        self.probe_terminal_alert()?;
+        Some(ContextMenu {
+            title: "PROBE".into(),
+            items: vec![MenuItem {
+                action: MenuAction::MindSnapshot,
+                label: "Reassign mind snapshot".into(),
+                enabled: true,
+                disabled_reason: None,
+            }],
+            cursor: 0,
+        })
     }
 
     fn inventory_context_menu(&self) -> ContextMenu {

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -17,9 +17,9 @@ use crate::api::tasks::{
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainersInput, CraftInput, DetachInput,
-    DropCargoInput, InputMode, InspectInput, MenuAction, MessagesInput, MineInput, MissionsInput,
-    ObjectActionInput, Pane, RecallInput, RecoverInput, RefuelInput, RemoteMineInput,
-    RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput,
+    DropCargoInput, InputMode, InspectInput, MenuAction, MessagesInput, MindSnapshotInput,
+    MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput, RefuelInput,
+    RemoteMineInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput,
 };
 
 pub fn handle_cockpit_event(
@@ -72,7 +72,7 @@ pub fn handle_cockpit_event(
 /// the contextual menu; panes backed by a rich wizard reuse its overlay.
 fn open_actions(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     match state.active_pane {
-        Pane::Mannies | Pane::Inventory => match state.build_context_menu() {
+        Pane::Mannies | Pane::Inventory | Pane::Probe => match state.build_context_menu() {
             Some(menu) if !menu.items.is_empty() => state.mode = InputMode::Menu(menu),
             _ => state.set_toast("no actions here"),
         },
@@ -193,6 +193,12 @@ fn fire_menu_action(
                     };
                 }
                 _ => state.storage_move = StorageMoveInput::PickManny { mannies, selection: 0 },
+            }
+            return;
+        }
+        MenuAction::MindSnapshot => {
+            if state.probe_terminal_alert().is_some() {
+                state.mind_snapshot = MindSnapshotInput::Confirm { error: None };
             }
             return;
         }

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -17,9 +17,9 @@ use crate::api::tasks::{
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, ContainersInput, CraftInput, DetachInput,
-    DropCargoInput, InputMode, InspectInput, MenuAction, MessagesInput, MindSnapshotInput,
-    MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput, RefuelInput,
-    RemoteMineInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput,
+    DropCargoInput, DropStorageContainerInput, InputMode, InspectInput, MenuAction, MessagesInput,
+    MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
+    RefuelInput, RemoteMineInput, RenameMannyInput, RepairInput, SalvageInput, StorageMoveInput,
 };
 
 pub fn handle_cockpit_event(
@@ -303,6 +303,37 @@ fn fire_menu_action(
                     state.detach = DetachInput::PickMode { manny_id: id, manny_name: name, container_id, container_name, selection: 0, error: None };
                 }
                 _ => state.detach = DetachInput::PickContainer { manny_id: id, manny_name: name, containers, selection: 0 },
+            }
+        }
+        MenuAction::DropStorageContainer if can => {
+            let containers = state.collect_detachable_containers();
+            if containers.is_empty() {
+                state.error = Some("no detachable containers in inventory".into());
+            } else if !state.has_atmospheric_drop_kit() {
+                state.error = Some("no atmospheric_drop_kit in inventory".into());
+            } else {
+                let planets = state.collect_planet_candidates();
+                if planets.is_empty() {
+                    state.error = Some("no planet in current sector — scan first".into());
+                } else if containers.len() == 1 {
+                    let (container_id, container_name) = containers.into_iter().next().unwrap();
+                    state.drop_container = DropStorageContainerInput::PickPlanet {
+                        manny_id: id,
+                        manny_name: name,
+                        container_id,
+                        container_name,
+                        planets,
+                        selection: 0,
+                        error: None,
+                    };
+                } else {
+                    state.drop_container = DropStorageContainerInput::PickContainer {
+                        manny_id: id,
+                        manny_name: name,
+                        containers,
+                        selection: 0,
+                    };
+                }
             }
         }
         MenuAction::Refuel if can => {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -11,7 +11,7 @@ mod grid;
 mod menu;
 mod panes;
 
-use crate::app::{AppState, Pane};
+use crate::app::{AppState, DrillLevel, Pane};
 use crate::ui::panels::{
     render_inventory_panel, render_mannies_panel, render_probe_panel, render_scanner_panel,
 };
@@ -150,7 +150,13 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
         Pane::Probe => render_probe_panel(frame, area, state, active),
         Pane::Inventory => render_inventory_panel(frame, area, state, active),
         Pane::Scanner => render_scanner_panel(frame, area, state, active),
-        Pane::Mannies => render_mannies_panel(frame, area, state, active),
+        Pane::Mannies => {
+            if let Some(DrillLevel::Manny(id)) = state.pane_nav[Pane::Mannies.index()].drill.last() {
+                panes::render_manny_detail(frame, area, state, id, active, p);
+            } else {
+                render_mannies_panel(frame, area, state, active);
+            }
+        }
         // Promoted panes are palette-aware.
         Pane::Map => panes::render_map(frame, area, state, active, p),
         Pane::Comms => panes::render_comms(frame, area, state, active, p),

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -6,9 +6,10 @@
 //! swaps a pane to its detail view (Missions → steps, Comms → message).
 //! Colours come from the active [`Palette`].
 
-use crate::api::types::{MissionStatus, MissionStepStatus};
+use crate::api::types::{MannyTaskVisibility, MissionStatus, MissionStepStatus};
 use crate::app::{AppState, DrillLevel, Pane};
-use crate::ui::theme::{object_icon, pane_block, Palette};
+use crate::ui::panels::mannies::{manny_task_eta, manny_task_label};
+use crate::ui::theme::{block_gauge_line, object_icon, pane_block, Palette};
 use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
@@ -237,4 +238,54 @@ pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: b
         }
     }
     render_body(frame, area, " STORAGE ", active, p, lines);
+}
+
+/// Detail view for a single manny (drill-in `l` on the Mannies pane): task,
+/// progress, time remaining, cargo breakdown, and location.
+pub fn render_manny_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool, p: Palette) {
+    let block = pane_block(" MANNY ", active, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
+
+    let Some(m) = state.mannies.as_ref().and_then(|v| v.iter().find(|m| m.id == id)) else {
+        frame.render_widget(Paragraph::new(Line::styled("manny gone", dim)), inner);
+        return;
+    };
+
+    let mut lines = vec![Line::styled(m.name.clone(), text.add_modifier(Modifier::BOLD))];
+    let task = m.current_task.as_ref();
+    if task.is_some() {
+        lines.push(Line::from(vec![
+            Span::styled(manny_task_label(task), Style::default().fg(p.accent)),
+            Span::styled(format!("  {:.0}%", m.task_progress_percent), text),
+        ]));
+        if let Some(eta) = manny_task_eta(m) {
+            lines.push(Line::from(vec![Span::styled("ETA ", dim), Span::styled(eta, text)]));
+        }
+    } else {
+        lines.push(Line::styled("idle", dim));
+    }
+    match state.manny_sector_coords(m) {
+        Some((x, y, z)) => lines.push(Line::from(vec![
+            Span::styled("sector ", dim),
+            Span::styled(format!("({x}, {y}, {z})"), text),
+        ])),
+        None => lines.push(Line::styled("on probe", dim)),
+    }
+    if matches!(m.task_visibility, Some(MannyTaskVisibility::ScutNetwork)) {
+        lines.push(Line::styled("≣ via SCUT", Style::default().fg(p.accent)));
+    }
+
+    // Cargo — what it is carrying (proxy for what it is mining/hauling).
+    lines.push(Line::raw(""));
+    let c = &m.cargo;
+    let used = c.metals + c.ice + c.deuterium + c.organic_compounds;
+    let ratio = if c.capacity > 0.0 { used / c.capacity } else { 0.0 };
+    lines.push(block_gauge_line("CARGO", ratio, &format!("{used:.1}/{:.1}", c.capacity), p.accent, p));
+    lines.push(Line::styled(format!("metals {:.1}  ice {:.1}", c.metals, c.ice), text));
+    lines.push(Line::styled(format!("deut {:.1}  org {:.1}", c.deuterium, c.organic_compounds), text));
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 }

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -10,7 +10,8 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::theme::{palette, pane_block};
+use crate::ui::theme::{format_duration, palette, pane_block};
+use chrono::Utc;
 // ── Mannies panel ─────────────────────────────────────────────────────────────
 
 pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppState, focused: bool) {
@@ -56,43 +57,78 @@ pub(crate) fn render_mannies_panel(frame: &mut Frame, area: Rect, state: &AppSta
     frame.render_stateful_widget(list, inner, &mut list_state);
 }
 
+/// Short label for a Manny task (shared by the list and the detail view).
+pub(crate) fn manny_task_label(task: Option<&MannyTask>) -> &'static str {
+    match task {
+        None => "idle",
+        Some(MannyTask::Repair) => "repair",
+        Some(MannyTask::Mining) => "mining",
+        Some(MannyTask::Crafting) => "crafting",
+        Some(MannyTask::AssistingAtomicPrinter) => "assisting printer",
+        Some(MannyTask::Salvage) => "salvage",
+        Some(MannyTask::InstallingWaypointBookmark) => "installing waypoint",
+        Some(MannyTask::DetachingStorageContainer) => "detaching container",
+        Some(MannyTask::InspectingAsteroid) => "inspecting",
+        Some(MannyTask::Returning) => "returning",
+        Some(MannyTask::WaitingForSpace) => "waiting for space",
+        Some(MannyTask::MovingStockage) => "moving cargo",
+        Some(MannyTask::DroppingStorageContainer) => "dropping container",
+        Some(MannyTask::RefillingDeuteriumTank) => "refueling",
+        Some(MannyTask::TurningOnScutRelay) => "activating relay",
+        Some(MannyTask::UnknownTooFar) => "too far",
+        Some(MannyTask::Unknown) => "?",
+    }
+}
+
+fn manny_task_color(task: Option<&MannyTask>) -> Color {
+    match task {
+        None => Color::DarkGray,
+        Some(MannyTask::Repair | MannyTask::Crafting | MannyTask::AssistingAtomicPrinter) => Color::Cyan,
+        Some(
+            MannyTask::Mining
+            | MannyTask::Salvage
+            | MannyTask::InspectingAsteroid
+            | MannyTask::DetachingStorageContainer
+            | MannyTask::DroppingStorageContainer,
+        ) => Color::Yellow,
+        Some(MannyTask::InstallingWaypointBookmark | MannyTask::RefillingDeuteriumTank) => Color::Green,
+        Some(MannyTask::Returning | MannyTask::MovingStockage) => Color::Blue,
+        Some(MannyTask::WaitingForSpace) => Color::Magenta,
+        Some(MannyTask::TurningOnScutRelay) => Color::LightBlue,
+        Some(MannyTask::UnknownTooFar | MannyTask::Unknown) => Color::DarkGray,
+    }
+}
+
+/// Time remaining on the current task, as a compact duration (if known).
+pub(crate) fn manny_task_eta(m: &Manny) -> Option<String> {
+    m.task_estimated_end_time
+        .map(|end| format_duration((end - Utc::now()).num_seconds().max(0)))
+}
+
 pub(crate) fn manny_list_item(m: &Manny) -> ListItem<'_> {
     let loc_icon = match m.location.location_type {
         MannyLocationType::Probe => Span::styled("●", Style::default().fg(Color::Green)),
         MannyLocationType::Sector => Span::styled("◌", Style::default().fg(Color::Yellow)),
         MannyLocationType::Unknown => Span::styled("?", Style::default().fg(Color::DarkGray)),
     };
-
-    let task_text = match &m.current_task {
-        None => Span::styled("idle", Style::default().fg(Color::DarkGray)),
-        Some(MannyTask::Repair) => Span::styled("repair", Style::default().fg(Color::Cyan)),
-        Some(MannyTask::Mining) => Span::styled("mining", Style::default().fg(Color::Yellow)),
-        Some(MannyTask::Crafting) => Span::styled("crafting", Style::default().fg(Color::Cyan)),
-        Some(MannyTask::AssistingAtomicPrinter) => Span::styled("assisting printer", Style::default().fg(Color::Cyan)),
-        Some(MannyTask::Salvage) => Span::styled("salvage", Style::default().fg(Color::Yellow)),
-        Some(MannyTask::InstallingWaypointBookmark) => Span::styled("installing waypoint", Style::default().fg(Color::Green)),
-        Some(MannyTask::DetachingStorageContainer) => Span::styled("detaching container", Style::default().fg(Color::Yellow)),
-        Some(MannyTask::InspectingAsteroid) => Span::styled("inspecting", Style::default().fg(Color::Yellow)),
-        Some(MannyTask::Returning) => Span::styled("returning", Style::default().fg(Color::Blue)),
-        Some(MannyTask::WaitingForSpace) => Span::styled("waiting", Style::default().fg(Color::Magenta)),
-        Some(MannyTask::MovingStockage) => Span::styled("moving cargo", Style::default().fg(Color::Blue)),
-        Some(MannyTask::DroppingStorageContainer) => Span::styled("dropping container", Style::default().fg(Color::Yellow)),
-        Some(MannyTask::RefillingDeuteriumTank) => Span::styled("refueling", Style::default().fg(Color::Green)),
-        Some(MannyTask::TurningOnScutRelay) => Span::styled("activating relay", Style::default().fg(Color::LightBlue)),
-        Some(MannyTask::UnknownTooFar) => Span::styled("too far", Style::default().fg(Color::DarkGray)),
-        Some(MannyTask::Unknown) => Span::styled("?", Style::default().fg(Color::DarkGray)),
-    };
+    let task = m.current_task.as_ref();
+    let task_text = Span::styled(manny_task_label(task), Style::default().fg(manny_task_color(task)));
 
     let progress = if m.current_task.is_some() {
         format!(" {:3.0}%", m.task_progress_percent)
     } else {
         String::new()
     };
+    // Time remaining next to the progress, when the task has an ETA.
+    let eta = manny_task_eta(m)
+        .filter(|_| m.current_task.is_some())
+        .map(|d| format!(" · {d}"))
+        .unwrap_or_default();
 
-    let name = format!("{:<14}", m.name);
+    let name = format!("{:<12}", m.name);
 
     let via_scut = if matches!(m.task_visibility, Some(MannyTaskVisibility::ScutNetwork)) {
-        Span::styled(" ≣ via SCUT", Style::default().fg(Color::LightBlue))
+        Span::styled(" ≣", Style::default().fg(Color::LightBlue))
     } else {
         Span::raw("")
     };
@@ -103,6 +139,7 @@ pub(crate) fn manny_list_item(m: &Manny) -> ListItem<'_> {
         Span::raw(name),
         task_text,
         Span::styled(progress, Style::default().fg(Color::DarkGray)),
+        Span::styled(eta, Style::default().fg(Color::DarkGray)),
         via_scut,
     ]))
 }

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -3,32 +3,28 @@ use crate::app::AppState;
 use chrono::Utc;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
 
-use crate::ui::theme::{format_duration, gauge_color, make_line_gauge, movement_phase_label, palette, pane_block, probe_status_label, probe_status_style};
+use crate::ui::theme::{
+    block_gauge_line, format_duration, movement_phase_label, palette, pane_block, probe_status_label,
+    probe_status_style, ratio_color,
+};
 // ── Probe panel ───────────────────────────────────────────────────────────────
 
 pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState, focused: bool) {
-    let block = pane_block(" PROBE ", focused, palette(state.color_mode));
+    let p = palette(state.color_mode);
+    let block = pane_block(" PROBE ", focused, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    if state.loading && state.probe.is_none() {
-        frame.render_widget(
-            Paragraph::new("Fetching…").style(Style::default().fg(Color::DarkGray)),
-            inner,
-        );
-        return;
-    }
-
     let Some(probe) = &state.probe else {
+        let msg = if state.loading { "fetching…" } else { "no data — F5 to refresh" };
         frame.render_widget(
-            Paragraph::new("No data — press F5 to refresh")
-                .style(Style::default().fg(Color::DarkGray)),
+            Paragraph::new(msg).style(Style::default().fg(p.dim)),
             inner,
         );
         return;
@@ -44,21 +40,16 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     let show_sector = active_movement.is_none()
         && probe.sector.as_ref().and_then(|s| s.relative.as_ref()).is_some();
 
-    let mut sections: Vec<Constraint> = vec![
-        Constraint::Length(1), // name + status
-    ];
+    let mut sections: Vec<Constraint> = vec![Constraint::Length(1)]; // header
     if show_sector {
-        sections.push(Constraint::Length(1)); // current sector coords
+        sections.push(Constraint::Length(1));
     }
     if active_movement.is_some() {
-        sections.push(Constraint::Length(1)); // coords + distance
-        sections.push(Constraint::Length(1)); // phase + ETA
-        sections.push(Constraint::Length(1)); // progress gauge
-        sections.push(Constraint::Length(1)); // speed gauge
+        sections.extend([Constraint::Length(1); 4]); // route, phase+eta, burn, speed
     }
-    sections.push(Constraint::Length(1)); // fuel gauge
+    sections.push(Constraint::Length(1)); // fuel
     if probe.systems.is_some() {
-        sections.push(Constraint::Length(1)); // integrity gauge
+        sections.push(Constraint::Length(1)); // integrity
     }
     sections.push(Constraint::Min(0)); // padding
 
@@ -66,38 +57,29 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
         .direction(Direction::Vertical)
         .constraints(sections)
         .split(inner);
-
     let mut row = 0;
 
-    // ── Header ──
-    let spinner = if state.loading { " ⟳" } else { "" };
-    let unread = state.unread_alert_count();
-    let alert_badge = if unread > 0 {
-        Span::styled(
-            format!(" [!{unread}]"),
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD | Modifier::RAPID_BLINK),
-        )
-    } else {
-        Span::raw("")
-    };
+    // ── Header: name · status · badges ──
     let mut status_spans = vec![
-        Span::styled(&probe.name, Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(&probe.name, Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
         Span::raw("  "),
         Span::styled(probe_status_label(&probe.status), probe_status_style(&probe.status)),
-        alert_badge,
-        Span::styled(spinner, Style::default().fg(Color::DarkGray)),
     ];
+    let unread = state.unread_alert_count();
+    if unread > 0 {
+        status_spans.push(Span::styled(
+            format!(" [!{unread}]"),
+            Style::default().fg(p.crit).add_modifier(Modifier::BOLD),
+        ));
+    }
     if state.probe_terminal_alert().is_some() {
         status_spans.push(Span::styled(
-            "  [^R reassign]",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            "  ⚠ RECOVER",
+            Style::default().fg(p.crit).add_modifier(Modifier::BOLD),
         ));
     }
     if !state.scut_coverage().is_empty() {
-        status_spans.push(Span::styled(
-            "  ≣ SCUT",
-            Style::default().fg(Color::LightBlue),
-        ));
+        status_spans.push(Span::styled("  ≣ SCUT", Style::default().fg(p.accent)));
     }
     frame.render_widget(Paragraph::new(Line::from(status_spans)), rows[row]);
     row += 1;
@@ -107,10 +89,10 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
         if let Some(rel) = probe.sector.as_ref().and_then(|s| s.relative.as_ref()) {
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("@ ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("@ ", Style::default().fg(p.dim)),
                     Span::styled(
                         format!("({},{},{})", rel.x as i64, rel.y as i64, rel.z as i64),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(p.text),
                     ),
                 ])),
                 rows[row],
@@ -129,13 +111,16 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
 
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
-                Span::raw(format!(
-                    "({},{},{}) → ({},{},{})  d:{}",
-                    mv.origin.x as i64, mv.origin.y as i64, mv.origin.z as i64,
-                    mv.target.x as i64, mv.target.y as i64, mv.target.z as i64,
-                    mv.distance,
-                )),
+                Span::styled("▶ ", Style::default().fg(p.warn)),
+                Span::styled(
+                    format!(
+                        "({},{},{}) → ({},{},{})  d:{}",
+                        mv.origin.x as i64, mv.origin.y as i64, mv.origin.z as i64,
+                        mv.target.x as i64, mv.target.y as i64, mv.target.z as i64,
+                        mv.distance,
+                    ),
+                    Style::default().fg(p.text),
+                ),
             ])),
             rows[row],
         );
@@ -143,42 +128,31 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
 
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(phase_label, Style::default().fg(Color::Yellow)),
-                Span::raw(format!("  ETA: {}", format_duration(remaining))),
+                Span::styled(format!("  {phase_label}"), Style::default().fg(p.warn)),
+                Span::styled(format!("  ETA {}", format_duration(remaining)), Style::default().fg(p.dim)),
             ])),
             rows[row],
         );
         row += 1;
 
         frame.render_widget(
-            make_line_gauge(&format!("{:<12}{:.0}%", "Travel", progress * 100.0), progress, Color::Yellow),
+            block_gauge_line("BURN", progress, &format!("{:.0}%", progress * 100.0), p.accent, p),
             rows[row],
         );
         row += 1;
 
         let velocity = mv.estimated_velocity_c.unwrap_or(0.0).clamp(0.0, 1.0);
         frame.render_widget(
-            make_line_gauge(
-                &format!("{:<12}{:.2}c", "Speed", velocity),
-                velocity,
-                Color::Yellow,
-            ),
+            block_gauge_line("SPEED", velocity, &format!("{velocity:.2}c"), p.accent, p),
             rows[row],
         );
         row += 1;
     }
 
     // ── Fuel ──
-    let fuel_ratio = probe.fuel.deuterium
-        .map(|d| (d / 100.0).clamp(0.0, 1.0))
-        .unwrap_or(0.0);
+    let fuel = probe.fuel.deuterium.map(|d| (d / 100.0).clamp(0.0, 1.0)).unwrap_or(0.0);
     frame.render_widget(
-        make_line_gauge(
-            &format!("{:<12}{:.1}%", "Fuel", fuel_ratio * 100.0),
-            fuel_ratio,
-            gauge_color(fuel_ratio),
-        ),
+        block_gauge_line("FUEL", fuel, &format!("{:.0}%", fuel * 100.0), ratio_color(fuel, p), p),
         rows[row],
     );
     row += 1;
@@ -187,11 +161,7 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     if let Some(sys) = &probe.systems {
         let integrity = (sys.integrity_percent.unwrap_or(100.0) / 100.0).clamp(0.0, 1.0);
         frame.render_widget(
-            make_line_gauge(
-                &format!("{:<12}{:.1}%", "Integrity", integrity * 100.0),
-                integrity,
-                gauge_color(integrity),
-            ),
+            block_gauge_line("INTEG", integrity, &format!("{:.0}%", integrity * 100.0), ratio_color(integrity, p), p),
             rows[row],
         );
         row += 1;
@@ -199,4 +169,3 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
 
     let _ = row;
 }
-

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -241,6 +241,32 @@ pub(crate) fn movement_phase_label(p: &MovementPhase) -> &'static str {
     }
 }
 
+/// Palette colour for a "how full" ratio: good > 50 %, warn 25–50 %, crit below.
+pub(crate) fn ratio_color(ratio: f64, p: Palette) -> Color {
+    if ratio > 0.5 {
+        p.good
+    } else if ratio > 0.25 {
+        p.warn
+    } else {
+        p.crit
+    }
+}
+
+/// Retro block gauge: `LABEL ▓▓▓▓▓▓░░░░  62%` — filled cells in `fill`, empty
+/// cells dim, value on the right. Static (no animation); the phosphor-CRT
+/// "squares" look.
+pub(crate) fn block_gauge_line(label: &str, ratio: f64, value: &str, fill: Color, p: Palette) -> Line<'static> {
+    const WIDTH: usize = 10;
+    let ratio = ratio.clamp(0.0, 1.0);
+    let filled = (ratio * WIDTH as f64).round() as usize;
+    Line::from(vec![
+        Span::styled(format!("{label:<9} "), Style::default().fg(p.dim)),
+        Span::styled("▓".repeat(filled), Style::default().fg(fill)),
+        Span::styled("░".repeat(WIDTH - filled), Style::default().fg(p.dim)),
+        Span::styled(format!(" {value:>5}"), Style::default().fg(p.text)),
+    ])
+}
+
 pub(crate) fn make_line_gauge(label: &str, ratio: f64, color: Color) -> LineGauge<'_> {
     LineGauge::default()
         .label(Line::raw(label.to_owned()))


### PR DESCRIPTION
Per-pane re-study: the **Probe** and **Mannies** panes reworked, with their gaps closed. (Two panes in one PR — Mannies reuses the `block_gauge_line` helper the Probe rework adds.)

## Probe

- Retro **block gauges** (`▓`/`░` + `%`, or `Nc` for speed): FUEL / INTEG coloured by ratio, BURN / SPEED in accent while travelling. Palette-coloured header; `⚠ RECOVER` badge replaces the dead `^R` hint.
- **Gap closed:** `Enter` opens recovery (**mind-snapshot reassign**) when the probe is dead/trapped — previously unreachable in the cockpit.
- New reusable helpers `theme::block_gauge_line` + `ratio_color`.

## Mannies

- **More info:** each row shows **time remaining** next to task + progress. Drill in (`l`) on a manny → **detail view**: task + %, **ETA**, **cargo breakdown** (metals / ice / deut / organic with a fill gauge), and **location / sector** (`≣ via SCUT` when remote).
- *What it mines / where the output goes* aren’t in the Manny API payload (only accumulated cargo + location), so cargo stands in for "what it’s hauling".
- **Gap closed:** **Drop container on planet** added to the Mannies menu (enabled with a drop-kit + detachable container + a planet in sector).
- Shared `manny_task_label` helper.

## Probe name

API-provided, set server-side at creation; no rename endpoint (`/api/probe` is GET-only) — not changeable from the cockpit.

## Verification

- `cargo build` ✓ (no warnings) · `cargo test` → 169 passed · `cargo clippy` → clean