### PR TITLE
feat(cockpit): mannies zoom list + mining target detail

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -193,6 +193,12 @@ pub struct Manny {
     pub cargo: MannyCargo,
     pub can_receive_orders: bool,
     pub task_estimated_end_time: Option<DateTime<Utc>>,
+    /// Current-task payload. For a mining task it carries the target asteroid,
+    /// resource types, and destination container (else the probe). Kept as a
+    /// raw value: the API's `anyOf` may also be an empty object/array, and
+    /// remote/too-far mannies expose an empty payload.
+    #[serde(default)]
+    pub task: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -153,6 +153,9 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
         Pane::Mannies => {
             if let Some(DrillLevel::Manny(id)) = state.pane_nav[Pane::Mannies.index()].drill.last() {
                 panes::render_manny_detail(frame, area, state, id, active, p);
+            } else if state.zoomed {
+                // Zoom shows the whole fleet at a glance, one detail card each.
+                panes::render_mannies_overview(frame, area, state, p);
             } else {
                 render_mannies_panel(frame, area, state, active);
             }

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -6,12 +6,12 @@
 //! swaps a pane to its detail view (Missions → steps, Comms → message).
 //! Colours come from the active [`Palette`].
 
-use crate::api::types::{MannyTaskVisibility, MissionStatus, MissionStepStatus};
+use crate::api::types::{Manny, MannyTaskVisibility, MissionStatus, MissionStepStatus};
 use crate::app::{AppState, DrillLevel, Pane};
 use crate::ui::panels::mannies::{manny_task_eta, manny_task_label};
 use crate::ui::theme::{block_gauge_line, object_icon, pane_block, Palette};
 use ratatui::{
-    layout::Rect,
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Paragraph, Wrap},
@@ -242,19 +242,14 @@ pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: b
 
 /// Detail view for a single manny (drill-in `l` on the Mannies pane): task,
 /// progress, time remaining, cargo breakdown, and location.
-pub fn render_manny_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool, p: Palette) {
-    let block = pane_block(" MANNY ", active, p);
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+/// The detail lines for one manny (task/%, ETA, location, cargo), shared by
+/// the drill-in detail and the zoom overview cards. The name lives in the
+/// block title, not here.
+fn manny_detail_lines(state: &AppState, m: &Manny, p: Palette) -> Vec<Line<'static>> {
     let dim = Style::default().fg(p.dim);
     let text = Style::default().fg(p.text);
+    let mut lines = Vec::new();
 
-    let Some(m) = state.mannies.as_ref().and_then(|v| v.iter().find(|m| m.id == id)) else {
-        frame.render_widget(Paragraph::new(Line::styled("manny gone", dim)), inner);
-        return;
-    };
-
-    let mut lines = vec![Line::styled(m.name.clone(), text.add_modifier(Modifier::BOLD))];
     let task = m.current_task.as_ref();
     if task.is_some() {
         lines.push(Line::from(vec![
@@ -286,6 +281,64 @@ pub fn render_manny_detail(frame: &mut Frame, area: Rect, state: &AppState, id: 
     lines.push(block_gauge_line("CARGO", ratio, &format!("{used:.1}/{:.1}", c.capacity), p.accent, p));
     lines.push(Line::styled(format!("metals {:.1}  ice {:.1}", c.metals, c.ice), text));
     lines.push(Line::styled(format!("deut {:.1}  org {:.1}", c.deuterium, c.organic_compounds), text));
+    lines
+}
 
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+pub fn render_manny_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool, p: Palette) {
+    let Some(m) = state.mannies.as_ref().and_then(|v| v.iter().find(|m| m.id == id)) else {
+        let block = pane_block(" MANNY ", active, p);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        frame.render_widget(Paragraph::new(Line::styled("manny gone", Style::default().fg(p.dim))), inner);
+        return;
+    };
+    let title = format!(" {} ", m.name);
+    let block = pane_block(&title, active, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(manny_detail_lines(state, m, p)).wrap(Wrap { trim: false }), inner);
+}
+
+/// One manny as a bordered card (used in the zoom overview). The selected
+/// manny's card gets the accent border.
+fn render_manny_card(frame: &mut Frame, area: Rect, state: &AppState, m: &Manny, selected: bool, p: Palette) {
+    let title = format!(" {} ", m.name);
+    let block = pane_block(&title, selected, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(manny_detail_lines(state, m, p)), inner);
+}
+
+/// Zoomed Mannies pane: every manny as a detail card, in a grid, so the whole
+/// fleet is visible at a glance.
+pub fn render_mannies_overview(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
+    let dim = Style::default().fg(p.dim);
+    let Some(mannies) = &state.mannies else {
+        frame.render_widget(Paragraph::new(Line::styled("no data", dim)), area);
+        return;
+    };
+    if mannies.is_empty() {
+        frame.render_widget(Paragraph::new(Line::styled("no mannies aboard", dim)), area);
+        return;
+    }
+
+    let n = mannies.len();
+    let cols = ((area.width as usize / 26).max(1)).min(n).min(3);
+    let rows_n = n.div_ceil(cols);
+    let row_rects = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(vec![Constraint::Ratio(1, rows_n as u32); rows_n])
+        .split(area);
+    for (r, row_rect) in row_rects.iter().enumerate() {
+        let col_rects = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Ratio(1, cols as u32); cols])
+            .split(*row_rect);
+        for (c, cell) in col_rects.iter().enumerate() {
+            let idx = r * cols + c;
+            if let Some(m) = mannies.get(idx) {
+                render_manny_card(frame, *cell, state, m, idx == state.mannies_selection, p);
+            }
+        }
+    }
 }

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -292,9 +292,9 @@ fn manny_detail_lines(state: &AppState, m: &Manny, p: Palette) -> Vec<Line<'stat
     let c = &m.cargo;
     let used = c.metals + c.ice + c.deuterium + c.organic_compounds;
     let ratio = if c.capacity > 0.0 { used / c.capacity } else { 0.0 };
-    lines.push(block_gauge_line("CARGO", ratio, &format!("{used:.1}/{:.1}", c.capacity), p.accent, p));
-    lines.push(Line::styled(format!("metals {:.1}  ice {:.1}", c.metals, c.ice), text));
-    lines.push(Line::styled(format!("deut {:.1}  org {:.1}", c.deuterium, c.organic_compounds), text));
+    lines.push(block_gauge_line("CARGO", ratio, &format!("{:.0}%", ratio * 100.0), p.accent, p));
+    lines.push(Line::styled(format!("metals {:.2}  ice {:.2}", c.metals, c.ice), text));
+    lines.push(Line::styled(format!("deut {:.2}  org {:.2}", c.deuterium, c.organic_compounds), text));
     lines
 }
 
@@ -376,10 +376,10 @@ pub fn render_mannies_overview(frame: &mut Frame, area: Rect, state: &AppState, 
         let c = &m.cargo;
         let used = c.metals + c.ice + c.deuterium + c.organic_compounds;
         let ratio = if c.capacity > 0.0 { used / c.capacity } else { 0.0 };
-        lines.push(block_gauge_line("    CARGO", ratio, &format!("{used:.0}/{:.0}", c.capacity), p.accent, p));
+        lines.push(block_gauge_line("    CARGO", ratio, &format!("{:.0}%", ratio * 100.0), p.accent, p));
         lines.push(Line::styled(
             format!(
-                "    metals {:.0} · ice {:.0} · deut {:.0} · org {:.0}",
+                "    metals {:.2} · ice {:.2} · deut {:.2} · org {:.2}",
                 c.metals, c.ice, c.deuterium, c.organic_compounds
             ),
             dim,

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -8,7 +8,7 @@
 
 use crate::api::types::{Manny, MannyLocationType, MannyTaskVisibility, MissionStatus, MissionStepStatus};
 use crate::app::{AppState, DrillLevel, Pane};
-use crate::ui::panels::mannies::{manny_task_eta, manny_task_label};
+use crate::ui::panels::mannies::{manny_mining_detail, manny_task_eta, manny_task_label};
 use crate::ui::theme::{block_gauge_line, object_icon, pane_block, Palette};
 use ratatui::{
     layout::Rect,
@@ -262,6 +262,20 @@ fn manny_detail_lines(state: &AppState, m: &Manny, p: Palette) -> Vec<Line<'stat
     } else {
         lines.push(Line::styled("idle", dim));
     }
+    // Mining target: which asteroid, resources, and where the output goes.
+    if let Some(d) = manny_mining_detail(m) {
+        lines.push(Line::from(vec![
+            Span::styled("⛏ ", Style::default().fg(p.accent)),
+            Span::styled(d.target, text),
+        ]));
+        if let Some(r) = d.resources {
+            lines.push(Line::styled(format!("  {r}"), dim));
+        }
+        lines.push(Line::from(vec![
+            Span::styled("→ ", dim),
+            Span::styled(d.destination, text),
+        ]));
+    }
     match state.manny_sector_coords(m) {
         Some((x, y, z)) => lines.push(Line::from(vec![
             Span::styled("sector ", dim),
@@ -347,6 +361,16 @@ pub fn render_mannies_overview(frame: &mut Frame, area: Rect, state: &AppState, 
             }
         }
         lines.push(Line::from(header));
+
+        // Mining target, when visible: asteroid · resources → destination.
+        if let Some(d) = manny_mining_detail(m) {
+            let mut s = format!("    ⛏ {}", d.target);
+            if let Some(r) = &d.resources {
+                s.push_str(&format!(" · {r}"));
+            }
+            s.push_str(&format!(" → {}", d.destination));
+            lines.push(Line::styled(s, dim));
+        }
 
         // Indented detail: cargo gauge, cargo breakdown, location.
         let c = &m.cargo;

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -6,12 +6,12 @@
 //! swaps a pane to its detail view (Missions → steps, Comms → message).
 //! Colours come from the active [`Palette`].
 
-use crate::api::types::{Manny, MannyTaskVisibility, MissionStatus, MissionStepStatus};
+use crate::api::types::{Manny, MannyLocationType, MannyTaskVisibility, MissionStatus, MissionStepStatus};
 use crate::app::{AppState, DrillLevel, Pane};
 use crate::ui::panels::mannies::{manny_task_eta, manny_task_label};
 use crate::ui::theme::{block_gauge_line, object_icon, pane_block, Palette};
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Paragraph, Wrap},
@@ -299,46 +299,77 @@ pub fn render_manny_detail(frame: &mut Frame, area: Rect, state: &AppState, id: 
     frame.render_widget(Paragraph::new(manny_detail_lines(state, m, p)).wrap(Wrap { trim: false }), inner);
 }
 
-/// One manny as a bordered card (used in the zoom overview). The selected
-/// manny's card gets the accent border.
-fn render_manny_card(frame: &mut Frame, area: Rect, state: &AppState, m: &Manny, selected: bool, p: Palette) {
-    let title = format!(" {} ", m.name);
-    let block = pane_block(&title, selected, p);
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-    frame.render_widget(Paragraph::new(manny_detail_lines(state, m, p)), inner);
-}
-
-/// Zoomed Mannies pane: every manny as a detail card, in a grid, so the whole
-/// fleet is visible at a glance.
+/// Zoomed Mannies pane: a vertical list where each manny is a summary line
+/// with its details indented below — the whole fleet at a glance.
 pub fn render_mannies_overview(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
     let dim = Style::default().fg(p.dim);
+    let block = pane_block(" MANNIES ", true, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
     let Some(mannies) = &state.mannies else {
-        frame.render_widget(Paragraph::new(Line::styled("no data", dim)), area);
+        frame.render_widget(Paragraph::new(Line::styled("no data", dim)), inner);
         return;
     };
     if mannies.is_empty() {
-        frame.render_widget(Paragraph::new(Line::styled("no mannies aboard", dim)), area);
+        frame.render_widget(Paragraph::new(Line::styled("no mannies aboard", dim)), inner);
         return;
     }
 
-    let n = mannies.len();
-    let cols = ((area.width as usize / 26).max(1)).min(n).min(3);
-    let rows_n = n.div_ceil(cols);
-    let row_rects = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(vec![Constraint::Ratio(1, rows_n as u32); rows_n])
-        .split(area);
-    for (r, row_rect) in row_rects.iter().enumerate() {
-        let col_rects = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints(vec![Constraint::Ratio(1, cols as u32); cols])
-            .split(*row_rect);
-        for (c, cell) in col_rects.iter().enumerate() {
-            let idx = r * cols + c;
-            if let Some(m) = mannies.get(idx) {
-                render_manny_card(frame, *cell, state, m, idx == state.mannies_selection, p);
+    let sel = state.mannies_selection;
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, m) in mannies.iter().enumerate() {
+        let selected = i == sel;
+        let name_style = if selected {
+            Style::default().fg(p.accent).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(p.text)
+        };
+        let sec = if selected { Style::default().fg(p.accent) } else { dim };
+
+        // Summary line: marker · loc · name · task % · ETA.
+        let loc = match m.location.location_type {
+            MannyLocationType::Probe => "●",
+            MannyLocationType::Sector => "◌",
+            MannyLocationType::Unknown => "?",
+        };
+        let task = m.current_task.as_ref();
+        let mut header = vec![
+            Span::styled(if selected { "▶ " } else { "  " }, Style::default().fg(p.accent)),
+            Span::styled(format!("{loc} "), sec),
+            Span::styled(format!("{:<12}", m.name), name_style),
+            Span::styled(manny_task_label(task), if task.is_none() { sec } else { name_style }),
+        ];
+        if m.current_task.is_some() {
+            header.push(Span::styled(format!(" {:.0}%", m.task_progress_percent), sec));
+            if let Some(eta) = manny_task_eta(m) {
+                header.push(Span::styled(format!(" · {eta}"), sec));
             }
         }
+        lines.push(Line::from(header));
+
+        // Indented detail: cargo gauge, cargo breakdown, location.
+        let c = &m.cargo;
+        let used = c.metals + c.ice + c.deuterium + c.organic_compounds;
+        let ratio = if c.capacity > 0.0 { used / c.capacity } else { 0.0 };
+        lines.push(block_gauge_line("    CARGO", ratio, &format!("{used:.0}/{:.0}", c.capacity), p.accent, p));
+        lines.push(Line::styled(
+            format!(
+                "    metals {:.0} · ice {:.0} · deut {:.0} · org {:.0}",
+                c.metals, c.ice, c.deuterium, c.organic_compounds
+            ),
+            dim,
+        ));
+        let mut loc_line = match state.manny_sector_coords(m) {
+            Some((x, y, z)) => format!("    sector ({x}, {y}, {z})"),
+            None => "    on probe".to_string(),
+        };
+        if matches!(m.task_visibility, Some(MannyTaskVisibility::ScutNetwork)) {
+            loc_line.push_str("  ≣ via SCUT");
+        }
+        lines.push(Line::styled(loc_line, dim));
+        lines.push(Line::raw(""));
     }
+
+    frame.render_widget(Paragraph::new(lines), inner);
 }

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -99,6 +99,44 @@ fn manny_task_color(task: Option<&MannyTask>) -> Color {
     }
 }
 
+/// Mining task detail, extracted from the Manny's `task` payload: which
+/// asteroid, the resource types, and where the output goes (a named container
+/// or the probe). `None` unless the Manny is mining with a visible payload.
+pub(crate) struct MiningDetail {
+    pub target: String,
+    pub resources: Option<String>,
+    pub destination: String,
+}
+
+pub(crate) fn manny_mining_detail(m: &Manny) -> Option<MiningDetail> {
+    if m.current_task != Some(MannyTask::Mining) {
+        return None;
+    }
+    let task = m.task.as_ref()?;
+    let target = task.get("target");
+    let name = target
+        .and_then(|t| t.get("name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("asteroid")
+        .to_string();
+    let resources = target
+        .and_then(|t| t.get("resourceTypes"))
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).collect::<Vec<_>>().join("/"))
+        .filter(|s| !s.is_empty());
+    // A targetContainer object means the output is dropped into that detached
+    // container; otherwise it comes back to the probe.
+    let destination = match task.get("targetContainer") {
+        Some(tc) if tc.is_object() => tc
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("container")
+            .to_string(),
+        _ => "probe".to_string(),
+    };
+    Some(MiningDetail { target: name, resources, destination })
+}
+
 /// Time remaining on the current task, as a compact duration (if known).
 pub(crate) fn manny_task_eta(m: &Manny) -> Option<String> {
     m.task_estimated_end_time


### PR DESCRIPTION
The Mannies pane detail, expanded.

## Zoom overview (`z`)

A **vertical list**: each manny is a summary line (loc · name · task % · ETA) with details **indented below** — mining target, cargo gauge + breakdown, and location. The selected manny is marked (`▶`) and accent-styled. Drill-in (`l`) still focuses one manny full-screen.

## Mining target (asteroid / resources / destination)

The API exposes the current-task payload (`Manny.task`) — we were ignoring it. Now, for a mining manny, we show:

- **which asteroid** (`task.target.name`),
- **what it mines** (`task.target.resourceTypes`),
- **where it goes** — a named detached container (`task.targetContainer`) or the probe.

`⛏ asteroid · resources → destination`. Remote/too-far mannies expose no payload (sensitive state omitted server-side), so it is simply not shown there. `Manny.task` is read as a raw value (the API `anyOf` can also be an empty object/array).

## ⚠ Merge order

This branch also touches `src/ui/panels/mannies.rs`, as does #101 (mannies theme). **Merge #101 first**, then this — I will rebase/resolve if git conflicts.

## Verification

- `cargo build` ✓ (no warnings) · `cargo test` → 169 passed · `cargo clippy` → clean