### PR TITLE
feat(cockpit): probe pane — one info per line, more detail

### DIFF
--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -1,8 +1,8 @@
-use crate::api::types::MovementPhase;
+use crate::api::types::{MovementPhase, SensorMode};
 use crate::app::AppState;
 use chrono::Utc;
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
@@ -20,152 +20,137 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     let block = pane_block(" PROBE ", focused, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
+    // Breathing room: a one-column margin inside the border.
+    let content = Rect {
+        x: inner.x + 1,
+        y: inner.y,
+        width: inner.width.saturating_sub(2),
+        height: inner.height,
+    };
+
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
+    // A dim, left-aligned label column so every row lines up.
+    let label = |s: &str| Span::styled(format!("{s:<7} "), dim);
 
     let Some(probe) = &state.probe else {
         let msg = if state.loading { "fetching…" } else { "no data — F5 to refresh" };
-        frame.render_widget(
-            Paragraph::new(msg).style(Style::default().fg(p.dim)),
-            inner,
-        );
+        frame.render_widget(Paragraph::new(msg).style(dim), content);
         return;
     };
 
-    let active_movement = probe.movement.as_ref().filter(|mv| {
+    let mut lines: Vec<Line> = Vec::new();
+
+    // ── Identity ──
+    lines.push(Line::styled(probe.name.clone(), text.add_modifier(Modifier::BOLD)));
+    lines.push(Line::from(vec![
+        label("status"),
+        Span::styled(probe_status_label(&probe.status), probe_status_style(&probe.status)),
+    ]));
+    let (sensor_txt, sensor_col) = match probe.sensor_mode {
+        SensorMode::Normal => ("normal", p.good),
+        SensorMode::Degraded => ("degraded", p.warn),
+        SensorMode::Blind => ("BLIND", p.crit),
+        SensorMode::Unknown => ("?", p.dim),
+    };
+    lines.push(Line::from(vec![
+        label("sensor"),
+        Span::styled(sensor_txt, Style::default().fg(sensor_col)),
+    ]));
+
+    // ── Badges ──
+    if state.probe_terminal_alert().is_some() {
+        lines.push(Line::styled(
+            "⚠ RECOVER — Enter",
+            Style::default().fg(p.crit).add_modifier(Modifier::BOLD),
+        ));
+    }
+    let unread = state.unread_alert_count();
+    if unread > 0 {
+        lines.push(Line::from(vec![
+            label("alerts"),
+            Span::styled(format!("{unread} unread"), Style::default().fg(p.crit)),
+        ]));
+    }
+    if !state.scut_coverage().is_empty() {
+        lines.push(Line::styled("≣ SCUT coverage", Style::default().fg(p.accent)));
+    }
+
+    // ── Vital gauges ──
+    lines.push(Line::raw(""));
+    let fuel = probe.fuel.deuterium.map(|d| (d / 100.0).clamp(0.0, 1.0)).unwrap_or(0.0);
+    lines.push(block_gauge_line("FUEL", fuel, &format!("{:.0}%", fuel * 100.0), ratio_color(fuel, p), p));
+    if let Some(sys) = &probe.systems {
+        let integ = (sys.integrity_percent.unwrap_or(100.0) / 100.0).clamp(0.0, 1.0);
+        lines.push(block_gauge_line("INTEG", integ, &format!("{:.0}%", integ * 100.0), ratio_color(integ, p), p));
+    }
+    let inv = &probe.inventory;
+    let cargo = if inv.capacity > 0.0 { (inv.used_capacity / inv.capacity).clamp(0.0, 1.0) } else { 0.0 };
+    lines.push(block_gauge_line("CARGO", cargo, &format!("{:.0}%", cargo * 100.0), p.accent, p));
+
+    // ── Movement (active) or current sector ──
+    let active = probe.movement.as_ref().filter(|mv| {
         !matches!(
             mv.phase.as_ref().unwrap_or(&mv.status),
             MovementPhase::Arrived | MovementPhase::Failed | MovementPhase::Destroyed | MovementPhase::Idle
         )
     });
-
-    let show_sector = active_movement.is_none()
-        && probe.sector.as_ref().and_then(|s| s.relative.as_ref()).is_some();
-
-    let mut sections: Vec<Constraint> = vec![Constraint::Length(1)]; // header
-    if show_sector {
-        sections.push(Constraint::Length(1));
-    }
-    if active_movement.is_some() {
-        sections.extend([Constraint::Length(1); 4]); // route, phase+eta, burn, speed
-    }
-    sections.push(Constraint::Length(1)); // fuel
-    if probe.systems.is_some() {
-        sections.push(Constraint::Length(1)); // integrity
-    }
-    sections.push(Constraint::Min(0)); // padding
-
-    let rows = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(sections)
-        .split(inner);
-    let mut row = 0;
-
-    // ── Header: name · status · badges ──
-    let mut status_spans = vec![
-        Span::styled(&probe.name, Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
-        Span::raw("  "),
-        Span::styled(probe_status_label(&probe.status), probe_status_style(&probe.status)),
-    ];
-    let unread = state.unread_alert_count();
-    if unread > 0 {
-        status_spans.push(Span::styled(
-            format!(" [!{unread}]"),
-            Style::default().fg(p.crit).add_modifier(Modifier::BOLD),
-        ));
-    }
-    if state.probe_terminal_alert().is_some() {
-        status_spans.push(Span::styled(
-            "  ⚠ RECOVER",
-            Style::default().fg(p.crit).add_modifier(Modifier::BOLD),
-        ));
-    }
-    if !state.scut_coverage().is_empty() {
-        status_spans.push(Span::styled("  ≣ SCUT", Style::default().fg(p.accent)));
-    }
-    frame.render_widget(Paragraph::new(Line::from(status_spans)), rows[row]);
-    row += 1;
-
-    // ── Current sector ──
-    if show_sector {
-        if let Some(rel) = probe.sector.as_ref().and_then(|s| s.relative.as_ref()) {
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("@ ", Style::default().fg(p.dim)),
-                    Span::styled(
-                        format!("({},{},{})", rel.x as i64, rel.y as i64, rel.z as i64),
-                        Style::default().fg(p.text),
-                    ),
-                ])),
-                rows[row],
-            );
-            row += 1;
-        }
-    }
-
-    // ── Movement ──
-    if let Some(mv) = active_movement {
+    if let Some(mv) = active {
         let remaining = (mv.arrival_at - Utc::now()).num_seconds().max(0);
         let elapsed = (Utc::now() - mv.started_at).num_seconds().max(0);
         let total = (mv.arrival_at - mv.started_at).num_seconds().max(1);
         let progress = (elapsed as f64 / total as f64).clamp(0.0, 1.0);
-        let phase_label = movement_phase_label(mv.phase.as_ref().unwrap_or(&mv.status));
-
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(p.warn)),
-                Span::styled(
-                    format!(
-                        "({},{},{}) → ({},{},{})  d:{}",
-                        mv.origin.x as i64, mv.origin.y as i64, mv.origin.z as i64,
-                        mv.target.x as i64, mv.target.y as i64, mv.target.z as i64,
-                        mv.distance,
-                    ),
-                    Style::default().fg(p.text),
-                ),
-            ])),
-            rows[row],
-        );
-        row += 1;
-
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled(format!("  {phase_label}"), Style::default().fg(p.warn)),
-                Span::styled(format!("  ETA {}", format_duration(remaining)), Style::default().fg(p.dim)),
-            ])),
-            rows[row],
-        );
-        row += 1;
-
-        frame.render_widget(
-            block_gauge_line("BURN", progress, &format!("{:.0}%", progress * 100.0), p.accent, p),
-            rows[row],
-        );
-        row += 1;
-
         let velocity = mv.estimated_velocity_c.unwrap_or(0.0).clamp(0.0, 1.0);
-        frame.render_widget(
-            block_gauge_line("SPEED", velocity, &format!("{velocity:.2}c"), p.accent, p),
-            rows[row],
-        );
-        row += 1;
+
+        lines.push(Line::raw(""));
+        lines.push(Line::from(vec![
+            label("travel"),
+            Span::styled(
+                format!(
+                    "({},{},{}) → ({},{},{})",
+                    mv.origin.x as i64, mv.origin.y as i64, mv.origin.z as i64,
+                    mv.target.x as i64, mv.target.y as i64, mv.target.z as i64,
+                ),
+                text,
+            ),
+        ]));
+        lines.push(Line::from(vec![label("dist"), Span::styled(format!("{}", mv.distance), text)]));
+        lines.push(Line::from(vec![
+            label("phase"),
+            Span::styled(movement_phase_label(mv.phase.as_ref().unwrap_or(&mv.status)), Style::default().fg(p.warn)),
+        ]));
+        lines.push(Line::from(vec![label("ETA"), Span::styled(format_duration(remaining), text)]));
+        lines.push(block_gauge_line("BURN", progress, &format!("{:.0}%", progress * 100.0), p.accent, p));
+        lines.push(block_gauge_line("SPEED", velocity, &format!("{velocity:.2}c"), p.accent, p));
+        lines.push(Line::from(vec![
+            label("cost"),
+            Span::styled(format!("{:.1} deut", mv.fuel_cost_deuterium), dim),
+        ]));
+    } else if let Some(rel) = probe.sector.as_ref().and_then(|s| s.relative.as_ref()) {
+        lines.push(Line::raw(""));
+        lines.push(Line::from(vec![
+            label("sector"),
+            Span::styled(format!("({}, {}, {})", rel.x as i64, rel.y as i64, rel.z as i64), text),
+        ]));
     }
 
-    // ── Fuel ──
-    let fuel = probe.fuel.deuterium.map(|d| (d / 100.0).clamp(0.0, 1.0)).unwrap_or(0.0);
-    frame.render_widget(
-        block_gauge_line("FUEL", fuel, &format!("{:.0}%", fuel * 100.0), ratio_color(fuel, p), p),
-        rows[row],
-    );
-    row += 1;
-
-    // ── Integrity ──
+    // ── Extras (shown when the pane is tall enough) ──
     if let Some(sys) = &probe.systems {
-        let integrity = (sys.integrity_percent.unwrap_or(100.0) / 100.0).clamp(0.0, 1.0);
-        frame.render_widget(
-            block_gauge_line("INTEG", integrity, &format!("{:.0}%", integrity * 100.0), ratio_color(integrity, p), p),
-            rows[row],
-        );
-        row += 1;
+        lines.push(Line::raw(""));
+        if let Some(e) = sys.energy_stored {
+            lines.push(Line::from(vec![label("energy"), Span::styled(format!("{e:.0}"), text)]));
+        }
+        if let Some(rate) = sys.internal_clock_rate {
+            lines.push(Line::from(vec![label("clock"), Span::styled(format!("{rate:.2}×"), text)]));
+        }
     }
+    lines.push(Line::from(vec![
+        label("hold"),
+        Span::styled(
+            format!("{} items · {} stocks · {} tanks", inv.items.len(), inv.resource_stocks.len(), inv.external_tanks.len()),
+            dim,
+        ),
+    ]));
 
-    let _ = row;
+    frame.render_widget(Paragraph::new(lines), content);
 }


### PR DESCRIPTION
Rework the Probe pane per feedback: use the space, one info per line, dont hug the left border, and show as much as fits.

## Changes

- **One-column left margin** inside the border; every row has a dim, aligned label column.
- **One info per line** instead of a cramped mix.
- **More detail from the API**, previously unused:
  - `sensor` mode (normal / degraded / blind, palette-coloured)
  - `CARGO` fill gauge (probe hold used/capacity)
  - movement: route, `dist`, `phase`, `ETA`, `BURN` + `SPEED` gauges, jump `cost` (deuterium)
  - systems: `energy` stored, internal `clock` rate
  - `hold` summary: items · stocks · tanks
- **Graceful density:** vital gauges (fuel / integrity / cargo) come first; the extras clip on a small 1/3 cell and fill in when the pane is zoomed.

Independent of the mannies PRs (touches only `panels/probe.rs`).

## Verification

- `cargo build` ✓ (no warnings) · `cargo test` → 169 passed · `cargo clippy` → clean