### PR TITLE
feat(cockpit): scanner pane — scan actions, declutter, neighbor map, palette

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -286,7 +286,13 @@ impl super::AppState {
         if probe_recovery
             || matches!(
                 pane,
-                Pane::Mannies | Pane::Inventory | Pane::Missions | Pane::Comms | Pane::Storage | Pane::Sector
+                Pane::Mannies
+                    | Pane::Inventory
+                    | Pane::Missions
+                    | Pane::Comms
+                    | Pane::Storage
+                    | Pane::Sector
+                    | Pane::Scanner
             )
         {
             parts.push("Enter act");

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -32,6 +32,11 @@ pub enum MenuAction {
     // Storage pane
     RenameContainer,
     EditContainerRules,
+    // Scanner pane
+    ScanObserve,
+    ScanNeighbors,
+    ScanRefresh,
+    ScanFilter,
 }
 
 /// A single entry in a contextual action menu.
@@ -97,8 +102,41 @@ impl super::AppState {
             super::Pane::Inventory => Some(self.inventory_context_menu()),
             super::Pane::Probe => self.probe_context_menu(),
             super::Pane::Storage => self.storage_context_menu(),
+            super::Pane::Scanner => Some(self.scanner_context_menu()),
             _ => None,
         }
+    }
+
+    fn scanner_context_menu(&self) -> ContextMenu {
+        // Neighbor batch scan needs a known probe position to offset from.
+        let has_pos = self.probe_sector_coords().is_some();
+        let items = vec![
+            MenuItem {
+                action: MenuAction::ScanObserve,
+                label: "Observe coordinates…".into(),
+                enabled: true,
+                disabled_reason: None,
+            },
+            MenuItem {
+                action: MenuAction::ScanNeighbors,
+                label: "Scan neighbors…".into(),
+                enabled: has_pos,
+                disabled_reason: (!has_pos).then(|| "unknown position".to_string()),
+            },
+            MenuItem {
+                action: MenuAction::ScanRefresh,
+                label: "Refresh current sector".into(),
+                enabled: true,
+                disabled_reason: None,
+            },
+            MenuItem {
+                action: MenuAction::ScanFilter,
+                label: format!("Cycle filter (now: {})", self.scan_filter.label()),
+                enabled: !self.scan_history.is_empty(),
+                disabled_reason: self.scan_history.is_empty().then(|| "no history".to_string()),
+            },
+        ];
+        ContextMenu { title: "SCANNER".into(), items, cursor: 0 }
     }
 
     fn storage_context_menu(&self) -> Option<ContextMenu> {

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -33,9 +33,9 @@ pub enum MenuAction {
     RenameContainer,
     EditContainerRules,
     // Scanner pane
+    ScanAround,
+    ScanDirection,
     ScanObserve,
-    ScanNeighbors,
-    ScanRefresh,
     ScanFilter,
 }
 
@@ -108,24 +108,25 @@ impl super::AppState {
     }
 
     fn scanner_context_menu(&self) -> ContextMenu {
-        // Neighbor batch scan needs a known probe position to offset from.
+        // Batch scans need a known probe position to offset from.
         let has_pos = self.probe_sector_coords().is_some();
+        let pos_reason = (!has_pos).then(|| "unknown position".to_string());
         let items = vec![
+            MenuItem {
+                action: MenuAction::ScanAround,
+                label: "Scan around (neighbors)".into(),
+                enabled: has_pos,
+                disabled_reason: pos_reason.clone(),
+            },
+            MenuItem {
+                action: MenuAction::ScanDirection,
+                label: "Scan a direction (×2)…".into(),
+                enabled: has_pos,
+                disabled_reason: pos_reason,
+            },
             MenuItem {
                 action: MenuAction::ScanObserve,
                 label: "Observe coordinates…".into(),
-                enabled: true,
-                disabled_reason: None,
-            },
-            MenuItem {
-                action: MenuAction::ScanNeighbors,
-                label: "Scan neighbors…".into(),
-                enabled: has_pos,
-                disabled_reason: (!has_pos).then(|| "unknown position".to_string()),
-            },
-            MenuItem {
-                action: MenuAction::ScanRefresh,
-                label: "Refresh current sector".into(),
                 enabled: true,
                 disabled_reason: None,
             },

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -20,7 +20,7 @@ use crate::app::{
     DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction, MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
     RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
-    StorageMoveInput,
+    ScanMode, StorageMoveInput,
 };
 
 pub fn handle_cockpit_event(
@@ -73,7 +73,7 @@ pub fn handle_cockpit_event(
 /// the contextual menu; panes backed by a rich wizard reuse its overlay.
 fn open_actions(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     match state.active_pane {
-        Pane::Mannies | Pane::Inventory | Pane::Probe | Pane::Storage => {
+        Pane::Mannies | Pane::Inventory | Pane::Probe | Pane::Storage | Pane::Scanner => {
             match state.build_context_menu() {
                 Some(menu) if !menu.items.is_empty() => state.mode = InputMode::Menu(menu),
                 _ => state.set_toast("no actions here"),
@@ -244,6 +244,27 @@ fn fire_menu_action(
                     state.container_rules = editor;
                 }
             }
+            return;
+        }
+        MenuAction::ScanObserve => {
+            state.scan_mode = ScanMode::Input(String::new());
+            return;
+        }
+        MenuAction::ScanNeighbors => {
+            if state.probe_sector_coords().is_some() {
+                state.scan_mode = ScanMode::DirectionPick;
+            }
+            return;
+        }
+        MenuAction::ScanRefresh => {
+            state.scan_loading = true;
+            state.scan_error = None;
+            fetch_sector(None, client.clone(), tx.clone());
+            return;
+        }
+        MenuAction::ScanFilter => {
+            state.cycle_scan_filter();
+            state.set_toast(format!("filter: {}", state.scan_filter.label()));
             return;
         }
         _ => {}

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -246,20 +246,24 @@ fn fire_menu_action(
             }
             return;
         }
-        MenuAction::ScanObserve => {
-            state.scan_mode = ScanMode::Input(String::new());
+        MenuAction::ScanAround => {
+            if let Some((x, y, z)) = state.probe_sector_coords() {
+                let offsets = super::geometry::neighbors_d1();
+                state.start_batch(offsets.len());
+                for (dx, dy, dz) in offsets {
+                    fetch_sector(Some((x + dx, y + dy, z + dz)), client.clone(), tx.clone());
+                }
+            }
             return;
         }
-        MenuAction::ScanNeighbors => {
+        MenuAction::ScanDirection => {
             if state.probe_sector_coords().is_some() {
                 state.scan_mode = ScanMode::DirectionPick;
             }
             return;
         }
-        MenuAction::ScanRefresh => {
-            state.scan_loading = true;
-            state.scan_error = None;
-            fetch_sector(None, client.clone(), tx.clone());
+        MenuAction::ScanObserve => {
+            state.scan_mode = ScanMode::Input(String::new());
             return;
         }
         MenuAction::ScanFilter => {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -149,7 +149,13 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
         // Reused classic renderers keep their own colours for now.
         Pane::Probe => render_probe_panel(frame, area, state, active),
         Pane::Inventory => render_inventory_panel(frame, area, state, active),
-        Pane::Scanner => render_scanner_panel(frame, area, state, active),
+        Pane::Scanner => {
+            if state.zoomed {
+                panes::render_scanner_neighbors(frame, area, state, active);
+            } else {
+                render_scanner_panel(frame, area, state, active);
+            }
+        }
         Pane::Mannies => {
             if let Some(DrillLevel::Manny(id)) = state.pane_nav[Pane::Mannies.index()].drill.last() {
                 panes::render_manny_detail(frame, area, state, id, active, p);

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -505,3 +505,99 @@ pub fn render_mannies_overview(frame: &mut Frame, area: Rect, state: &AppState, 
 
     frame.render_widget(Paragraph::new(lines), inner);
 }
+
+/// Zoom view for the Scanner pane: a spatial mini-map of the six sectors
+/// adjacent to the probe, coloured by interest, with a legend. Focuses the
+/// Scanner on its real job — knowing what lies *around* the current sector.
+pub fn render_scanner_neighbors(frame: &mut Frame, area: Rect, state: &AppState, active: bool) {
+    use crate::ui::panels::scanner::sector_interest_color;
+    use crate::ui::theme::{knowledge_label, map_cell_style};
+
+    let p = crate::ui::theme::palette(state.color_mode);
+    let block = pane_block(" SCANNER · NEIGHBORS ", active, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let dim = Style::default().fg(p.dim);
+
+    let Some((px, py, pz)) = state.probe_sector_coords() else {
+        frame.render_widget(Paragraph::new(Line::styled("unknown probe position", dim)), inner);
+        return;
+    };
+
+    // Look up a scanned observation at exact relative coordinates.
+    let at = |x: i32, y: i32, z: i32| {
+        state.scan_history.iter().find(|s| {
+            let c = &s.relative_coordinates;
+            c.x.round() as i32 == x && c.y.round() as i32 == y && c.z.round() as i32 == z
+        })
+    };
+    // (symbol, color) for a neighbor cell — dim dot when never scanned.
+    let cell = |x: i32, y: i32, z: i32| match at(x, y, z) {
+        Some(s) => {
+            let (sym, st) = map_cell_style(s, p);
+            (sym.to_string(), st)
+        }
+        None => ("·".to_string(), dim),
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("from ", dim),
+        Span::styled(format!("({px},{py},{pz})"), Style::default().fg(p.text)),
+    ]));
+    lines.push(Line::raw(""));
+
+    // XY plane cross around the probe (P), with the +X/-X row centred.
+    let (uy, us) = cell(px, py + 1, pz);
+    let (dy, ds) = cell(px, py - 1, pz);
+    let (lx, ls) = cell(px - 1, py, pz);
+    let (rx, rs) = cell(px + 1, py, pz);
+    lines.push(Line::from(vec![Span::raw("      "), Span::styled(uy, us), Span::styled("  +Y", dim)]));
+    lines.push(Line::from(vec![
+        Span::styled(lx, ls),
+        Span::styled(" -X   ", dim),
+        Span::styled("P", Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
+        Span::styled("   +X ", dim),
+        Span::styled(rx, rs),
+    ]));
+    lines.push(Line::from(vec![Span::raw("      "), Span::styled(dy, ds), Span::styled("  -Y", dim)]));
+    lines.push(Line::raw(""));
+
+    // Z axis on its own row (out-of-plane).
+    let (zu, zus) = cell(px, py, pz + 1);
+    let (zd, zds) = cell(px, py, pz - 1);
+    lines.push(Line::from(vec![
+        Span::styled("+Z ", dim),
+        Span::styled(zu, zus),
+        Span::styled("    -Z ", dim),
+        Span::styled(zd, zds),
+    ]));
+    lines.push(Line::raw(""));
+
+    // Legend: one row per direction with coords, symbol, and what's known.
+    let dirs = [
+        ("+X", px + 1, py, pz),
+        ("-X", px - 1, py, pz),
+        ("+Y", px, py + 1, pz),
+        ("-Y", px, py - 1, pz),
+        ("+Z", px, py, pz + 1),
+        ("-Z", px, py, pz - 1),
+    ];
+    for (tag, x, y, z) in dirs {
+        let (sym, st, label, coord_color) = match at(x, y, z) {
+            Some(s) => {
+                let (sym, st) = map_cell_style(s, p);
+                (sym.to_string(), st, knowledge_label(&s.knowledge_level), sector_interest_color(s, p))
+            }
+            None => ("·".to_string(), dim, "unscanned", p.dim),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("{tag} "), dim),
+            Span::styled(sym, st),
+            Span::styled(format!(" ({x},{y},{z}) "), Style::default().fg(coord_color)),
+            Span::styled(label, dim),
+        ]));
+    }
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod object_actions;
 pub(crate) mod scut_network;
 pub(crate) mod pickers;
 pub(crate) mod repair;
+pub(crate) mod scanner;
 pub(crate) mod storage_move;
 pub(crate) mod travel;
 pub(crate) mod waypoints;
@@ -39,6 +40,7 @@ pub(crate) use pickers::{
     render_scut_relay_overlay,
 };
 pub(crate) use repair::render_repair_overlay;
+pub(crate) use scanner::render_scan_input_overlay;
 pub(crate) use storage_move::render_storage_move_overlay;
 pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
@@ -49,7 +51,7 @@ use crate::app::{
     JettisonInput, MineInput,
     MessagesInput, MindSnapshotInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput,
     RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
-    ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
+    ScanMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -152,6 +154,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if !matches!(state.storage_move, StorageMoveInput::Inactive) {
         render_storage_move_overlay(frame, area, state);
+    }
+    if !matches!(state.scan_mode, ScanMode::Current) {
+        render_scan_input_overlay(frame, area, state);
     }
     if state.help_open {
         render_help_overlay(frame, area);

--- a/src/ui/overlays/scanner.rs
+++ b/src/ui/overlays/scanner.rs
@@ -1,0 +1,105 @@
+use crate::app::{AppState, ScanMode};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use super::centered_rect;
+
+/// Coordinate-entry and neighbor-scan prompts for the Scanner pane. Both modes
+/// are handled by the shared scan-input router in `input/mod.rs`; this only
+/// renders the prompt.
+pub(crate) fn render_scan_input_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match &state.scan_mode {
+        ScanMode::Input(buf) => render_coord_input(frame, area, buf),
+        ScanMode::DirectionPick => render_direction_pick(frame, area, state),
+        ScanMode::Current => {}
+    }
+}
+
+fn render_coord_input(frame: &mut Frame, area: Rect, buf: &str) {
+    let popup = centered_rect(52, 7, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" OBSERVE SECTOR ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "relative coordinates, space-separated",
+            Style::default().fg(Color::DarkGray),
+        ))),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("x y z: ", Style::default().fg(Color::Cyan)),
+            Span::raw(buf),
+            Span::styled("█", Style::default().fg(Color::Cyan)),
+        ])),
+        rows[1],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::raw(" observe  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[2],
+    );
+}
+
+fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
+    let popup = centered_rect(52, 7, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" SCAN NEIGHBORS ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let origin = state
+        .probe_sector_coords()
+        .map(|(x, y, z)| format!("({x}, {y}, {z})"))
+        .unwrap_or_else(|| "unknown".into());
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(vec![
+                Span::styled("from ", Style::default().fg(Color::DarkGray)),
+                Span::styled(origin, Style::default().fg(Color::White)),
+            ]),
+            Line::default(),
+            Line::from("pick an axis to sweep its two faces:"),
+        ]),
+        rows[0],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("[x] [y] [z]", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(" scan  "),
+            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        rows[1],
+    );
+}

--- a/src/ui/panels/scanner.rs
+++ b/src/ui/panels/scanner.rs
@@ -1,36 +1,44 @@
-use crate::api::types::{
-    DangerLevel, SectorObject, SectorObjectType, SensorMode,
-};
+use crate::api::types::{DangerLevel, SectorObject, SectorObjectType, SensorMode};
 use crate::app::AppState;
-use chrono::Utc;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
     Frame,
 };
 
-use crate::ui::theme::{format_age, format_duration, freshness_color, freshness_label, gauge_color, knowledge_color, knowledge_label, map_cell_symbol, object_icon, palette, pane_block, sensor_dot, sensor_style};
+use crate::ui::theme::{
+    knowledge_color, knowledge_label, map_cell_style, object_color, object_icon, palette,
+    pane_block, ratio_color, Palette,
+};
 // ── Scanner panel ─────────────────────────────────────────────────────────────
+//
+// The SECTOR pane owns the current sector's full detail. The Scanner is the
+// cartography station: it scans *elsewhere* (neighbors, remote coordinates) and
+// keeps the history of everything observed. So the history list is always
+// present, and the detail area focuses on the selected — usually remote —
+// observation. When the cursor lands on the current sector, we redirect to the
+// SECTOR pane instead of duplicating it. All colours come from the active
+// [`Palette`] so the pane matches the rest of the phosphor cockpit.
 
 pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppState, focused: bool) {
-    let block = pane_block(" SCANNER ", focused, palette(state.color_mode));
+    let p = palette(state.color_mode);
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
+
+    let block = pane_block(" SCANNER ", focused, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
     let Some(probe) = &state.probe else {
-        frame.render_widget(
-            Paragraph::new("No data").style(Style::default().fg(Color::DarkGray)),
-            inner,
-        );
+        frame.render_widget(Paragraph::new("No data").style(dim), inner);
         return;
     };
 
     let is_blind = probe.sensor_mode == SensorMode::Blind;
 
-    // Action hints come from the cockpit's shared hints line (F1); the pane
-    // uses its whole area for the sector detail + history.
+    // History list is the core of the pane — always shown when non-empty.
     let filtered = state.filtered_history_indices();
     let history_len = filtered.len();
     let history_width: u16 = if history_len > 0 { 22 } else { 0 };
@@ -41,11 +49,8 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
     let detail_area = cols[0];
     let history_area = cols[1];
 
-    // History list (always rendered when non-empty)
     if history_len > 0 {
-        let hist_block = Block::default()
-            .borders(Borders::LEFT)
-            .border_style(Style::default().fg(Color::DarkGray));
+        let hist_block = Block::default().borders(Borders::LEFT).border_style(dim);
         let hist_inner = hist_block.inner(history_area);
         frame.render_widget(hist_block, history_area);
 
@@ -55,12 +60,12 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
                 let s = &state.scan_history[i];
                 let c = &s.relative_coordinates;
                 let label = format!("{},{},{}", c.x as i64, c.y as i64, c.z as i64);
-                let color = sector_interest_color(s);
-                let (sym, sym_style) = map_cell_symbol(s);
+                let color = sector_interest_color(s, p);
+                let (sym, sym_style) = map_cell_style(s, p);
                 ListItem::new(Line::from(vec![
                     Span::styled(format!("{sym} "), sym_style),
                     Span::styled(format!("{label:<9}"), Style::default().fg(color)),
-                    Span::styled(format!("d:{}", s.distance), Style::default().fg(Color::DarkGray)),
+                    Span::styled(format!("d:{}", s.distance), dim),
                 ]))
             })
             .collect();
@@ -74,229 +79,171 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
         frame.render_stateful_widget(list, hist_inner, &mut list_state);
     }
 
-    // Detail area
+    // ── Detail area ──
     if state.scan_loading {
-        frame.render_widget(
-            Paragraph::new("Scanning…").style(Style::default().fg(Color::DarkGray)),
-            detail_area,
-        );
+        frame.render_widget(Paragraph::new("Scanning…").style(dim), detail_area);
         return;
     }
-
     if let Some(err) = &state.scan_error {
         frame.render_widget(
-            Paragraph::new(format!("ERR: {err}")).style(Style::default().fg(Color::Red)),
+            Paragraph::new(format!("ERR: {err}")).style(Style::default().fg(p.crit)),
             detail_area,
         );
         return;
     }
-
     let Some(sector) = state.current_sector() else {
         let (msg, color) = if is_blind {
-            ("● sensors blind — history available →", Color::Red)
+            ("● sensors blind — history available →", p.crit)
         } else if focused {
-            ("No scan data — F5 to refresh", Color::DarkGray)
+            ("No scan data — Enter to observe", p.dim)
         } else {
-            ("No scan data", Color::DarkGray)
+            ("No scan data", p.dim)
         };
-        frame.render_widget(
-            Paragraph::new(msg).style(Style::default().fg(color)),
-            detail_area,
-        );
+        frame.render_widget(Paragraph::new(msg).style(Style::default().fg(color)), detail_area);
         return;
     };
 
-    let sensor = probe.sensor_mode.clone();
+    let coords = &sector.relative_coordinates;
+    let (cx, cy, cz) = (coords.x as i64, coords.y as i64, coords.z as i64);
     let mut lines: Vec<Line> = Vec::new();
 
-    let knowledge_str = knowledge_label(&sector.knowledge_level);
-    let knowledge_color = knowledge_color(&sector.knowledge_level);
-    let confidence_color = gauge_color(sector.confidence);
-    let coords = &sector.relative_coordinates;
+    // Current sector: redirect to SECTOR, stay focused on remote scanning.
+    if state.viewing_probe_sector() {
+        lines.push(Line::from(vec![
+            Span::styled(format!("({cx},{cy},{cz})"), text),
+            Span::styled("  current sector", dim),
+        ]));
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled("→ details in the SECTOR pane", Style::default().fg(p.accent))));
+        let obj_count = sector.objects.as_ref().map(|o| o.len()).unwrap_or(0);
+        let summary = if obj_count > 0 {
+            format!("{obj_count} object(s) here")
+        } else {
+            "empty sector".to_string()
+        };
+        lines.push(Line::from(Span::styled(summary, dim)));
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled("z zoom → neighbor map", dim)));
+        frame.render_widget(Paragraph::new(lines), detail_area);
+        return;
+    }
+
+    // ── Remote / neighbor observation ──
+    // Header: coords · distance · knowledge level. Sensors live in PROBE; the
+    // scan-quality % is relegated to the zoom view.
     lines.push(Line::from(vec![
-        Span::styled(
-            format!("({},{},{})", coords.x as i64, coords.y as i64, coords.z as i64),
-            Style::default().fg(Color::White),
-        ),
+        Span::styled(format!("({cx},{cy},{cz})"), text),
+        Span::raw("  "),
+        Span::styled(format!("d:{}", sector.distance), dim),
         Span::raw("  "),
         Span::styled(
-            format!("d:{}", sector.distance),
-            Style::default().fg(Color::DarkGray),
-        ),
-        Span::raw("  "),
-        Span::styled(knowledge_str, Style::default().fg(knowledge_color)),
-        Span::raw("  "),
-        Span::styled(
-            format!("{:.0}%", sector.confidence * 100.0),
-            Style::default().fg(confidence_color).add_modifier(Modifier::BOLD),
+            knowledge_label(&sector.knowledge_level),
+            Style::default().fg(knowledge_color(&sector.knowledge_level, p)),
         ),
     ]));
 
-    let freshness_str = sector.data_freshness.as_ref().map(freshness_label).unwrap_or("—");
-    let freshness_color = sector.data_freshness.as_ref().map(freshness_color).unwrap_or(Color::DarkGray);
-    let scan_q = sector.scan.scan_quality;
-    let mut freshness_spans = vec![
-        Span::styled(freshness_str, Style::default().fg(freshness_color)),
-        Span::raw("  quality: "),
+    // Single confidence gauge — the one trust signal kept in compact.
+    let conf = sector.confidence;
+    lines.push(Line::from(vec![
+        Span::styled("confidence ", dim),
         Span::styled(
-            format!("{:.0}%", scan_q * 100.0),
-            Style::default().fg(gauge_color(scan_q)),
+            format!("{:.0}%", conf * 100.0),
+            Style::default().fg(ratio_color(conf, p)).add_modifier(Modifier::BOLD),
         ),
-        Span::raw("  sensors: "),
-        Span::styled(sensor_dot(&sensor), sensor_style(&sensor)),
-    ];
-    if let Some(scanned_at) = sector.scanned_at {
-        let age_secs = (Utc::now() - scanned_at).num_seconds().max(0);
-        freshness_spans.push(Span::styled(
-            format!("  scanned {}", format_age(age_secs)),
-            Style::default().fg(Color::DarkGray),
-        ));
-    }
-    lines.push(Line::from(freshness_spans));
+    ]));
 
-    let req = sector.scan.required_residence_seconds;
-    let cur = sector.scan.current_sector_residence_seconds;
-    if req > 0 {
-        let ratio = (cur as f64 / req as f64).clamp(0.0, 1.0);
-        let res_color = if ratio >= 1.0 { Color::Green } else { Color::Yellow };
-        lines.push(Line::from(vec![
-            Span::styled("residence  ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format!("{} / {}", format_duration(cur), format_duration(req)),
-                Style::default().fg(res_color),
-            ),
-        ]));
-    }
-
+    // Navigational risk (safety-critical — always kept).
     if let Some(risk) = &sector.navigational_risk {
         if !risk.is_empty() {
             lines.push(Line::from(vec![
-                Span::styled("risk  ", Style::default().fg(Color::DarkGray)),
-                Span::styled(risk.as_str(), Style::default().fg(Color::Yellow)),
+                Span::styled("risk  ", dim),
+                Span::styled(risk.as_str(), Style::default().fg(p.warn)),
             ]));
         }
     }
 
-    if let Some(msg) = &sector.message {
-        if !msg.is_empty() {
-            lines.push(Line::from(Span::styled(
-                msg.as_str(),
-                Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
-            )));
-        }
-    }
-
-    let browsing = focused && state.scanner_obj_selection.is_some() && state.viewing_probe_sector();
-    let selected_obj_id: Option<String> = if browsing {
-        state
-            .scanner_obj_selection
-            .and_then(|i| state.scanner_objects().into_iter().nth(i))
-            .map(|e| e.id)
-    } else {
-        None
-    };
-
+    // Confirmed objects (decluttered: no mass/radius/uid — see zoom).
     if let Some(objects) = &sector.objects {
         if !objects.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "── objects ──",
-                Style::default().fg(Color::DarkGray),
-            )));
+            lines.push(Line::from(Span::styled("── objects ──", dim)));
             for obj in objects {
-                lines.extend(sector_object_lines(obj, browsing, selected_obj_id.as_deref()));
+                lines.extend(sector_object_lines(obj, true, p));
             }
         }
     }
 
     if let Some(probes) = &sector.probes {
         if !probes.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "── other probes ──",
-                Style::default().fg(Color::DarkGray),
-            )));
-            for p in probes {
-                let moving = if p.moving { " moving" } else { " idle" };
+            lines.push(Line::from(Span::styled("── other probes ──", dim)));
+            for pr in probes {
+                let moving = if pr.moving { " moving" } else { " idle" };
                 lines.push(Line::from(vec![
-                    Span::styled("⊕ ", Style::default().fg(Color::Cyan)),
-                    Span::raw(p.name.as_str()),
-                    Span::styled(moving, Style::default().fg(Color::DarkGray)),
+                    Span::styled("⊕ ", Style::default().fg(p.accent)),
+                    Span::styled(pr.name.as_str(), text),
+                    Span::styled(moving, dim),
                 ]));
             }
         }
     }
 
+    // The value of a neighbor scan: what the sector *probably* holds.
     let has_objects = sector.objects.as_ref().is_some_and(|o| !o.is_empty());
     let confirmed_empty = sector.objects.as_ref().is_some_and(|o| o.is_empty())
-        && sector.possible_objects.as_ref().is_none_or(|p| p.is_empty())
+        && sector.possible_objects.as_ref().is_none_or(|o| o.is_empty())
         && sector.estimated_objects.is_none();
     if confirmed_empty {
-        lines.push(Line::from(Span::styled(
-            "empty sector",
-            Style::default().fg(Color::DarkGray),
-        )));
+        lines.push(Line::from(Span::styled("empty sector", dim)));
     }
     if !has_objects {
         if let Some(possible) = &sector.possible_objects {
             if !possible.is_empty() {
-                lines.push(Line::from(Span::styled(
-                    "── possible ──",
-                    Style::default().fg(Color::DarkGray),
-                )));
-                for p in possible {
-                    lines.push(Line::from(vec![
-                        Span::styled("? ", Style::default().fg(Color::DarkGray)),
-                        Span::raw(p.as_str()),
-                    ]));
+                lines.push(Line::from(Span::styled("── possible ──", dim)));
+                for pobj in possible {
+                    lines.push(Line::from(vec![Span::styled("? ", dim), Span::styled(pobj.as_str(), text)]));
                 }
             }
         }
         if let Some(est) = &sector.estimated_objects {
-            lines.push(Line::from(Span::styled(
-                "── estimated ──",
-                Style::default().fg(Color::DarkGray),
-            )));
+            lines.push(Line::from(Span::styled("── estimated ──", dim)));
             if est.star == Some(true) {
                 lines.push(Line::from(vec![
-                    Span::styled("★ ", Style::default().fg(Color::Yellow)),
-                    Span::raw("star"),
+                    Span::styled("★ ", Style::default().fg(p.warn)),
+                    Span::styled("star", text),
                 ]));
             }
             let pmin = est.planet_count_min.unwrap_or(0);
             let pmax = est.planet_count_max.unwrap_or(0);
             if pmax > 0 {
                 lines.push(Line::from(vec![
-                    Span::styled("● ", Style::default().fg(Color::Cyan)),
-                    Span::raw(if pmin == pmax {
-                        format!("{pmin} planet(s)")
-                    } else {
-                        format!("{pmin}–{pmax} planet(s)")
-                    }),
+                    Span::styled("● ", Style::default().fg(p.accent)),
+                    Span::styled(
+                        if pmin == pmax {
+                            format!("{pmin} planet(s)")
+                        } else {
+                            format!("{pmin}–{pmax} planet(s)")
+                        },
+                        text,
+                    ),
                 ]));
             }
             if let Some(bh) = est.black_hole_probability {
                 if bh > 0.0 {
                     lines.push(Line::from(vec![
-                        Span::styled("◉ ", Style::default().fg(Color::Magenta)),
-                        Span::raw(format!("black hole {:.0}%", bh * 100.0)),
+                        Span::styled("◉ ", Style::default().fg(p.crit)),
+                        Span::styled(format!("black hole {:.0}%", bh * 100.0), text),
                     ]));
                 }
             }
             if let Some(danger) = &est.danger_estimate {
                 let (label, color) = match danger {
-                    DangerLevel::Low => ("low", Color::Green),
-                    DangerLevel::Moderate => ("moderate", Color::Yellow),
-                    DangerLevel::Extreme => ("extreme", Color::Red),
-                    DangerLevel::Unknown => ("?", Color::DarkGray),
+                    DangerLevel::Low => ("low", p.good),
+                    DangerLevel::Moderate => ("moderate", p.warn),
+                    DangerLevel::Extreme => ("extreme", p.crit),
+                    DangerLevel::Unknown => ("?", p.dim),
                 };
                 lines.push(Line::from(vec![
-                    Span::styled("danger  ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("danger  ", dim),
                     Span::styled(label, Style::default().fg(color)),
-                ]));
-            }
-            if let Some(age) = &est.signal_age {
-                lines.push(Line::from(vec![
-                    Span::styled("signal  ", Style::default().fg(Color::DarkGray)),
-                    Span::raw(age.as_str()),
                 ]));
             }
         }
@@ -308,75 +255,59 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
     );
 }
 
-pub(crate) fn sector_interest_color(s: &crate::api::types::SectorObservation) -> Color {
+/// Palette-aware interest colour for a scanned sector (drives the history list
+/// and the neighbor map).
+pub(crate) fn sector_interest_color(s: &crate::api::types::SectorObservation, p: Palette) -> ratatui::style::Color {
     use crate::api::types::{DangerLevel, KnowledgeLevel, SectorObjectType};
 
-    // Known objects present
     if let Some(objects) = &s.objects {
         if !objects.is_empty() {
-            let has_star = objects.iter().any(|o| {
-                matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem)
-            });
-            let has_blackhole = objects
+            let has_star = objects
                 .iter()
-                .any(|o| matches!(o.object_type, SectorObjectType::BlackHole));
-            let has_extreme = objects
-                .iter()
-                .any(|o| matches!(o.danger_level, Some(DangerLevel::Extreme)));
+                .any(|o| matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem));
+            let has_blackhole = objects.iter().any(|o| matches!(o.object_type, SectorObjectType::BlackHole));
+            let has_extreme = objects.iter().any(|o| matches!(o.danger_level, Some(DangerLevel::Extreme)));
             if has_extreme || has_blackhole {
-                return Color::Red;
+                return p.crit;
             }
             if has_star {
-                return Color::Yellow;
+                return p.warn;
             }
-            return Color::Green;
+            return p.good;
         }
     }
 
-    // Estimated objects from neighbor scan
     if let Some(est) = &s.estimated_objects {
         if matches!(est.danger_estimate, Some(DangerLevel::Extreme)) {
-            return Color::Red;
+            return p.crit;
         }
         if est.black_hole_probability.unwrap_or(0.0) > 0.5 {
-            return Color::Magenta;
+            return p.crit;
         }
         if est.star == Some(true) {
-            return Color::Yellow;
+            return p.warn;
         }
         if est.planet_count_max.unwrap_or(0) > 0 {
-            return Color::Cyan;
+            return p.accent;
         }
     }
 
-    if s.possible_objects.as_ref().is_some_and(|p| !p.is_empty()) {
-        return Color::Cyan;
+    if s.possible_objects.as_ref().is_some_and(|o| !o.is_empty()) {
+        return p.accent;
     }
-
     if s.knowledge_level == KnowledgeLevel::Detailed {
-        return Color::White;
+        return p.text;
     }
-
-    Color::DarkGray
+    p.dim
 }
 
-pub(crate) fn obj_sel_prefix(browsing: bool, selected: bool) -> Option<Span<'static>> {
-    if !browsing {
-        return None;
-    }
-    Some(if selected {
-        Span::styled("▶ ", Style::default().fg(Color::Yellow))
-    } else {
-        Span::raw("  ")
-    })
-}
-
-pub(crate) fn sector_object_lines<'a>(
-    obj: &'a SectorObject,
-    browsing: bool,
-    selected_id: Option<&str>,
-) -> Vec<Line<'a>> {
-    let (icon, color) = object_icon(&obj.object_type);
+/// Lines for one scanned object. `compact` drops the scientific detail
+/// (mass / radius / uid and nested-body dimensions) shown only in the zoom view.
+pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: Palette) -> Vec<Line<'a>> {
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
+    let glyph = object_icon(&obj.object_type).0;
+    let color = object_color(&obj.object_type, p);
     let estimated = if obj.estimated.unwrap_or(false) { "~ " } else { "" };
     let name = obj.name.as_deref().unwrap_or("unnamed");
     let danger = obj
@@ -390,165 +321,122 @@ pub(crate) fn sector_object_lines<'a>(
         .unwrap_or("");
 
     let manny_state = obj.manny_state.as_deref().unwrap_or("");
-
     let salvageable = obj.salvageable.unwrap_or(false);
 
-    let main_selected = browsing && obj.id.is_some() && obj.id.as_deref() == selected_id;
-    let name_style = if main_selected {
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-    };
-    let mut main_spans: Vec<Span> = Vec::new();
-    if let Some(prefix) = obj_sel_prefix(browsing, main_selected) {
-        main_spans.push(prefix);
-    }
-    main_spans.extend([
-        Span::styled(icon, Style::default().fg(color)),
+    let mut main_spans: Vec<Span> = vec![
+        Span::styled(glyph, Style::default().fg(color)),
         Span::raw(" "),
-        Span::styled(estimated, Style::default().fg(Color::DarkGray)),
-        Span::styled(format!("{name}{danger}"), name_style),
-    ]);
+        Span::styled(estimated, dim),
+        Span::styled(format!("{name}{danger}"), text),
+    ];
     if salvageable {
-        main_spans.push(Span::styled("  ⬡ salvageable", Style::default().fg(Color::Yellow)));
+        main_spans.push(Span::styled("  ⬡ salvageable", Style::default().fg(p.warn)));
     }
     if !manny_state.is_empty() {
-        main_spans.push(Span::styled(
-            format!("  [{manny_state}]"),
-            Style::default().fg(Color::DarkGray),
-        ));
+        main_spans.push(Span::styled(format!("  [{manny_state}]"), dim));
     }
-    // drifting item: show type + quantity instead of summary
     if obj.object_type == SectorObjectType::DriftingItem {
         if let (Some(itype), Some(qty)) = (&obj.item_type, obj.quantity) {
-            main_spans.push(Span::styled(
-                format!("  {itype} × {qty}"),
-                Style::default().fg(Color::DarkGray),
-            ));
+            main_spans.push(Span::styled(format!("  {itype} × {qty}"), dim));
         }
     } else if obj.object_type == SectorObjectType::DetachedContainer {
         if let Some(cap) = obj.capacity {
             let mode = obj.mode.as_deref().unwrap_or("drifting");
-            main_spans.push(Span::styled(
-                format!("  {mode}  {cap:.2} ECE"),
-                Style::default().fg(Color::DarkGray),
-            ));
+            main_spans.push(Span::styled(format!("  {mode}  {cap:.2} ECE"), dim));
         }
     } else if let Some(summary) = &obj.summary {
         if !matches!(obj.object_type, SectorObjectType::SolarSystem) || obj.bookmark_targets.is_empty() {
-            main_spans.push(Span::styled(
-                format!("  {summary}"),
-                Style::default().fg(Color::DarkGray),
-            ));
+            main_spans.push(Span::styled(format!("  {summary}"), dim));
         }
     }
 
     let mut lines = vec![Line::from(main_spans)];
 
-    let skip_dimensions = matches!(obj.object_type, SectorObjectType::SolarSystem);
-    let has_mass = obj.mass.is_some() && !skip_dimensions;
-    let has_radius = obj.radius.is_some() && !skip_dimensions;
-    let has_uid = obj.manny_uid.is_some();
-    if has_mass || has_radius || has_uid {
-        let mut detail_spans = vec![Span::raw("  ")];
-        if let Some(m) = obj.mass {
-            detail_spans.push(Span::styled("mass ", Style::default().fg(Color::DarkGray)));
-            detail_spans.push(Span::styled(
-                format!("{m:.3e}"),
-                Style::default().fg(Color::White),
-            ));
-            if has_radius { detail_spans.push(Span::raw("  ")); }
+    // Scientific detail — zoom only.
+    if !compact {
+        let skip_dimensions = matches!(obj.object_type, SectorObjectType::SolarSystem);
+        let has_mass = obj.mass.is_some() && !skip_dimensions;
+        let has_radius = obj.radius.is_some() && !skip_dimensions;
+        let has_uid = obj.manny_uid.is_some();
+        if has_mass || has_radius || has_uid {
+            let mut detail_spans = vec![Span::raw("  ")];
+            if let Some(m) = obj.mass {
+                detail_spans.push(Span::styled("mass ", dim));
+                detail_spans.push(Span::styled(format!("{m:.3e}"), text));
+                if has_radius {
+                    detail_spans.push(Span::raw("  "));
+                }
+            }
+            if let Some(r) = obj.radius {
+                detail_spans.push(Span::styled("radius ", dim));
+                detail_spans.push(Span::styled(format!("{r:.3e}"), text));
+            }
+            if let Some(uid) = &obj.manny_uid {
+                if has_mass || has_radius {
+                    detail_spans.push(Span::raw("  "));
+                }
+                detail_spans.push(Span::styled("uid ", dim));
+                detail_spans.push(Span::styled(uid.as_str(), text));
+            }
+            lines.push(Line::from(detail_spans));
         }
-        if let Some(r) = obj.radius {
-            detail_spans.push(Span::styled("radius ", Style::default().fg(Color::DarkGray)));
-            detail_spans.push(Span::styled(
-                format!("{r:.3e}"),
-                Style::default().fg(Color::White),
-            ));
-        }
-        if let Some(uid) = &obj.manny_uid {
-            if has_mass || has_radius { detail_spans.push(Span::raw("  ")); }
-            detail_spans.push(Span::styled("uid ", Style::default().fg(Color::DarkGray)));
-            detail_spans.push(Span::styled(uid.as_str(), Style::default().fg(Color::White)));
-        }
-        lines.push(Line::from(detail_spans));
     }
 
-    // Minable asteroid targets with resource types
+    // Minable asteroid targets with resource types (kept in both views —
+    // that's the actionable payoff of a scan).
     if let Some(targets) = &obj.minable_targets {
         for target in targets {
-            let (icon, color) = object_icon(&target.object_type);
+            let tglyph = object_icon(&target.object_type).0;
+            let tcolor = object_color(&target.object_type, p);
             let name = target.name.as_deref().unwrap_or("unnamed");
-            let selected = browsing && selected_id == Some(target.id.as_str());
-            let target_style = if selected {
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
-            };
-            let mut spans: Vec<Span> = Vec::new();
-            if let Some(prefix) = obj_sel_prefix(browsing, selected) {
-                spans.push(prefix);
-            }
-            spans.extend([
-                Span::styled("  ", Style::default().fg(Color::DarkGray)),
-                Span::styled(icon, Style::default().fg(color)),
+            let mut spans: Vec<Span> = vec![
+                Span::raw("  "),
+                Span::styled(tglyph, Style::default().fg(tcolor)),
                 Span::raw(" "),
-                Span::styled(name.to_string(), target_style),
-            ]);
+                Span::styled(name.to_string(), text),
+            ];
             if let Some(resources) = &target.resource_types {
-                let res_str = resources.iter().map(|r| match r.as_str() {
-                    "metals" => "metals",
-                    "ice" => "ice",
-                    "carbon_compounds" => "carbon",
-                    other => other,
-                }).collect::<Vec<_>>().join("  ");
+                let res_str = resources
+                    .iter()
+                    .map(|r| match r.as_str() {
+                        "carbon_compounds" => "carbon",
+                        other => other,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("  ");
                 if !res_str.is_empty() {
-                    spans.push(Span::styled(
-                        format!("  {res_str}"),
-                        Style::default().fg(Color::Yellow),
-                    ));
+                    spans.push(Span::styled(format!("  {res_str}"), Style::default().fg(p.warn)));
                 }
             }
             lines.push(Line::from(spans));
         }
     }
 
-    // Nested bodies of a solar system
+    // Nested bodies of a solar system.
     for target in &obj.bookmark_targets {
-        let (icon, color) = object_icon(&target.object_type);
+        let tglyph = object_icon(&target.object_type).0;
+        let tcolor = object_color(&target.object_type, p);
         let name = target.name.as_deref().unwrap_or("unnamed");
-        let selected = browsing && selected_id == Some(target.id.as_str());
-        let target_style = if selected {
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
-        } else {
-            Style::default()
-        };
-        let mut spans: Vec<Span> = Vec::new();
-        if let Some(prefix) = obj_sel_prefix(browsing, selected) {
-            spans.push(prefix);
-        }
-        spans.extend([
-            Span::styled("  ", Style::default().fg(Color::DarkGray)),
-            Span::styled(icon, Style::default().fg(color)),
+        let mut spans: Vec<Span> = vec![
+            Span::raw("  "),
+            Span::styled(tglyph, Style::default().fg(tcolor)),
             Span::raw(" "),
-            Span::styled(name.to_string(), target_style),
-        ]);
-        let mut extras: Vec<String> = Vec::new();
-        if let Some(m) = target.mass {
-            extras.push(format!("{m:.3e} {}", target.mass_unit.as_deref().unwrap_or("")));
-        }
-        if let Some(r) = target.radius {
-            extras.push(format!("r {r:.3e} {}", target.radius_unit.as_deref().unwrap_or("")));
-        }
-        if !extras.is_empty() {
-            spans.push(Span::styled(
-                format!("  {}", extras.join("  ")),
-                Style::default().fg(Color::DarkGray),
-            ));
+            Span::styled(name.to_string(), text),
+        ];
+        if !compact {
+            let mut extras: Vec<String> = Vec::new();
+            if let Some(m) = target.mass {
+                extras.push(format!("{m:.3e} {}", target.mass_unit.as_deref().unwrap_or("")));
+            }
+            if let Some(r) = target.radius {
+                extras.push(format!("r {r:.3e} {}", target.radius_unit.as_deref().unwrap_or("")));
+            }
+            if !extras.is_empty() {
+                spans.push(Span::styled(format!("  {}", extras.join("  ")), dim));
+            }
         }
         lines.push(Line::from(spans));
     }
 
     lines
 }
-

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,6 +1,5 @@
 use crate::api::types::{
-    DangerLevel, DataFreshness, KnowledgeLevel,
-    MovementPhase, ProbeStatus, SectorObjectType, SectorObservation, SensorMode,
+    DangerLevel, KnowledgeLevel, MovementPhase, ProbeStatus, SectorObjectType, SectorObservation,
 };
 use crate::app::ColorMode;
 use ratatui::{
@@ -110,6 +109,27 @@ pub(crate) fn map_cell_symbol(s: &SectorObservation) -> (&'static str, Style) {
     ("·", Style::default().fg(Color::White))
 }
 
+/// Palette-aware version of [`map_cell_symbol`] for the phosphor cockpit.
+pub(crate) fn map_cell_style(s: &SectorObservation, p: Palette) -> (&'static str, Style) {
+    if let Some(objects) = &s.objects {
+        for obj in objects {
+            if matches!(obj.object_type, SectorObjectType::BlackHole) {
+                return ("◉", Style::default().fg(p.crit));
+            }
+            if matches!(obj.danger_level, Some(DangerLevel::Extreme)) {
+                return ("!", Style::default().fg(p.crit));
+            }
+            if matches!(obj.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem) {
+                let has_minable = obj.minable_targets.as_ref().is_some_and(|t| !t.is_empty());
+                let style = Style::default().fg(p.warn);
+                return ("★", if has_minable { style.add_modifier(Modifier::BOLD) } else { style });
+            }
+        }
+        return ("●", Style::default().fg(p.good));
+    }
+    ("·", Style::default().fg(p.dim))
+}
+
 /// Short content summary of a scanned sector for the map info line.
 pub(crate) fn item_icon(item_type: &str) -> (&'static str, Color) {
     match item_type {
@@ -133,33 +153,29 @@ pub(crate) fn knowledge_label(k: &KnowledgeLevel) -> &'static str {
     }
 }
 
-pub(crate) fn knowledge_color(k: &KnowledgeLevel) -> Color {
+pub(crate) fn knowledge_color(k: &KnowledgeLevel, p: Palette) -> Color {
     match k {
-        KnowledgeLevel::Detailed => Color::Green,
-        KnowledgeLevel::NeighborScan => Color::Cyan,
-        KnowledgeLevel::DistantScan => Color::Yellow,
-        KnowledgeLevel::LongRangeEstimation => Color::Red,
-        KnowledgeLevel::Unknown => Color::DarkGray,
+        KnowledgeLevel::Detailed => p.good,
+        KnowledgeLevel::NeighborScan => p.accent,
+        KnowledgeLevel::DistantScan => p.warn,
+        KnowledgeLevel::LongRangeEstimation => p.crit,
+        KnowledgeLevel::Unknown => p.dim,
     }
 }
 
-pub(crate) fn freshness_label(f: &DataFreshness) -> &'static str {
-    match f {
-        DataFreshness::Live => "live",
-        DataFreshness::DegradedLive => "degraded live",
-        DataFreshness::Historical => "historical",
-        DataFreshness::Unavailable => "unavailable",
-        DataFreshness::Unknown => "?",
-    }
-}
-
-pub(crate) fn freshness_color(f: &DataFreshness) -> Color {
-    match f {
-        DataFreshness::Live => Color::Green,
-        DataFreshness::DegradedLive => Color::Yellow,
-        DataFreshness::Historical => Color::DarkGray,
-        DataFreshness::Unavailable => Color::Red,
-        DataFreshness::Unknown => Color::DarkGray,
+/// Palette-aware colour for a scanned object's type. The glyph still comes from
+/// [`object_icon`]; this maps the *meaning* onto the active palette so mono
+/// modes stay single-hue and semantic modes get green/yellow/red.
+pub(crate) fn object_color(t: &SectorObjectType, p: Palette) -> Color {
+    match t {
+        SectorObjectType::Star | SectorObjectType::SolarSystem => p.warn,
+        SectorObjectType::Planet => p.accent,
+        SectorObjectType::Asteroid | SectorObjectType::DriftingItem => p.text,
+        SectorObjectType::DustCloud => p.dim,
+        SectorObjectType::BlackHole => p.crit,
+        SectorObjectType::Manny | SectorObjectType::DeuteriumRefuelStation => p.good,
+        SectorObjectType::DetachedContainer | SectorObjectType::ScutRelay => p.accent,
+        SectorObjectType::Unknown => p.dim,
     }
 }
 
@@ -208,22 +224,6 @@ pub(crate) fn probe_status_style(s: &ProbeStatus) -> Style {
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
         }
         ProbeStatus::Unknown => Style::default().fg(Color::DarkGray),
-    }
-}
-
-pub(crate) fn sensor_dot(m: &SensorMode) -> &'static str {
-    match m {
-        SensorMode::Normal | SensorMode::Degraded | SensorMode::Blind | SensorMode::Unknown => "●",
-    }
-}
-
-
-pub(crate) fn sensor_style(m: &SensorMode) -> Style {
-    match m {
-        SensorMode::Normal => Style::default().fg(Color::Green),
-        SensorMode::Degraded => Style::default().fg(Color::Yellow),
-        SensorMode::Blind => Style::default().fg(Color::Red),
-        SensorMode::Unknown => Style::default().fg(Color::DarkGray),
     }
 }
 
@@ -282,19 +282,6 @@ pub(crate) fn gauge_color(ratio: f64) -> Color {
         Color::Yellow
     } else {
         Color::Red
-    }
-}
-
-/// Compact human age: "just now", "5m ago", "3h ago", "2d ago".
-pub fn format_age(secs: i64) -> String {
-    if secs < 60 {
-        "just now".to_string()
-    } else if secs < 3600 {
-        format!("{}m ago", secs / 60)
-    } else if secs < 86400 {
-        format!("{}h ago", secs / 3600)
-    } else {
-        format!("{}d ago", secs / 86400)
     }
 }
 


### PR DESCRIPTION
Makes the scanner pane a real cartography station, with a clean role split from the SECTOR (current-sector detail) and MAP (spatial + travel) panes.

## Actions (Enter → contextual menu)
- **Scan around (neighbors)** — instant batch of the 12 distance-1 neighbors (`neighbors_d1`)
- **Scan a direction (×2)…** — pick an axis X/Y/Z → both faces at distance 2 (`face_d2`)
- **Observe coordinates…** — arbitrary relative `x y z` → `GET /api/sector`
- **Cycle filter** — all → objects → minable → danger

## Views
- **Compact** — history (known sectors) always left; detail = selected observation. Decluttered: dropped sensors (lives in PROBE), scan quality, scanned-age, residence, message, and mass/radius/uid science. Current sector redirects to the SECTOR pane instead of duplicating it.
- **Zoom** — neighbor mini-map: the six adjacent sectors coloured by interest + a legend.

## Theme
- The whole pane and the neighbor map are now **palette-aware** (new `theme::object_color` / `map_cell_style`, palette arg on `knowledge_color`) — matches the phosphor cockpit in every color mode. Dropped the dead `freshness_*` / `sensor_*` / `format_age` helpers.

The `ScanMode::Input`/`DirectionPick` key routers already existed; this adds the launchers + `overlays/scanner.rs` for the prompts.

169 tests green, clippy clean.