### PR TITLE
feat(cockpit): live tick + periodic sync indicator

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -199,6 +199,11 @@ pub struct Manny {
     /// remote/too-far mannies expose an empty payload.
     #[serde(default)]
     pub task: Option<serde_json::Value>,
+    /// Client-side receipt timestamp (not an API field), stamped on
+    /// `update_mannies`. Lets the UI interpolate `task_progress_percent`
+    /// against `task_estimated_end_time` so progress ticks between fetches.
+    #[serde(default)]
+    pub observed_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -281,6 +281,20 @@ impl AppState {
         Some((rel.x.round() as i32, rel.y.round() as i32, rel.z.round() as i32))
     }
 
+    /// Seconds since the last successful full sync (probe update), if any.
+    /// `last_update` is reset on every `update_probe`, so any refresh — manual,
+    /// event-driven, or periodic — restarts the clock.
+    pub fn seconds_since_sync(&self) -> Option<i64> {
+        self.last_update.map(|t| (Local::now() - t).num_seconds().max(0))
+    }
+
+    /// Whether a periodic auto-refresh is due: idle and ≥60 s since the last
+    /// sync. Requires a prior successful sync, so a failed initial fetch does
+    /// not spin-retry every tick.
+    pub fn periodic_refresh_due(&self) -> bool {
+        !self.loading && matches!(self.seconds_since_sync(), Some(s) if s >= 60)
+    }
+
     pub fn next_refresh_instant(&self) -> Instant {
         match self.movement_arrival {
             Some(arrival) => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -146,7 +146,13 @@ impl AppState {
         self.clamp_inventory_selection();
     }
 
-    pub fn update_mannies(&mut self, mannies: Vec<Manny>) {
+    pub fn update_mannies(&mut self, mut mannies: Vec<Manny>) {
+        // Stamp receipt time so the UI can interpolate task progress between
+        // fetches (server sends a snapshot % + an estimated end time).
+        let now = Utc::now();
+        for m in &mut mannies {
+            m.observed_at = Some(now);
+        }
         // Clamp selection in case list shrank.
         if !mannies.is_empty() {
             self.mannies_selection = self.mannies_selection.min(mannies.len() - 1);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1420,3 +1420,36 @@ fn periodic_refresh_not_due_when_recent_or_loading() {
     state.loading = true;
     assert!(!state.periodic_refresh_due(), "a fetch already in flight");
 }
+
+// ── manny task progress interpolation ─────────────────────────────────────
+
+#[test]
+fn manny_task_progress_falls_back_to_snapshot_without_timestamps() {
+    use crate::ui::panels::mannies::manny_task_progress;
+    let mut m = make_manny("m1", "probe", false, Some("mining"));
+    m.task_progress_percent = 42.0; // no observed_at / end → static
+    assert!((manny_task_progress(&m) - 0.42).abs() < 1e-9);
+}
+
+#[test]
+fn manny_task_progress_interpolates_forward_between_fetches() {
+    use crate::ui::panels::mannies::manny_task_progress;
+    let mut m = make_manny("m1", "sector", false, Some("mining"));
+    // Snapshot: 20% when observed 30 s ago, 30 s left → total 75 s, now ~60%.
+    m.task_progress_percent = 20.0;
+    m.observed_at = Some(chrono::Utc::now() - chrono::Duration::seconds(30));
+    m.task_estimated_end_time = Some(chrono::Utc::now() + chrono::Duration::seconds(30));
+    let prog = manny_task_progress(&m);
+    assert!(prog > 0.20, "progress advanced past the snapshot: {prog}");
+    assert!(prog < 1.0, "not complete yet: {prog}");
+}
+
+#[test]
+fn manny_task_progress_complete_when_past_end() {
+    use crate::ui::panels::mannies::manny_task_progress;
+    let mut m = make_manny("m1", "sector", false, Some("mining"));
+    m.task_progress_percent = 80.0;
+    m.observed_at = Some(chrono::Utc::now() - chrono::Duration::seconds(120));
+    m.task_estimated_end_time = Some(chrono::Utc::now() - chrono::Duration::seconds(10));
+    assert_eq!(manny_task_progress(&m), 1.0);
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1388,3 +1388,35 @@ fn inventory_context_menu_present_but_disabled_when_empty() {
     // Nothing loaded → every action disabled with a reason.
     assert!(menu.items.iter().all(|i| !i.enabled && i.disabled_reason.is_some()));
 }
+
+// ── periodic auto-refresh gating ──────────────────────────────────────────
+
+#[test]
+fn seconds_since_sync_none_before_first_sync() {
+    let state = AppState::default();
+    assert_eq!(state.seconds_since_sync(), None);
+}
+
+#[test]
+fn periodic_refresh_not_due_without_prior_sync() {
+    // Never synced → not due (avoids spin-retry on a failed initial fetch).
+    let state = AppState::default();
+    assert!(!state.periodic_refresh_due());
+}
+
+#[test]
+fn periodic_refresh_due_after_60s_when_idle() {
+    let mut state = AppState::default();
+    state.last_update = Some(chrono::Local::now() - chrono::Duration::seconds(90));
+    assert!(state.periodic_refresh_due());
+}
+
+#[test]
+fn periodic_refresh_not_due_when_recent_or_loading() {
+    let mut state = AppState::default();
+    state.last_update = Some(chrono::Local::now() - chrono::Duration::seconds(10));
+    assert!(!state.periodic_refresh_due(), "10s is within the 60s window");
+    state.last_update = Some(chrono::Local::now() - chrono::Duration::seconds(90));
+    state.loading = true;
+    assert!(!state.periodic_refresh_due(), "a fetch already in flight");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,12 @@ async fn run(
     let mut boot_tick = tokio::time::interval(std::time::Duration::from_millis(90));
     boot_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    // Steady-state 1 s tick: redraws so time-derived values (progress bars,
+    // percentages, ETAs, sync age) advance live, and triggers the periodic
+    // ≤60 s auto-refresh when one is due.
+    let mut ui_tick = tokio::time::interval(std::time::Duration::from_secs(1));
+    ui_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     // Initial data fetch
     fetch_all(client.clone(), tx.clone());
     fetch_api_version(client.clone(), tx.clone());
@@ -93,6 +99,15 @@ async fn run(
 
             _ = boot_tick.tick(), if state.booting => {
                 state.boot_tick();
+            }
+
+            _ = ui_tick.tick() => {
+                // The redraw at the loop top makes live values tick; here we
+                // only fire the periodic refresh when it is due.
+                if !state.booting && state.periodic_refresh_due() {
+                    fetch_all(client.clone(), tx.clone());
+                    state.loading = true;
+                }
             }
 
             Some(msg) = rx.recv() => {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -234,8 +234,13 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
     }
 
     let mut meta = Vec::new();
+    // Sync status: spinner while a refresh is in flight, else the age since the
+    // last successful sync (ticks live via the 1 s UI tick).
     if state.loading {
-        meta.push(("⟳".to_string(), p.accent));
+        meta.push(("⟳ sync".to_string(), p.accent));
+    } else if let Some(age) = state.seconds_since_sync() {
+        let label = if age < 60 { format!("⟳ {age}s") } else { format!("⟳ {}m", age / 60) };
+        meta.push((label, p.dim));
     }
     if !state.scut_coverage().is_empty() {
         meta.push(("≣ SCUT".to_string(), p.accent));

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -252,9 +252,9 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
     if let Some(v) = state.api_version {
         meta.push((format!("API v{v}"), p.dim));
     }
-    if let Some(t) = state.last_update {
-        meta.push((t.format("%H:%M:%S").to_string(), p.dim));
-    }
+    // Live wall clock — ticks every second via the 1 s UI tick. (Sync recency
+    // lives in the ⟳ indicator above, so this is a real clock, not last-sync.)
+    meta.push((chrono::Local::now().format("%H:%M:%S").to_string(), p.dim));
     let meta_len: usize = meta.iter().map(|(s, _)| s.chars().count() + 3).sum();
     let meta_spans: Vec<Span> = meta
         .iter()

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -8,7 +8,9 @@
 
 use crate::api::types::{Manny, MannyLocationType, MannyTaskVisibility, MissionStatus, MissionStepStatus};
 use crate::app::{AppState, DrillLevel, Pane};
-use crate::ui::panels::mannies::{manny_mining_detail, manny_task_eta, manny_task_label};
+use crate::ui::panels::mannies::{
+    manny_mining_detail, manny_task_eta, manny_task_label, manny_task_progress,
+};
 use crate::ui::theme::{block_gauge_line, object_icon, pane_block, Palette};
 use ratatui::{
     layout::Rect,
@@ -362,7 +364,7 @@ fn manny_detail_lines(state: &AppState, m: &Manny, p: Palette) -> Vec<Line<'stat
     if task.is_some() {
         lines.push(Line::from(vec![
             Span::styled(manny_task_label(task), Style::default().fg(p.accent)),
-            Span::styled(format!("  {:.0}%", m.task_progress_percent), text),
+            Span::styled(format!("  {:.0}%", manny_task_progress(m) * 100.0), text),
         ]));
         if let Some(eta) = manny_task_eta(m) {
             lines.push(Line::from(vec![Span::styled("ETA ", dim), Span::styled(eta, text)]));
@@ -463,7 +465,7 @@ pub fn render_mannies_overview(frame: &mut Frame, area: Rect, state: &AppState, 
             Span::styled(manny_task_label(task), if task.is_none() { sec } else { name_style }),
         ];
         if m.current_task.is_some() {
-            header.push(Span::styled(format!(" {:.0}%", m.task_progress_percent), sec));
+            header.push(Span::styled(format!(" {:.0}%", manny_task_progress(m) * 100.0), sec));
             if let Some(eta) = manny_task_eta(m) {
                 header.push(Span::styled(format!(" · {eta}"), sec));
             }

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -121,6 +121,26 @@ pub(crate) fn manny_task_eta(m: &Manny) -> Option<String> {
         .map(|end| format_duration((end - Utc::now()).num_seconds().max(0)))
 }
 
+/// Task progress in 0..=1, interpolated client-side so it ticks between
+/// fetches. The server sends a snapshot `task_progress_percent` at
+/// `observed_at` plus an estimated end time; assuming a linear task we rebuild
+/// the timeline and advance progress with the wall clock. Falls back to the
+/// raw snapshot when timestamps are missing, and never runs backward from it.
+pub(crate) fn manny_task_progress(m: &Manny) -> f64 {
+    let p0 = (m.task_progress_percent / 100.0).clamp(0.0, 1.0);
+    let (Some(obs), Some(end)) = (m.observed_at, m.task_estimated_end_time) else {
+        return p0;
+    };
+    let remaining_at_obs = (end - obs).num_seconds() as f64;
+    if remaining_at_obs <= 0.0 || p0 >= 1.0 {
+        // Overdue or already complete at the snapshot.
+        return if end <= Utc::now() { 1.0 } else { p0 };
+    }
+    let total = remaining_at_obs / (1.0 - p0);
+    let remaining_now = (end - Utc::now()).num_seconds() as f64;
+    (1.0 - remaining_now / total).clamp(p0, 1.0)
+}
+
 pub(crate) fn manny_list_item(m: &Manny, selected: bool, p: Palette) -> ListItem<'_> {
     // On the selected row everything is accent so the ETA/% stay legible;
     // otherwise the palette's text for the name/task and dim for the rest.
@@ -144,7 +164,7 @@ pub(crate) fn manny_list_item(m: &Manny, selected: bool, p: Palette) -> ListItem
     let task_style = if task.is_none() { secondary } else { primary };
 
     let progress = if m.current_task.is_some() {
-        format!(" {:3.0}%", m.task_progress_percent)
+        format!(" {:3.0}%", manny_task_progress(m) * 100.0)
     } else {
         String::new()
     };


### PR DESCRIPTION
Adds a shared refresh behaviour across the whole cockpit.

## Live tick
A steady-state 1 s UI tick redraws so time-derived values — progress bars, percentages, ETAs, ages — advance continuously, not only on the next keypress/event.

## Periodic sync (≤60 s) + event-driven
When idle and ≥60 s since the last sync, the tick fires `fetch_all`. Event-driven refetches (pane actions) and the movement-arrival refresh already handle the rest. `last_update` gates the 60 s window and is reset by any sync, so we never poll more often than needed. A failed initial fetch does not spin-retry (requires a prior successful sync).

## Status bar
Bottom-right shows the sync state: `⟳ sync` while a refresh is in flight, else `⟳ Ns` — age since the last successful sync, ticking live.

New `AppState::seconds_since_sync()` / `periodic_refresh_due()`, unit-tested. 173 tests green, clippy clean.