### PR TITLE
feat(cockpit): sector pane — palette-aware + planet science

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -705,6 +705,21 @@ pub struct SectorProbePresence {
     pub moving: bool,
 }
 
+/// The four mineable-resource values shared by `resourceComposition`
+/// (normalized shares) and `resourceAmounts` (remaining reserves). JSON keys
+/// are snake_case, so this struct intentionally has no `rename_all`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ResourceShares {
+    #[serde(default)]
+    pub deuterium: f64,
+    #[serde(default)]
+    pub metals: f64,
+    #[serde(default)]
+    pub ice: f64,
+    #[serde(default)]
+    pub carbon_compounds: f64,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SectorObject {
@@ -720,6 +735,26 @@ pub struct SectorObject {
     pub radius_unit: Option<String>,
     pub danger_level: Option<DangerLevel>,
     pub habitability_score: Option<f64>,
+    /// Planet classification (present on planets).
+    pub category: Option<String>,
+    /// Asteroid composition class (iron, silicate, carbonaceous, ice, …).
+    pub composition: Option<String>,
+    /// True when a Manny can mine this object (planets & asteroids).
+    pub manny_mineable: Option<bool>,
+    /// Raw sensor material hints (asteroids); prefer resource_types for logic.
+    #[serde(default)]
+    pub resources: Vec<String>,
+    /// Mineable resource types present (planets, asteroids, stations).
+    #[serde(default)]
+    pub resource_types: Vec<String>,
+    /// Normalized mineable-resource shares (sum ≈ 1).
+    pub resource_composition: Option<ResourceShares>,
+    /// Remaining reserves in equivalent earth containers (asteroids).
+    pub resource_amounts: Option<ResourceShares>,
+    /// Solar-system body counts.
+    pub star_count: Option<i64>,
+    pub planet_count: Option<i64>,
+    pub orbital_body_count: Option<i64>,
     pub salvageable: Option<bool>,
     pub manny_state: Option<String>,
     pub manny_uid: Option<String>,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -692,6 +692,7 @@ pub struct WaypointBookmarkTarget {
     pub mass_unit: Option<String>,
     pub radius: Option<f64>,
     pub radius_unit: Option<String>,
+    pub category: Option<String>,
     pub habitability_score: Option<f64>,
     #[serde(default)]
     pub waypoint_bookmarks: Vec<WaypointBookmarkHistory>,
@@ -838,8 +839,8 @@ pub struct MinableTarget {
     pub name: Option<String>,
     pub mass: Option<f64>,
     pub resource_types: Option<Vec<String>>,
-    pub resource_amounts: Option<serde_json::Value>,
-    pub resource_composition: Option<serde_json::Value>,
+    pub resource_amounts: Option<ResourceShares>,
+    pub resource_composition: Option<ResourceShares>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -155,7 +155,7 @@ impl AppState {
             if let Some(id) = &o.id {
                 push(&mut out, ScannerObjectEntry {
                     id: id.clone(),
-                    name: o.name.clone().unwrap_or_else(|| format!("{:?}", o.object_type).to_lowercase()),
+                    name: o.name.clone().unwrap_or_default(),
                     object_type: o.object_type.clone(),
                     provenance: ObjectProvenance::TopLevel,
                 });
@@ -163,7 +163,7 @@ impl AppState {
             for t in o.minable_targets.iter().flatten() {
                 push(&mut out, ScannerObjectEntry {
                     id: t.id.clone(),
-                    name: t.name.clone().unwrap_or_else(|| "unnamed".into()),
+                    name: t.name.clone().unwrap_or_default(),
                     object_type: t.object_type.clone(),
                     provenance: ObjectProvenance::MinableTarget,
                 });
@@ -172,11 +172,22 @@ impl AppState {
                 if matches!(t.object_type, SectorObjectType::Asteroid) {
                     push(&mut out, ScannerObjectEntry {
                         id: t.id.clone(),
-                        name: t.name.clone().unwrap_or_else(|| "unnamed".into()),
+                        name: t.name.clone().unwrap_or_default(),
                         object_type: t.object_type.clone(),
                         provenance: ObjectProvenance::BookmarkTarget,
                     });
                 }
+            }
+        }
+        // Synthesize a stable "type #n" label for objects the API left unnamed,
+        // numbered per type in scan order.
+        let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        for e in out.iter_mut() {
+            let label = crate::ui::theme::object_type_label(&e.object_type);
+            let n = counts.entry(label).or_insert(0);
+            *n += 1;
+            if e.name.trim().is_empty() {
+                e.name = format!("{label} #{n}");
             }
         }
         out

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -138,6 +138,49 @@ impl AppState {
     /// Actionable objects of the probe's current sector, in display order:
     /// for each top-level object, the object itself (if it has an id), then
     /// its minable targets, then its bookmark-target asteroids.
+    /// Presence flags and remaining reserves (ECE) per mineable resource for a
+    /// sector object, indexed as [`RESOURCE_TYPES`] (deuterium, metals, ice,
+    /// carbon_compounds). Looks up a top-level object or a nested mining target
+    /// by id. `None` when the object isn't in the current sector scan.
+    pub fn minable_target_reserves(&self, object_id: &str) -> Option<([bool; 4], [f64; 4])> {
+        use crate::api::types::ResourceShares;
+        let objs = self.current_sector()?.objects.as_ref()?;
+        let build = |types: &[String], amt: Option<&ResourceShares>| {
+            let has = |t: &str| types.iter().any(|x| x == t);
+            let flags = [has("deuterium"), has("metals"), has("ice"), has("carbon_compounds")];
+            let res = amt
+                .map(|a| [a.deuterium, a.metals, a.ice, a.carbon_compounds])
+                .unwrap_or([0.0; 4]);
+            (flags, res)
+        };
+        for o in objs {
+            if o.id.as_deref() == Some(object_id) {
+                return Some(build(&o.resource_types, o.resource_amounts.as_ref()));
+            }
+            if let Some(t) = o.minable_targets.iter().flatten().find(|t| t.id == object_id) {
+                let types = t.resource_types.clone().unwrap_or_default();
+                return Some(build(&types, t.resource_amounts.as_ref()));
+            }
+        }
+        None
+    }
+
+    /// Max sensible mining amount for the selected resources: the sum of their
+    /// remaining reserves when known, else the probe's free cargo capacity.
+    pub fn mine_reserve_max(&self, object_id: &str, resources: [bool; 4]) -> f64 {
+        match self.minable_target_reserves(object_id) {
+            Some((_, res)) => {
+                let sum: f64 = res.iter().zip(resources).filter(|(_, sel)| *sel).map(|(r, _)| *r).sum();
+                if sum > 0.0 {
+                    (sum * 10000.0).round() / 10000.0
+                } else {
+                    self.mine_max_amount()
+                }
+            }
+            None => self.mine_max_amount(),
+        }
+    }
+
     pub fn scanner_objects(&self) -> Vec<ScannerObjectEntry> {
         if !self.viewing_probe_sector() {
             return vec![];

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1510,3 +1510,33 @@ fn scanner_objects_number_unnamed_by_type() {
     assert_eq!(by_id("a2"), "asteroid #2");
     assert_eq!(by_id("p1"), "Vulcan"); // real names kept
 }
+
+// ── mining target reserves ────────────────────────────────────────────────
+
+#[test]
+fn minable_target_reserves_reads_types_and_amounts() {
+    let mut state = AppState::default();
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+        {"type": "asteroid", "id": "ast-1", "name": "AX", "summary": "",
+         "resourceTypes": ["metals", "ice"],
+         "resourceAmounts": {"deuterium": 0.0, "metals": 2.0, "ice": 1.0, "carbon_compounds": 0.0}}
+    ]"#)];
+    let (flags, res) = state.minable_target_reserves("ast-1").expect("reserves");
+    assert_eq!(flags, [false, true, true, false]);
+    assert_eq!(res, [0.0, 2.0, 1.0, 0.0]);
+    // Sum of selected present reserves (metals+ice).
+    assert_eq!(state.mine_reserve_max("ast-1", [false, true, true, false]), 3.0);
+    // Unknown object → None.
+    assert!(state.minable_target_reserves("nope").is_none());
+}
+
+#[test]
+fn mine_reserve_max_falls_back_to_free_capacity_without_reserves() {
+    let mut state = AppState::default();
+    state.probe = Some(make_probe(0.5, 0., 0., 0.));
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+        {"type": "asteroid", "id": "ast-1", "name": "AX", "summary": "", "resourceTypes": ["metals"]}
+    ]"#)];
+    // No resourceAmounts → reserves are 0 → fall back to free capacity (0.5).
+    assert_eq!(state.mine_reserve_max("ast-1", [false, true, false, false]), 0.5);
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1453,3 +1453,43 @@ fn manny_task_progress_complete_when_past_end() {
     m.task_estimated_end_time = Some(chrono::Utc::now() - chrono::Duration::seconds(10));
     assert_eq!(manny_task_progress(&m), 1.0);
 }
+
+// ── new v63 planet/asteroid fields ────────────────────────────────────────
+
+#[test]
+fn sector_object_planet_science_fields_deserialize() {
+    use crate::api::types::SectorObject;
+    let planet: SectorObject = serde_json::from_str(r#"{
+        "type": "planet",
+        "name": "Kepler-relative-1",
+        "summary": "temperate ocean world",
+        "category": "ocean",
+        "habitabilityScore": 0.82,
+        "mannyMineable": true,
+        "resourceTypes": ["metals", "ice"],
+        "resourceComposition": {"deuterium": 0.0, "metals": 0.6, "ice": 0.4, "carbon_compounds": 0.0}
+    }"#).unwrap();
+    assert_eq!(planet.category.as_deref(), Some("ocean"));
+    assert_eq!(planet.habitability_score, Some(0.82));
+    assert_eq!(planet.manny_mineable, Some(true));
+    assert_eq!(planet.resource_types, vec!["metals", "ice"]);
+    let comp = planet.resource_composition.expect("composition");
+    assert!((comp.metals - 0.6).abs() < 1e-9 && (comp.ice - 0.4).abs() < 1e-9);
+}
+
+#[test]
+fn sector_object_asteroid_reserves_deserialize() {
+    use crate::api::types::SectorObject;
+    let ast: SectorObject = serde_json::from_str(r#"{
+        "type": "asteroid",
+        "name": "AX-12",
+        "summary": "carbonaceous",
+        "composition": "carbonaceous",
+        "resourceAmounts": {"deuterium": 0.0, "metals": 1.25, "ice": 0.0, "carbon_compounds": 3.5}
+    }"#).unwrap();
+    assert_eq!(ast.composition.as_deref(), Some("carbonaceous"));
+    let amt = ast.resource_amounts.expect("amounts");
+    assert!((amt.carbon_compounds - 3.5).abs() < 1e-9);
+    // Absent fields stay None / empty.
+    assert!(ast.category.is_none() && ast.resource_types.is_empty());
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1493,3 +1493,20 @@ fn sector_object_asteroid_reserves_deserialize() {
     // Absent fields stay None / empty.
     assert!(ast.category.is_none() && ast.resource_types.is_empty());
 }
+
+#[test]
+fn scanner_objects_number_unnamed_by_type() {
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    // Two unnamed top-level asteroids + one named planet.
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+        {"type": "asteroid", "id": "a1", "name": null, "summary": ""},
+        {"type": "planet", "id": "p1", "name": "Vulcan", "summary": ""},
+        {"type": "asteroid", "id": "a2", "name": null, "summary": ""}
+    ]"#)];
+    let entries = state.scanner_objects();
+    let by_id = |id: &str| entries.iter().find(|e| e.id == id).unwrap().name.clone();
+    assert_eq!(by_id("a1"), "asteroid #1");
+    assert_eq!(by_id("a2"), "asteroid #2");
+    assert_eq!(by_id("p1"), "Vulcan"); // real names kept
+}

--- a/src/input/mine.rs
+++ b/src/input/mine.rs
@@ -82,9 +82,16 @@ pub(super) fn handle_mine_event(
                         let (id, name) = candidates[selection].clone();
                         (manny_id.clone(), manny_name.clone(), id, name)
                     };
+                    // Preselect the resources the target actually holds; fall
+                    // back to metals when the reserves are unknown.
+                    let resources = state
+                        .minable_target_reserves(&object_id)
+                        .map(|(flags, _)| flags)
+                        .filter(|f| f.iter().any(|&x| x))
+                        .unwrap_or([false, true, false, false]);
                     state.mine = MineInput::Configure {
                         manny_id, manny_name, object_id, object_name,
-                        resources: [false, true, false, false],
+                        resources,
                         amount_buf: "0.30".into(),
                         amount_mode: false,
                         target_container: None,
@@ -94,8 +101,10 @@ pub(super) fn handle_mine_event(
                 _ => {}
             }
         }
-        MineInput::Configure { amount_mode, .. } => {
+        MineInput::Configure { amount_mode, object_id, resources, .. } => {
             let am = *amount_mode;
+            let obj_id = object_id.clone();
+            let res = *resources;
             match code {
                 KeyCode::Esc => state.mine = MineInput::Inactive,
                 KeyCode::Tab => {
@@ -106,13 +115,20 @@ pub(super) fn handle_mine_event(
                 }
                 KeyCode::Char(c @ '1'..='4') if !am => {
                     let idx = (c as u8 - b'1') as usize;
-                    if let MineInput::Configure { ref mut resources, ref mut error, .. } = state.mine {
-                        resources[idx] = !resources[idx];
-                        *error = None;
+                    // Only toggle resources the target actually holds.
+                    let present = state
+                        .minable_target_reserves(&obj_id)
+                        .map(|(flags, _)| flags[idx])
+                        .unwrap_or(true);
+                    if present {
+                        if let MineInput::Configure { ref mut resources, ref mut error, .. } = state.mine {
+                            resources[idx] = !resources[idx];
+                            *error = None;
+                        }
                     }
                 }
                 KeyCode::Char('m') | KeyCode::Char('M') if am => {
-                    let max = state.mine_max_amount();
+                    let max = state.mine_reserve_max(&obj_id, res);
                     if let MineInput::Configure { ref mut amount_buf, ref mut error, .. } = state.mine {
                         *amount_buf = format!("{:.4}", max);
                         *error = None;

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -127,30 +127,71 @@ fn render_message_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &s
 }
 
 pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {
+    use crate::ui::panels::scanner::sector_object_lines;
+    use crate::ui::theme::object_color;
+
     let dim = Style::default().fg(p.dim);
-    let mut lines = Vec::new();
-    match state.current_sector() {
-        Some(s) => {
-            let v = &s.relative_coordinates;
-            lines.push(Line::styled(
-                format!("({}, {}, {})  d{}", v.x as i32, v.y as i32, v.z as i32, s.distance),
-                Style::default().fg(p.text),
-            ));
-            let objs = state.scanner_objects();
-            lines.push(Line::styled(format!("{} object(s)", objs.len()), dim));
-            let cur = cursor(state, Pane::Sector);
-            for (i, e) in objs.iter().enumerate() {
-                let (icon, color) = object_icon(&e.object_type);
-                let name: String = e.name.chars().take(20).collect();
-                lines.push(Line::from(vec![
-                    Span::styled(format!("{icon} "), Style::default().fg(color)),
-                    Span::styled(name, row_style(active, i == cur).patch(Style::default().fg(p.text))),
-                ]));
+    let text = Style::default().fg(p.text);
+    let Some(s) = state.current_sector() else {
+        render_body(frame, area, " SECTOR ", active, p, vec![Line::styled("no sector scan yet", dim)]);
+        return;
+    };
+    let v = &s.relative_coordinates;
+    let header = format!("({}, {}, {})  d{}", v.x as i32, v.y as i32, v.z as i32, s.distance);
+
+    // Zoom: the science station — full per-object detail (class, habitability,
+    // composition, resource shares/reserves, mineability, dimensions).
+    if state.zoomed {
+        let mut lines = vec![Line::styled(header, text), Line::raw("")];
+        match &s.objects {
+            Some(objs) if !objs.is_empty() => {
+                for obj in objs {
+                    lines.extend(sector_object_lines(obj, false, p));
+                }
             }
+            _ => lines.push(Line::styled("empty sector", dim)),
         }
-        None => lines.push(Line::styled("no sector scan yet", dim)),
+        render_body(frame, area, " SECTOR ", active, p, lines);
+        return;
+    }
+
+    // Compact: navigable object list, each row tagged with its headline datum
+    // (planet habitability/class, asteroid composition).
+    let mut lines = vec![Line::styled(header, text)];
+    let objs = state.scanner_objects();
+    lines.push(Line::styled(format!("{} object(s)", objs.len()), dim));
+    let cur = cursor(state, Pane::Sector);
+    for (i, e) in objs.iter().enumerate() {
+        let color = object_color(&e.object_type, p);
+        let icon = object_icon(&e.object_type).0;
+        let name: String = e.name.chars().take(18).collect();
+        let mut spans = vec![
+            Span::styled(format!("{icon} "), Style::default().fg(color)),
+            Span::styled(name, row_style(active, i == cur).patch(text)),
+        ];
+        if let Some(tag) = sector_entry_tag(state, &e.id, p) {
+            spans.push(tag);
+        }
+        lines.push(Line::from(spans));
     }
     render_body(frame, area, " SECTOR ", active, p, lines);
+}
+
+/// A terse dim tag for a compact Sector row, looked up from the raw object:
+/// planet habitability/class, asteroid composition, else a mineable marker.
+fn sector_entry_tag<'a>(state: &AppState, id: &str, p: Palette) -> Option<Span<'a>> {
+    let s = state.current_sector()?;
+    let obj = s.objects.as_ref()?.iter().find(|o| o.id.as_deref() == Some(id))?;
+    if let Some(h) = obj.habitability_score {
+        return Some(Span::styled(format!("  hab {:.0}%", h * 100.0), Style::default().fg(p.dim)));
+    }
+    if let Some(cat) = &obj.category {
+        return Some(Span::styled(format!("  {cat}"), Style::default().fg(p.dim)));
+    }
+    if let Some(comp) = &obj.composition {
+        return Some(Span::styled(format!("  {comp}"), Style::default().fg(p.dim)));
+    }
+    (obj.manny_mineable == Some(true)).then(|| Span::styled("  ⛏", Style::default().fg(p.warn)))
 }
 
 pub fn render_missions(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -6,12 +6,18 @@
 //! swaps a pane to its detail view (Missions → steps, Comms → message).
 //! Colours come from the active [`Palette`].
 
-use crate::api::types::{Manny, MannyLocationType, MannyTaskVisibility, MissionStatus, MissionStepStatus};
+use crate::api::types::{
+    Manny, MannyLocationType, MannyTaskVisibility, MissionStatus, MissionStepStatus, SectorObject,
+    SectorObjectType,
+};
 use crate::app::{AppState, DrillLevel, Pane};
 use crate::ui::panels::mannies::{
     manny_mining_detail, manny_task_eta, manny_task_label, manny_task_progress,
 };
-use crate::ui::theme::{block_gauge_line, object_icon, pane_block, Palette};
+use crate::ui::panels::scanner::{resource_shares_line, sector_object_lines};
+use crate::ui::theme::{
+    block_gauge_line, object_color, object_icon, object_type_label, pane_block, ratio_color, Palette,
+};
 use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
@@ -127,9 +133,6 @@ fn render_message_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &s
 }
 
 pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {
-    use crate::ui::panels::scanner::sector_object_lines;
-    use crate::ui::theme::object_color;
-
     let dim = Style::default().fg(p.dim);
     let text = Style::default().fg(p.text);
     let Some(s) = state.current_sector() else {
@@ -139,14 +142,21 @@ pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bo
     let v = &s.relative_coordinates;
     let header = format!("({}, {}, {})  d{}", v.x as i32, v.y as i32, v.z as i32, s.distance);
 
-    // Zoom: the science station — full per-object detail (class, habitability,
-    // composition, resource shares/reserves, mineability, dimensions).
+    // Zoom: the science station — full per-object detail. Solar systems get a
+    // merged per-body breakdown (star, each planet's class/habitability, each
+    // mineable body's resources); standalone objects reuse the scanner's
+    // verbose object lines.
     if state.zoomed {
         let mut lines = vec![Line::styled(header, text), Line::raw("")];
         match &s.objects {
             Some(objs) if !objs.is_empty() => {
                 for obj in objs {
-                    lines.extend(sector_object_lines(obj, false, p));
+                    if obj.object_type == SectorObjectType::SolarSystem {
+                        lines.extend(solar_system_zoom_lines(obj, p));
+                    } else {
+                        lines.extend(sector_object_lines(obj, false, p));
+                    }
+                    lines.push(Line::raw(""));
                 }
             }
             _ => lines.push(Line::styled("empty sector", dim)),
@@ -155,8 +165,9 @@ pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bo
         return;
     }
 
-    // Compact: navigable object list, each row tagged with its headline datum
-    // (planet habitability/class, asteroid composition).
+    // Compact: navigable object list, each row tagged with its headline data
+    // (system star/planet count, asteroid composition/resources, planet
+    // habitability).
     let mut lines = vec![Line::styled(header, text)];
     let objs = state.scanner_objects();
     lines.push(Line::styled(format!("{} object(s)", objs.len()), dim));
@@ -164,34 +175,177 @@ pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bo
     for (i, e) in objs.iter().enumerate() {
         let color = object_color(&e.object_type, p);
         let icon = object_icon(&e.object_type).0;
-        let name: String = e.name.chars().take(18).collect();
+        let name: String = e.name.chars().take(16).collect();
         let mut spans = vec![
             Span::styled(format!("{icon} "), Style::default().fg(color)),
             Span::styled(name, row_style(active, i == cur).patch(text)),
         ];
-        if let Some(tag) = sector_entry_tag(state, &e.id, p) {
-            spans.push(tag);
-        }
+        spans.extend(sector_entry_tags(state, &e.id, p));
         lines.push(Line::from(spans));
     }
     render_body(frame, area, " SECTOR ", active, p, lines);
 }
 
-/// A terse dim tag for a compact Sector row, looked up from the raw object:
-/// planet habitability/class, asteroid composition, else a mineable marker.
-fn sector_entry_tag<'a>(state: &AppState, id: &str, p: Palette) -> Option<Span<'a>> {
-    let s = state.current_sector()?;
-    let obj = s.objects.as_ref()?.iter().find(|o| o.id.as_deref() == Some(id))?;
-    if let Some(h) = obj.habitability_score {
-        return Some(Span::styled(format!("  hab {:.0}%", h * 100.0), Style::default().fg(p.dim)));
+/// Join mineable resource types into a terse label (`metals ice carbon`).
+fn resource_types_str(types: &[String]) -> String {
+    types
+        .iter()
+        .map(|r| match r.as_str() {
+            "carbon_compounds" => "carbon",
+            other => other,
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Terse headline tags for a compact Sector row, looked up from the raw object
+/// (top-level or nested by id): system star/planet count, asteroid
+/// composition/resources, planet habitability + class.
+fn sector_entry_tags(state: &AppState, id: &str, p: Palette) -> Vec<Span<'static>> {
+    let dim = Style::default().fg(p.dim);
+    let mut out: Vec<Span<'static>> = Vec::new();
+    let Some(s) = state.current_sector() else { return out };
+    let Some(objs) = s.objects.as_ref() else { return out };
+
+    if let Some(o) = objs.iter().find(|o| o.id.as_deref() == Some(id)) {
+        match o.object_type {
+            SectorObjectType::SolarSystem => {
+                out.push(Span::styled("  ★".to_string(), Style::default().fg(p.warn)));
+                out.push(Span::styled(format!(" · {} planet(s)", o.planet_count.unwrap_or(0)), dim));
+            }
+            SectorObjectType::Asteroid => {
+                if let Some(c) = &o.composition {
+                    out.push(Span::styled(format!("  {c}"), dim));
+                } else if !o.resource_types.is_empty() {
+                    out.push(Span::styled(format!("  {}", resource_types_str(&o.resource_types)), dim));
+                }
+            }
+            SectorObjectType::Planet => {
+                if let Some(h) = o.habitability_score {
+                    out.push(Span::styled(format!("  hab {:.0}%", h * 100.0), Style::default().fg(ratio_color(h, p))));
+                }
+                if let Some(c) = &o.category {
+                    out.push(Span::styled(format!(" {c}"), dim));
+                }
+            }
+            _ => {
+                if o.manny_mineable == Some(true) {
+                    out.push(Span::styled("  ⛏".to_string(), Style::default().fg(p.warn)));
+                }
+            }
+        }
+        return out;
     }
-    if let Some(cat) = &obj.category {
-        return Some(Span::styled(format!("  {cat}"), Style::default().fg(p.dim)));
+
+    // Nested body of a solar system, matched by id.
+    for o in objs {
+        if let Some(t) = o.minable_targets.iter().flatten().find(|t| t.id == id) {
+            if let Some(rt) = &t.resource_types {
+                if !rt.is_empty() {
+                    out.push(Span::styled(format!("  {}", resource_types_str(rt)), dim));
+                }
+            }
+            return out;
+        }
+        if let Some(t) = o.bookmark_targets.iter().find(|t| t.id == id) {
+            if let Some(h) = t.habitability_score {
+                out.push(Span::styled(format!("  hab {:.0}%", h * 100.0), Style::default().fg(ratio_color(h, p))));
+            }
+            if let Some(c) = &t.category {
+                out.push(Span::styled(format!(" {c}"), dim));
+            }
+            return out;
+        }
     }
-    if let Some(comp) = &obj.composition {
-        return Some(Span::styled(format!("  {comp}"), Style::default().fg(p.dim)));
+    out
+}
+
+/// Zoom breakdown of a solar system: header + body counts, then one entry per
+/// nested body (union of bookmark + mineable targets, merged by id) with its
+/// type, class, habitability and mineable resources.
+fn solar_system_zoom_lines(obj: &SectorObject, p: Palette) -> Vec<Line<'static>> {
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    let name = obj
+        .name
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| object_type_label(&obj.object_type).to_string());
+    lines.push(Line::from(vec![
+        Span::styled(format!("{} ", object_icon(&obj.object_type).0), Style::default().fg(object_color(&obj.object_type, p))),
+        Span::styled(name, text),
+    ]));
+    lines.push(Line::styled(
+        format!(
+            "  ★ {} star(s) · {} planet(s) · {} bodies",
+            obj.star_count.unwrap_or(0),
+            obj.planet_count.unwrap_or(0),
+            obj.orbital_body_count.unwrap_or(0),
+        ),
+        dim,
+    ));
+
+    // Union of nested body ids, bookmark targets first, then mineable-only.
+    let mut ids: Vec<String> = Vec::new();
+    for t in &obj.bookmark_targets {
+        if !ids.contains(&t.id) {
+            ids.push(t.id.clone());
+        }
     }
-    (obj.manny_mineable == Some(true)).then(|| Span::styled("  ⛏", Style::default().fg(p.warn)))
+    for t in obj.minable_targets.iter().flatten() {
+        if !ids.contains(&t.id) {
+            ids.push(t.id.clone());
+        }
+    }
+
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for id in ids {
+        let bt = obj.bookmark_targets.iter().find(|t| t.id == id);
+        let mt = obj.minable_targets.iter().flatten().find(|t| t.id == id);
+        let otype = bt.map(|b| b.object_type.clone()).or_else(|| mt.map(|m| m.object_type.clone()));
+        let Some(otype) = otype else { continue };
+        let label = object_type_label(&otype);
+        let n = counts.entry(label).or_insert(0);
+        *n += 1;
+        let name = bt
+            .and_then(|b| b.name.clone())
+            .or_else(|| mt.and_then(|m| m.name.clone()))
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| format!("{label} #{n}"));
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {} ", object_icon(&otype).0), Style::default().fg(object_color(&otype, p))),
+            Span::styled(name, text),
+            Span::styled(format!("  {label}"), dim),
+        ]));
+        if let Some(b) = bt {
+            if let Some(h) = b.habitability_score {
+                lines.push(Line::from(vec![
+                    Span::styled("      habitability ", dim),
+                    Span::styled(format!("{:.0}%", h * 100.0), Style::default().fg(ratio_color(h, p))),
+                ]));
+            }
+            if let Some(c) = &b.category {
+                lines.push(Line::from(vec![Span::styled("      class ", dim), Span::styled(c.clone(), text)]));
+            }
+        }
+        if let Some(m) = mt {
+            if let Some(rt) = &m.resource_types {
+                if !rt.is_empty() {
+                    lines.push(Line::from(vec![
+                        Span::styled("      resources ", dim),
+                        Span::styled(resource_types_str(rt), Style::default().fg(p.warn)),
+                    ]));
+                }
+            }
+            if let Some(line) = resource_shares_line("      shares ", m.resource_composition.as_ref(), true, p) {
+                lines.push(line);
+            }
+        }
+    }
+    lines
 }
 
 pub fn render_missions(frame: &mut Frame, area: Rect, state: &AppState, active: bool, p: Palette) {

--- a/src/ui/overlays/alerts.rs
+++ b/src/ui/overlays/alerts.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::{palette, Palette};
 use crate::api::types::{AlertType, ProbeAlert};
 use crate::app::{AlertsInput, AppState};
 use ratatui::{
@@ -21,29 +22,29 @@ fn alert_type_label(t: &AlertType) -> &'static str {
 }
 
 /// Colour-code the row by alert type severity (dimmed once read).
-fn type_color(t: &AlertType) -> Color {
+fn type_color(t: &AlertType, p: Palette) -> Color {
     match t {
-        AlertType::StorageContainerBreak => Color::Red,
-        AlertType::IntelligentLife => Color::Cyan,
-        AlertType::SectorObjectDetected => Color::Yellow,
-        AlertType::AnomalyDetected => Color::Magenta,
-        AlertType::Unknown => Color::Gray,
+        AlertType::StorageContainerBreak => p.crit,
+        AlertType::IntelligentLife => p.accent,
+        AlertType::SectorObjectDetected => p.warn,
+        AlertType::AnomalyDetected => p.crit,
+        AlertType::Unknown => p.text,
     }
 }
 
-fn alert_row(alert: &ProbeAlert) -> ListItem<'static> {
+fn alert_row(alert: &ProbeAlert, p: Palette) -> ListItem<'static> {
     let unread = alert.is_unread();
     let (marker, marker_color) = if unread {
-        ("● ", type_color(&alert.alert_type))
+        ("● ", type_color(&alert.alert_type, p))
     } else {
-        ("○ ", Color::DarkGray)
+        ("○ ", p.dim)
     };
     let text_style = if unread {
-        Style::default().fg(Color::White)
+        Style::default().fg(p.text)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(p.dim)
     };
-    let label_color = if unread { type_color(&alert.alert_type) } else { Color::DarkGray };
+    let label_color = if unread { type_color(&alert.alert_type, p) } else { p.dim };
     ListItem::new(Line::from(vec![
         Span::styled(marker, Style::default().fg(marker_color)),
         Span::styled(
@@ -55,6 +56,7 @@ fn alert_row(alert: &ProbeAlert) -> ListItem<'static> {
 }
 
 pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let AlertsInput::Browsing { selection, show_warnings } = state.alerts_input else {
         return;
     };
@@ -72,7 +74,7 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         .title(" ALERTS ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -90,9 +92,9 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     let warns_unread = state.damage_warnings.iter().filter(|w| w.is_unread()).count();
     let tab_style = |active: bool| {
         if active {
-            Style::default().fg(Color::Black).bg(Color::Cyan).add_modifier(Modifier::BOLD)
+            Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(p.dim)
         }
     };
     frame.render_widget(
@@ -108,11 +110,11 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     if entries.is_empty() {
         let label = if show_warnings { "no damage warnings" } else { "no active alerts" };
         frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(label, Style::default().fg(Color::DarkGray)))),
+            Paragraph::new(Line::from(Span::styled(label, Style::default().fg(p.dim)))),
             rows[1],
         );
     } else {
-        let items: Vec<ListItem> = entries.iter().map(alert_row).collect();
+        let items: Vec<ListItem> = entries.iter().map(|a| alert_row(a, p)).collect();
         let list = List::new(items)
             .highlight_style(Style::default().add_modifier(Modifier::BOLD))
             .highlight_symbol("▶ ");
@@ -124,13 +126,13 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     // ── Footer ──
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
             Span::raw(" select  "),
-            Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Tab]", Style::default().fg(p.accent)),
             Span::raw(" switch  "),
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" ack  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" close"),
         ])),
         rows[2],

--- a/src/ui/overlays/containers.rs
+++ b/src/ui/overlays/containers.rs
@@ -1,7 +1,8 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, ContainerRulesInput, RenameContainerInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
     Frame,
@@ -10,6 +11,7 @@ use ratatui::{
 use super::centered_rect;
 
 pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let RenameContainerInput::Typing { ref current_label, ref buf, ref error, .. } =
         state.rename_container
     else {
@@ -22,7 +24,7 @@ pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, sta
         .title(format!(" RENAME — {current_label} "))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -32,21 +34,21 @@ pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, sta
         .split(inner);
 
     let mut lines: Vec<Line> = vec![Line::from(vec![
-        Span::styled("Label: ", Style::default().fg(Color::Cyan)),
+        Span::styled("Label: ", Style::default().fg(p.accent)),
         Span::raw(buf.as_str()),
-        Span::styled("█", Style::default().fg(Color::Cyan)),
+        Span::styled("█", Style::default().fg(p.accent)),
     ])];
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
 
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" rename  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -54,6 +56,7 @@ pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, sta
 }
 
 pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let ContainerRulesInput::Editing {
         ref container_label,
         ref types,
@@ -75,7 +78,7 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
         .title(format!(" ROUTING RULES — {container_label} "))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -86,13 +89,13 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
 
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("P", Style::default().fg(Color::Green)),
+            Span::styled("P", Style::default().fg(p.good)),
             Span::raw(" priority  "),
-            Span::styled("E", Style::default().fg(Color::Yellow)),
+            Span::styled("E", Style::default().fg(p.warn)),
             Span::raw(" exclude  "),
-            Span::styled("S", Style::default().fg(Color::Red)),
+            Span::styled("S", Style::default().fg(p.crit)),
             Span::raw(" strict  "),
-            Span::styled("·", Style::default().fg(Color::DarkGray)),
+            Span::styled("·", Style::default().fg(p.dim)),
             Span::raw(" none"),
         ])),
         rows[0],
@@ -102,17 +105,17 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
         .iter()
         .map(|ty| {
             let (tag, color) = if priority.iter().any(|t| t == ty) {
-                ("[P]", Color::Green)
+                ("[P]", p.good)
             } else if exclusion.iter().any(|t| t == ty) {
-                ("[E]", Color::Yellow)
+                ("[E]", p.warn)
             } else if strict_exclusion.iter().any(|t| t == ty) {
-                ("[S]", Color::Red)
+                ("[S]", p.crit)
             } else {
-                ("[ ]", Color::DarkGray)
+                ("[ ]", p.dim)
             };
             ListItem::new(Line::from(vec![
                 Span::styled(format!("{tag} "), Style::default().fg(color).add_modifier(Modifier::BOLD)),
-                Span::styled(ty.clone(), Style::default().fg(Color::White)),
+                Span::styled(ty.clone(), Style::default().fg(p.text)),
             ]))
         })
         .collect();
@@ -126,16 +129,16 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
     frame.render_stateful_widget(list, rows[1], &mut ls);
 
     let footer = if let Some(err) = error {
-        Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red)))
+        Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit)))
     } else {
         Line::from(vec![
-            Span::styled("[Space]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Space]", Style::default().fg(p.accent)),
             Span::raw(" cycle  "),
-            Span::styled("[Del]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Del]", Style::default().fg(p.accent)),
             Span::raw(" clear  "),
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" save  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])
     };

--- a/src/ui/overlays/craft.rs
+++ b/src/ui/overlays/craft.rs
@@ -1,7 +1,8 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, AtomicPrinterCraftInput, CraftInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
@@ -9,6 +10,7 @@ use ratatui::{
 
 use super::centered_rect;
 pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let CraftInput::PickRecipe { ref manny_name, selection, ref error, .. } = state.craft else { return };
 
     let recipes = state.manny_craft_recipes();
@@ -21,7 +23,7 @@ pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppSta
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -34,7 +36,7 @@ pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppSta
     if recipes.is_empty() {
         lines.push(Line::from(Span::styled(
             "loading recipes…",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         )));
     }
     for (i, recipe) in recipes.iter().enumerate() {
@@ -50,14 +52,14 @@ pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppSta
         let detail = format!("  {}m  {}", duration_min, ingredients);
         if selected {
             lines.push(Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
-                Span::styled(recipe.name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
-                Span::styled(detail, Style::default().fg(Color::DarkGray)),
+                Span::styled("▶ ", Style::default().fg(p.warn)),
+                Span::styled(recipe.name.as_str(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
+                Span::styled(detail, Style::default().fg(p.dim)),
             ]));
         } else {
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(recipe.name.as_str(), Style::default().fg(Color::DarkGray)),
+                Span::styled(recipe.name.as_str(), Style::default().fg(p.dim)),
             ]));
         }
     }
@@ -65,18 +67,18 @@ pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppSta
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
 
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
             Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" start  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -84,6 +86,7 @@ pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppSta
 }
 
 pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let AtomicPrinterCraftInput::PickRecipe { selection, ref error } = state.atomic_printer_craft else { return };
 
     let recipes = state.atomic_printer_recipes();
@@ -95,7 +98,7 @@ pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect,
         .title(" ATOMIC PRINTER — SELECT RECIPE ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Magenta));
+        .border_style(Style::default().fg(p.crit));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -108,7 +111,7 @@ pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect,
     if recipes.is_empty() {
         lines.push(Line::from(Span::styled(
             "loading recipes…",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         )));
     }
     for (i, recipe) in recipes.iter().enumerate() {
@@ -124,14 +127,14 @@ pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect,
         let detail = format!("  {}m  {}", duration_min, ingredients);
         if selected {
             lines.push(Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
-                Span::styled(recipe.name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
-                Span::styled(detail, Style::default().fg(Color::DarkGray)),
+                Span::styled("▶ ", Style::default().fg(p.warn)),
+                Span::styled(recipe.name.as_str(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
+                Span::styled(detail, Style::default().fg(p.dim)),
             ]));
         } else {
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(recipe.name.as_str(), Style::default().fg(Color::DarkGray)),
+                Span::styled(recipe.name.as_str(), Style::default().fg(p.dim)),
             ]));
         }
     }
@@ -139,17 +142,17 @@ pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect,
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
             Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" start  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],

--- a/src/ui/overlays/drop_container.rs
+++ b/src/ui/overlays/drop_container.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, DropStorageContainerInput};
 use ratatui::{layout::Rect, Frame};
 
@@ -9,14 +10,14 @@ pub(crate) fn render_drop_container_overlay(frame: &mut Frame, area: Rect, state
         DropStorageContainerInput::PickContainer { containers, selection, .. } => {
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, " DROP CONTAINER — SELECT CONTAINER ", 54, height,
+            render_pick_list(frame, area, palette(state.color_mode), " DROP CONTAINER — SELECT CONTAINER ", 54, height,
                 None, &names, *selection, None, "select");
         }
         DropStorageContainerInput::PickPlanet { container_name, planets, selection, error, .. } => {
             let names: Vec<&str> = planets.iter().map(|(_, n)| n.as_str()).collect();
             let height = (planets.len() as u16 + 7).min(18);
             let prompt = format!("Drop {container_name} on planet:");
-            render_pick_list(frame, area, " DROP CONTAINER — SELECT PLANET ", 54, height,
+            render_pick_list(frame, area, palette(state.color_mode), " DROP CONTAINER — SELECT PLANET ", 54, height,
                 Some(&prompt), &names, *selection, error.as_deref(), "drop");
         }
     }

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -1,6 +1,7 @@
+use crate::ui::theme::Palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
@@ -9,28 +10,28 @@ use ratatui::{
 use super::centered_rect;
 // ── Help overlay ──────────────────────────────────────────────────────────────
 
-pub(crate) fn help_key_line(key: &'static str, desc: &'static str) -> Line<'static> {
+pub(crate) fn help_key_line(key: &'static str, desc: &'static str, p: Palette) -> Line<'static> {
     Line::from(vec![
-        Span::styled(format!("  {key:<10}"), Style::default().fg(Color::Cyan)),
+        Span::styled(format!("  {key:<10}"), Style::default().fg(p.accent)),
         Span::raw(desc),
     ])
 }
 
-pub(crate) fn help_section(title: &'static str) -> Line<'static> {
+pub(crate) fn help_section(title: &'static str, p: Palette) -> Line<'static> {
     Line::from(Span::styled(
         title,
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        Style::default().fg(p.warn).add_modifier(Modifier::BOLD),
     ))
 }
 
-pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
+pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect, p: Palette) {
     let popup = centered_rect(76, 28, area);
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .title(" HELP — KEYBINDINGS ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -45,53 +46,53 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect) {
         .split(rows[0]);
 
     let left: Vec<Line> = vec![
-        help_section("Navigate"),
-        help_key_line("e r t", "Scanner · Map · Comms"),
-        help_key_line("d f g", "Sector · Probe · Missions"),
-        help_key_line("c v b", "Inventory · Storage · Mannies"),
-        help_key_line("j k / ↑↓", "move cursor in pane"),
-        help_key_line("l / h", "drill in / out (→ ←)"),
-        help_key_line("Tab", "cycle panes (Shift-Tab reverse)"),
-        help_key_line("z", "zoom active pane full screen"),
-        help_key_line("Esc", "close / leave zoom / drill up"),
+        help_section("Navigate", p),
+        help_key_line("e r t", "Scanner · Map · Comms", p),
+        help_key_line("d f g", "Sector · Probe · Missions", p),
+        help_key_line("c v b", "Inventory · Storage · Mannies", p),
+        help_key_line("j k / ↑↓", "move cursor in pane", p),
+        help_key_line("l / h", "drill in / out (→ ←)", p),
+        help_key_line("Tab", "cycle panes (Shift-Tab reverse)", p),
+        help_key_line("z", "zoom active pane full screen", p),
+        help_key_line("Esc", "close / leave zoom / drill up", p),
         Line::default(),
-        help_section("Act & global"),
-        help_key_line("Enter", "contextual action menu"),
-        help_key_line("F1", "toggle hints line"),
-        help_key_line("F2", "cycle color mode"),
-        help_key_line("F5", "refresh"),
-        help_key_line("?", "this help"),
-        help_key_line("q", "quit"),
+        help_section("Act & global", p),
+        help_key_line("Enter", "contextual action menu", p),
+        help_key_line("F1", "toggle hints line", p),
+        help_key_line("F2", "cycle color mode", p),
+        help_key_line("F5", "refresh", p),
+        help_key_line("?", "this help", p),
+        help_key_line("q", "quit", p),
         Line::default(),
-        help_section("In a menu"),
-        help_key_line("j k", "move"),
-        help_key_line("Enter", "fire selected"),
-        help_key_line("Esc", "close"),
+        help_section("In a menu", p),
+        help_key_line("j k", "move", p),
+        help_key_line("Enter", "fire selected", p),
+        help_key_line("Esc", "close", p),
     ];
 
     let right: Vec<Line> = vec![
-        help_section("Actions per pane (Enter)"),
-        help_key_line("Mannies", "mine, craft, repair, salvage,"),
-        help_key_line("", "inspect, recover, detach, refuel,"),
-        help_key_line("", "drop cargo, recall/abandon, rename"),
-        help_key_line("Inventory", "jettison, atomic craft, move stock"),
-        help_key_line("Missions", "browse steps, abandon"),
-        help_key_line("Comms", "messages inbox/sent/compose, alerts"),
-        help_key_line("Storage", "rename, rules, recover, detach, move"),
-        help_key_line("Sector", "object actions: mine, inspect,"),
-        help_key_line("", "salvage, recover, deploy, relay"),
+        help_section("Actions per pane (Enter)", p),
+        help_key_line("Mannies", "mine, craft, repair, salvage,", p),
+        help_key_line("", "inspect, recover, detach, refuel,", p),
+        help_key_line("", "drop cargo, recall/abandon, rename", p),
+        help_key_line("Inventory", "jettison, atomic craft, move stock", p),
+        help_key_line("Missions", "browse steps, abandon", p),
+        help_key_line("Comms", "messages inbox/sent/compose, alerts", p),
+        help_key_line("Storage", "rename, rules, recover, detach, move", p),
+        help_key_line("Sector", "object actions: mine, inspect,", p),
+        help_key_line("", "salvage, recover, deploy, relay", p),
         Line::default(),
-        help_section("Config"),
-        help_key_line("theme", "color mode (mono-green/amber,"),
-        help_key_line("", "phosphor-semantic, modern-16)"),
-        help_key_line("hints", "show the hints line (F1)"),
+        help_section("Config", p),
+        help_key_line("theme", "color mode (mono-green/amber,", p),
+        help_key_line("", "phosphor-semantic, modern-16, p)", p),
+        help_key_line("hints", "show the hints line (F1)", p),
     ];
 
     frame.render_widget(Paragraph::new(left), cols[0]);
     frame.render_widget(Paragraph::new(right), cols[1]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Esc/?]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc/?]", Style::default().fg(p.accent)),
             Span::raw(" close"),
         ])),
         rows[1],

--- a/src/ui/overlays/inventory_detail.rs
+++ b/src/ui/overlays/inventory_detail.rs
@@ -1,7 +1,8 @@
+use crate::ui::theme::{palette, Palette};
 use crate::app::{AppState, InventoryRow};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
@@ -10,14 +11,15 @@ use ratatui::{
 use super::centered_rect;
 // ── Inventory detail overlay ──────────────────────────────────────────────────
 
-pub(crate) fn detail_kv(key: &str, value: String) -> Line<'static> {
+pub(crate) fn detail_kv(p: Palette, key: &str, value: String) -> Line<'static> {
     Line::from(vec![
-        Span::styled(format!("{key:<12}"), Style::default().fg(Color::DarkGray)),
+        Span::styled(format!("{key:<12}"), Style::default().fg(p.dim)),
         Span::raw(value),
     ])
 }
 
 pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let Some(probe) = &state.probe else { return };
     let Some(row) = state.selected_inventory_row() else { return };
     let inv = &probe.inventory;
@@ -26,18 +28,18 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
         InventoryRow::Stock { id } => {
             let Some(stock) = inv.resource_stocks.iter().find(|s| s.id == id) else { return };
             let mut lines = vec![
-                detail_kv("Type", stock.stock_type.clone()),
-                detail_kv("Amount", format!("{:.4} ECE", stock.amount)),
-                detail_kv("Space", format!("{:.4}", stock.container_space)),
+                detail_kv(p, "Type", stock.stock_type.clone()),
+                detail_kv(p, "Amount", format!("{:.4} ECE", stock.amount)),
+                detail_kv(p, "Space", format!("{:.4}", stock.container_space)),
             ];
             if !stock.containers.is_empty() {
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     "── containers ──",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(p.dim),
                 )));
                 for line in &stock.containers {
-                    lines.push(detail_kv(
+                    lines.push(detail_kv(p, 
                         &line.container.label,
                         format!("{:.4} ECE  (space {:.4})", line.amount, line.container_space),
                     ));
@@ -48,9 +50,9 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
         InventoryRow::ActiveItem { id } => {
             let Some(item) = inv.items.iter().find(|i| i.id == id) else { return };
             let mut lines = vec![
-                detail_kv("Type", item.item_type.clone()),
-                detail_kv("Space", format!("{:.4}", item.container_space)),
-                detail_kv(
+                detail_kv(p, "Type", item.item_type.clone()),
+                detail_kv(p, "Space", format!("{:.4}", item.container_space)),
+                detail_kv(p, 
                     "Task",
                     match item.current_task.as_deref() {
                         None => "idle".into(),
@@ -59,22 +61,22 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
                 ),
             ];
             if let Some(loc) = &item.location {
-                lines.push(detail_kv("Location", format!("{:?}", loc.location_type).to_lowercase()));
+                lines.push(detail_kv(p, "Location", format!("{:?}", loc.location_type).to_lowercase()));
             }
             if let Some(container) = &item.container {
-                lines.push(detail_kv("Container", container.label.clone()));
+                lines.push(detail_kv(p, "Container", container.label.clone()));
             }
             if let Some(cargo) = &item.cargo {
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     "── cargo ──",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(p.dim),
                 )));
-                lines.push(detail_kv("Capacity", format!("{:.3}", cargo.capacity)));
-                lines.push(detail_kv("Deuterium", format!("{:.3}", cargo.deuterium)));
-                lines.push(detail_kv("Metals", format!("{:.3}", cargo.metals)));
-                lines.push(detail_kv("Ice", format!("{:.3}", cargo.ice)));
-                lines.push(detail_kv("Organic", format!("{:.3}", cargo.organic_compounds)));
+                lines.push(detail_kv(p, "Capacity", format!("{:.3}", cargo.capacity)));
+                lines.push(detail_kv(p, "Deuterium", format!("{:.3}", cargo.deuterium)));
+                lines.push(detail_kv(p, "Metals", format!("{:.3}", cargo.metals)));
+                lines.push(detail_kv(p, "Ice", format!("{:.3}", cargo.ice)));
+                lines.push(detail_kv(p, "Organic", format!("{:.3}", cargo.organic_compounds)));
             }
             (item.name.clone(), lines)
         }
@@ -82,9 +84,9 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
             let items: Vec<_> = inv.items.iter().filter(|i| i.item_type == item_type).collect();
             let Some(first) = items.first() else { return };
             let mut lines = vec![
-                detail_kv("Type", item_type.clone()),
-                detail_kv("Count", format!("{}", items.len())),
-                detail_kv(
+                detail_kv(p, "Type", item_type.clone()),
+                detail_kv(p, "Count", format!("{}", items.len())),
+                detail_kv(p, 
                     "Space",
                     format!("{:.4} total", items.iter().map(|i| i.container_space).sum::<f64>()),
                 ),
@@ -96,7 +98,7 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
                     .unwrap_or_default();
                 lines.push(Line::from(vec![
                     Span::raw(format!("  {}", item.name)),
-                    Span::styled(container, Style::default().fg(Color::DarkGray)),
+                    Span::styled(container, Style::default().fg(p.dim)),
                 ]));
             }
             (first.name.clone(), lines)
@@ -110,7 +112,7 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
         .title(format!(" {title} "))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -121,7 +123,7 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" close"),
         ])),
         rows[1],

--- a/src/ui/overlays/jettison.rs
+++ b/src/ui/overlays/jettison.rs
@@ -1,7 +1,8 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, JettisonInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
@@ -9,6 +10,7 @@ use ratatui::{
 
 use super::centered_rect;
 pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.jettison {
         JettisonInput::ConfirmManny { manny_name, error, .. } => {
             let popup = centered_rect(48, 8, area);
@@ -17,7 +19,7 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 .title(format!(" JETTISON — {manny_name} "))
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Red));
+                .border_style(Style::default().fg(p.crit));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -29,21 +31,21 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
             let mut lines: Vec<Line> = Vec::new();
             lines.push(Line::from(Span::styled(
                 "Eject manny into the sector?",
-                Style::default().fg(Color::Red),
+                Style::default().fg(p.crit),
             )));
             if let Some(err) = error {
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     format!("✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.crit).add_modifier(Modifier::BOLD)),
                     Span::raw(" EJECT  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 rows[1],
@@ -57,7 +59,7 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 .title(" DEPLOY SCUT RELAY ")
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::LightBlue));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -68,21 +70,21 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
 
             let mut lines = vec![Line::from(Span::styled(
                 "Deploy an inactive SCUT relay into this sector?",
-                Style::default().fg(Color::White),
+                Style::default().fg(p.text),
             ))];
             if let Some(err) = error {
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     format!("✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.accent).add_modifier(Modifier::BOLD)),
                     Span::raw(" DEPLOY  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 rows[1],
@@ -96,7 +98,7 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 .title(format!(" JETTISON — {item_name} "))
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow));
+                .border_style(Style::default().fg(p.warn));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -107,31 +109,31 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
 
             let mut lines: Vec<Line> = Vec::new();
             lines.push(Line::from(vec![
-                Span::styled("Amount: ", Style::default().fg(Color::Cyan)),
+                Span::styled("Amount: ", Style::default().fg(p.accent)),
                 Span::raw(buf.as_str()),
-                Span::styled("█", Style::default().fg(Color::Cyan)),
-                Span::styled(" ECE", Style::default().fg(Color::DarkGray)),
+                Span::styled("█", Style::default().fg(p.accent)),
+                Span::styled(" ECE", Style::default().fg(p.dim)),
             ]));
             lines.push(Line::from(vec![
-                Span::styled("MAX  ", Style::default().fg(Color::DarkGray)),
-                Span::styled(format!("{max_amount:.3}"), Style::default().fg(Color::White)),
+                Span::styled("MAX  ", Style::default().fg(p.dim)),
+                Span::styled(format!("{max_amount:.3}"), Style::default().fg(p.text)),
                 Span::raw("   "),
-                Span::styled("[M]", Style::default().fg(Color::Yellow)),
-                Span::styled(" fill", Style::default().fg(Color::DarkGray)),
-                Span::styled("  [empty = all]", Style::default().fg(Color::DarkGray)),
+                Span::styled("[M]", Style::default().fg(p.warn)),
+                Span::styled(" fill", Style::default().fg(p.dim)),
+                Span::styled("  [empty = all]", Style::default().fg(p.dim)),
             ]));
             if let Some(err) = error {
                 lines.push(Line::from(Span::styled(
                     format!("✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
                     Span::raw(" confirm  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 rows[1],

--- a/src/ui/overlays/map.rs
+++ b/src/ui/overlays/map.rs
@@ -4,13 +4,13 @@ use crate::api::types::{
 use crate::app::AppState;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-use crate::ui::theme::{format_duration, map_cell_symbol};
+use crate::ui::theme::{format_duration, map_cell_symbol, palette};
 use super::centered_rect;
 pub(crate) fn sector_brief(s: &SectorObservation) -> String {
     let Some(objects) = &s.objects else {
@@ -50,6 +50,7 @@ pub(crate) fn sector_brief(s: &SectorObservation) -> String {
 }
 
 pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     use std::collections::HashMap;
 
     let popup = centered_rect(66, 24, area);
@@ -62,11 +63,11 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
                 state.map.center_x, state.map.y_layer, state.map.center_z,
                 state.map.y_layer,
             ),
-            Style::default().fg(Color::Cyan),
+            Style::default().fg(p.accent),
         ))
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let map_inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -127,18 +128,18 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
     let mut info_spans: Vec<Span> = vec![
         Span::styled(
             format!("({cx},{y},{cz})"),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default().fg(p.text).add_modifier(Modifier::BOLD),
         ),
     ];
     if let Some(d) = state.map_center_distance() {
         info_spans.push(Span::styled(
             format!("  d:{d}"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         ));
         if d > 0 {
             info_spans.push(Span::styled(
                 format!("  ETA ~{}", format_duration((5 + 35 * d) * 60)),
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(p.warn),
             ));
         }
     }
@@ -160,29 +161,29 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
         });
     info_spans.push(Span::styled(
         format!("  {brief}"),
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(p.dim),
     ));
     frame.render_widget(Paragraph::new(Line::from(info_spans)), info_area);
 
     // ── Legend ──
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("⊕", Style::default().fg(Color::Cyan)),
-            Span::styled(" probe  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("★", Style::default().fg(Color::Yellow)),
-            Span::styled(" star  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("●", Style::default().fg(Color::Green)),
-            Span::styled(" objects  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("◉", Style::default().fg(Color::Magenta)),
-            Span::styled(" black hole  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("!", Style::default().fg(Color::Red)),
-            Span::styled(" danger  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("○", Style::default().fg(Color::Blue)),
-            Span::styled(" visited  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("·", Style::default().fg(Color::White)),
-            Span::styled(" empty  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("·", Style::default().fg(Color::DarkGray)),
-            Span::styled(" unscanned", Style::default().fg(Color::DarkGray)),
+            Span::styled("⊕", Style::default().fg(p.accent)),
+            Span::styled(" probe  ", Style::default().fg(p.dim)),
+            Span::styled("★", Style::default().fg(p.warn)),
+            Span::styled(" star  ", Style::default().fg(p.dim)),
+            Span::styled("●", Style::default().fg(p.good)),
+            Span::styled(" objects  ", Style::default().fg(p.dim)),
+            Span::styled("◉", Style::default().fg(p.crit)),
+            Span::styled(" black hole  ", Style::default().fg(p.dim)),
+            Span::styled("!", Style::default().fg(p.crit)),
+            Span::styled(" danger  ", Style::default().fg(p.dim)),
+            Span::styled("○", Style::default().fg(p.accent)),
+            Span::styled(" visited  ", Style::default().fg(p.dim)),
+            Span::styled("·", Style::default().fg(p.text)),
+            Span::styled(" empty  ", Style::default().fg(p.dim)),
+            Span::styled("·", Style::default().fg(p.dim)),
+            Span::styled(" unscanned", Style::default().fg(p.dim)),
         ])),
         legend_area,
     );
@@ -191,13 +192,13 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
     if let Some(buf) = &state.map.coord_input {
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("go to (x y z): ", Style::default().fg(Color::Cyan)),
+                Span::styled("go to (x y z): ", Style::default().fg(p.accent)),
                 Span::raw(buf.as_str()),
-                Span::styled("█", Style::default().fg(Color::Cyan)),
+                Span::styled("█", Style::default().fg(p.accent)),
                 Span::raw("  "),
-                Span::styled("[Enter]", Style::default().fg(Color::Green)),
+                Span::styled("[Enter]", Style::default().fg(p.good)),
                 Span::raw(" center  "),
-                Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                Span::styled("[Esc]", Style::default().fg(p.accent)),
                 Span::raw(" cancel"),
             ])),
             hint_area,
@@ -205,17 +206,17 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
     } else {
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("[hjkl]", Style::default().fg(Color::Cyan)),
+                Span::styled("[hjkl]", Style::default().fg(p.accent)),
                 Span::raw(" pan  "),
-                Span::styled("[u/d]", Style::default().fg(Color::Cyan)),
+                Span::styled("[u/d]", Style::default().fg(p.accent)),
                 Span::raw(" y±1  "),
-                Span::styled("[0]", Style::default().fg(Color::Cyan)),
+                Span::styled("[0]", Style::default().fg(p.accent)),
                 Span::raw(" probe  "),
-                Span::styled("[c]", Style::default().fg(Color::Cyan)),
+                Span::styled("[c]", Style::default().fg(p.accent)),
                 Span::raw(" go to  "),
-                Span::styled("[g]", Style::default().fg(Color::Yellow)),
+                Span::styled("[g]", Style::default().fg(p.warn)),
                 Span::raw(" travel  "),
-                Span::styled("[b/Esc]", Style::default().fg(Color::Cyan)),
+                Span::styled("[b/Esc]", Style::default().fg(p.accent)),
                 Span::raw(" close"),
             ])),
             hint_area,
@@ -255,7 +256,7 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
             let is_center = dx == 0 && dz == 0;
 
             let (sym, style) = if is_probe {
-                ("⊕", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+                ("⊕", Style::default().fg(p.accent).add_modifier(Modifier::BOLD))
             } else if let Some(sector) = sector_lookup.get(&(x, y, z)) {
                 let (s, st) = map_cell_symbol(sector);
                 if is_center {
@@ -264,16 +265,16 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
                     (s, st)
                 }
             } else if visited.contains(&(x, y, z)) {
-                let st = Style::default().fg(Color::Blue);
+                let st = Style::default().fg(p.accent);
                 if is_center {
                     ("○", st.add_modifier(Modifier::REVERSED))
                 } else {
                     ("○", st)
                 }
             } else if is_center {
-                ("+", Style::default().fg(Color::DarkGray).add_modifier(Modifier::REVERSED))
+                ("+", Style::default().fg(p.dim).add_modifier(Modifier::REVERSED))
             } else {
-                ("·", Style::default().fg(Color::DarkGray))
+                ("·", Style::default().fg(p.dim))
             };
 
             buf.set_string(tc, tr, sym, style);

--- a/src/ui/overlays/messages.rs
+++ b/src/ui/overlays/messages.rs
@@ -1,7 +1,7 @@
 use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
@@ -21,6 +21,7 @@ fn preview(body: &str) -> String {
 }
 
 pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.messages_input {
         MessagesInput::Browsing { sent_tab, selection } => {
             let popup = centered_rect(76, 80, area);
@@ -29,7 +30,7 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
                 .title(" MESSAGES ")
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::White));
+                .border_style(Style::default().fg(p.text));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -39,12 +40,12 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
                 .split(inner);
 
             // Tabs
-            let inbox_style = if *sent_tab { Style::default().fg(Color::DarkGray) } else { Style::default().fg(Color::White).add_modifier(Modifier::BOLD) };
-            let sent_style = if *sent_tab { Style::default().fg(Color::White).add_modifier(Modifier::BOLD) } else { Style::default().fg(Color::DarkGray) };
+            let inbox_style = if *sent_tab { Style::default().fg(p.dim) } else { Style::default().fg(p.text).add_modifier(Modifier::BOLD) };
+            let sent_style = if *sent_tab { Style::default().fg(p.text).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.dim) };
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
                     Span::styled("Inbox", inbox_style),
-                    Span::styled("   |   ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("   |   ", Style::default().fg(p.dim)),
                     Span::styled("Sent", sent_style),
                 ])),
                 rows[0],
@@ -53,30 +54,30 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             let mut lines: Vec<Line> = Vec::new();
             if *sent_tab {
                 if state.sent_messages.is_empty() {
-                    lines.push(Line::from(Span::styled("No sent messages.", Style::default().fg(Color::DarkGray))));
+                    lines.push(Line::from(Span::styled("No sent messages.", Style::default().fg(p.dim))));
                 }
                 for (i, m) in state.sent_messages.iter().enumerate() {
                     let marker = if i == *selection { "▸ " } else { "  " };
                     lines.push(Line::from(vec![
-                        Span::styled(marker, Style::default().fg(Color::Cyan)),
-                        Span::styled(format!("→ {} ", m.recipient.name), Style::default().fg(Color::White)),
-                        Span::styled(preview(&m.body), Style::default().fg(Color::Gray)),
+                        Span::styled(marker, Style::default().fg(p.accent)),
+                        Span::styled(format!("→ {} ", m.recipient.name), Style::default().fg(p.text)),
+                        Span::styled(preview(&m.body), Style::default().fg(p.text)),
                     ]));
                 }
             } else {
                 if state.messages.is_empty() {
-                    lines.push(Line::from(Span::styled("No messages.", Style::default().fg(Color::DarkGray))));
+                    lines.push(Line::from(Span::styled("No messages.", Style::default().fg(p.dim))));
                 }
                 for (i, m) in state.messages.iter().enumerate() {
                     let marker = if i == *selection { "▸ " } else { "  " };
                     let unread = m.status == MessageStatus::Unread;
-                    let dot = if unread { Span::styled("● ", Style::default().fg(Color::Cyan)) } else { Span::raw("  ") };
-                    let name_style = if unread { Style::default().fg(Color::White).add_modifier(Modifier::BOLD) } else { Style::default().fg(Color::Gray) };
+                    let dot = if unread { Span::styled("● ", Style::default().fg(p.accent)) } else { Span::raw("  ") };
+                    let name_style = if unread { Style::default().fg(p.text).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.text) };
                     lines.push(Line::from(vec![
-                        Span::styled(marker, Style::default().fg(Color::Cyan)),
+                        Span::styled(marker, Style::default().fg(p.accent)),
                         dot,
                         Span::styled(format!("{} ", m.sender.name), name_style),
-                        Span::styled(preview(&m.body), Style::default().fg(Color::DarkGray)),
+                        Span::styled(preview(&m.body), Style::default().fg(p.dim)),
                     ]));
                 }
             }
@@ -84,13 +85,13 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
 
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Tab]", Style::default().fg(p.accent)),
                     Span::raw(" inbox/sent  "),
-                    Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Enter]", Style::default().fg(p.accent)),
                     Span::raw(" read  "),
-                    Span::styled("[c]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[c]", Style::default().fg(p.accent)),
                     Span::raw(" compose  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" close"),
                 ])),
                 rows[2],
@@ -116,7 +117,7 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
                 .title(format!(" MESSAGE → {recipient_name} "))
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Cyan));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -126,19 +127,19 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
                 .split(inner);
 
             let mut lines = vec![Line::from(vec![
-                Span::styled(body_buf.clone(), Style::default().fg(Color::White)),
-                Span::styled("▏", Style::default().fg(Color::Cyan)),
+                Span::styled(body_buf.clone(), Style::default().fg(p.text)),
+                Span::styled("▏", Style::default().fg(p.accent)),
             ])];
             if let Some(err) = error {
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
             }
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
                     Span::raw(" send  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 rows[1],

--- a/src/ui/overlays/messages.rs
+++ b/src/ui/overlays/messages.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -103,7 +104,7 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
             let height = (recipients.len() as u16 + 6).min(16);
             render_pick_list(
-                frame, area, " NEW MESSAGE — recipient ", 54, height,
+                frame, area, palette(state.color_mode), " NEW MESSAGE — recipient ", 54, height,
                 Some("Send to:"), &refs, *selection, None, "compose",
             );
         }

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -35,7 +35,8 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 Some("Select mining target:"), &names, *selection, None, "confirm");
         }
 
-        MineInput::Configure { manny_name, object_name, resources, amount_buf, amount_mode, target_container, error, .. } => {
+        MineInput::Configure { manny_name, object_name, object_id, resources, amount_buf, amount_mode, target_container, error, .. } => {
+            let reserves = state.minable_target_reserves(object_id);
             let popup = centered_rect(52, 15, area);
             frame.render_widget(Clear, popup);
 
@@ -67,17 +68,30 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 ),
             ]));
             for (i, (&label, &_type_str)) in RESOURCE_LABELS.iter().zip(RESOURCE_TYPES.iter()).enumerate() {
-                let checked = if resources[i] { "[✓]" } else { "[ ]" };
-                let (checked_color, label_color) = if resources[i] {
-                    (Color::Green, Color::White)
+                let present = reserves.map(|(f, _)| f[i]).unwrap_or(true);
+                let reserve = reserves.map(|(_, r)| r[i]);
+                let (checkbox, checked_color, label_color) = if !present {
+                    ("[·]", Color::DarkGray, Color::DarkGray)
+                } else if resources[i] {
+                    ("[✓]", Color::Green, Color::White)
                 } else {
-                    (Color::DarkGray, Color::DarkGray)
+                    ("[ ]", Color::DarkGray, Color::Gray)
                 };
-                lines.push(Line::from(vec![
-                    Span::styled(format!("  {checked} "), Style::default().fg(checked_color)),
+                let mut spans = vec![
+                    Span::styled(format!("  {checkbox} "), Style::default().fg(checked_color)),
                     Span::styled(format!("{} ", i + 1), Style::default().fg(Color::DarkGray)),
-                    Span::styled(label, Style::default().fg(label_color)),
-                ]));
+                    Span::styled(format!("{label:<9}"), Style::default().fg(label_color)),
+                ];
+                // Remaining reserve (ECE) when the target exposes it.
+                match (present, reserve) {
+                    (true, Some(r)) if r > 0.0 => spans.push(Span::styled(
+                        format!(" {r:.2}"),
+                        Style::default().fg(Color::DarkGray),
+                    )),
+                    (false, _) => spans.push(Span::styled(" —", Style::default().fg(Color::DarkGray))),
+                    _ => {}
+                }
+                lines.push(Line::from(spans));
             }
 
             lines.push(Line::default());

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -1,13 +1,13 @@
 use crate::app::{AppState, MineInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-use crate::ui::theme::format_duration;
+use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_pick_list};
 pub(crate) fn estimate_mine_duration(target_amount: f64) -> (i64, i64) {
     const CARGO_CAP: f64 = 0.30;
@@ -27,6 +27,7 @@ pub(crate) fn estimate_mine_duration(target_amount: f64) -> (i64, i64) {
 }
 
 pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.mine {
         MineInput::PickAsteroid { manny_name, candidates, selection, .. } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
@@ -47,7 +48,7 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 .title(title)
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Cyan));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -59,36 +60,36 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             let mut lines: Vec<Line> = Vec::new();
 
             // Resources section
-            let res_header_color = if *amount_mode { Color::DarkGray } else { Color::Cyan };
+            let res_header_color = if *amount_mode { p.dim } else { p.accent };
             lines.push(Line::from(vec![
                 Span::styled("Resources", Style::default().fg(res_header_color)),
                 Span::styled(
                     if *amount_mode { "  (Tab to edit)" } else { "  [1-4 to toggle]" },
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(p.dim),
                 ),
             ]));
             for (i, (&label, &_type_str)) in RESOURCE_LABELS.iter().zip(RESOURCE_TYPES.iter()).enumerate() {
                 let present = reserves.map(|(f, _)| f[i]).unwrap_or(true);
                 let reserve = reserves.map(|(_, r)| r[i]);
                 let (checkbox, checked_color, label_color) = if !present {
-                    ("[·]", Color::DarkGray, Color::DarkGray)
+                    ("[·]", p.dim, p.dim)
                 } else if resources[i] {
-                    ("[✓]", Color::Green, Color::White)
+                    ("[✓]", p.good, p.text)
                 } else {
-                    ("[ ]", Color::DarkGray, Color::Gray)
+                    ("[ ]", p.dim, p.text)
                 };
                 let mut spans = vec![
                     Span::styled(format!("  {checkbox} "), Style::default().fg(checked_color)),
-                    Span::styled(format!("{} ", i + 1), Style::default().fg(Color::DarkGray)),
+                    Span::styled(format!("{} ", i + 1), Style::default().fg(p.dim)),
                     Span::styled(format!("{label:<9}"), Style::default().fg(label_color)),
                 ];
                 // Remaining reserve (ECE) when the target exposes it.
                 match (present, reserve) {
                     (true, Some(r)) if r > 0.0 => spans.push(Span::styled(
                         format!(" {r:.2}"),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(p.dim),
                     )),
-                    (false, _) => spans.push(Span::styled(" —", Style::default().fg(Color::DarkGray))),
+                    (false, _) => spans.push(Span::styled(" —", Style::default().fg(p.dim))),
                     _ => {}
                 }
                 lines.push(Line::from(spans));
@@ -97,23 +98,23 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             lines.push(Line::default());
 
             // Amount section
-            let amt_header_color = if *amount_mode { Color::Cyan } else { Color::DarkGray };
+            let amt_header_color = if *amount_mode { p.accent } else { p.dim };
             if *amount_mode {
                 lines.push(Line::from(vec![
                     Span::styled("Amount: ", Style::default().fg(amt_header_color)),
                     Span::raw(amount_buf.as_str()),
-                    Span::styled("█", Style::default().fg(Color::Cyan)),
-                    Span::styled(" ECE", Style::default().fg(Color::DarkGray)),
+                    Span::styled("█", Style::default().fg(p.accent)),
+                    Span::styled(" ECE", Style::default().fg(p.dim)),
                     Span::raw("  "),
-                    Span::styled("[M]", Style::default().fg(Color::Yellow)),
-                    Span::styled(" max", Style::default().fg(Color::DarkGray)),
+                    Span::styled("[M]", Style::default().fg(p.warn)),
+                    Span::styled(" max", Style::default().fg(p.dim)),
                 ]));
             } else {
                 lines.push(Line::from(vec![
                     Span::styled("Amount: ", Style::default().fg(amt_header_color)),
-                    Span::styled(amount_buf.as_str(), Style::default().fg(Color::DarkGray)),
-                    Span::styled(" ECE", Style::default().fg(Color::DarkGray)),
-                    Span::styled("  [Tab to edit]", Style::default().fg(Color::DarkGray)),
+                    Span::styled(amount_buf.as_str(), Style::default().fg(p.dim)),
+                    Span::styled(" ECE", Style::default().fg(p.dim)),
+                    Span::styled("  [Tab to edit]", Style::default().fg(p.dim)),
                 ]));
             }
 
@@ -124,7 +125,7 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                     lines.push(Line::from(vec![
                         Span::styled(
                             format!("{trips} trip{}  •  ~{}", if trips == 1 { "" } else { "s" }, format_duration(secs)),
-                            Style::default().fg(Color::DarkGray),
+                            Style::default().fg(p.dim),
                         ),
                     ]));
                 } else {
@@ -142,9 +143,9 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                     None => "probe (none)",
                 };
                 lines.push(Line::from(vec![
-                    Span::styled("Store in: ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(target_label, Style::default().fg(Color::Cyan)),
-                    Span::styled("  [c] cycle", Style::default().fg(Color::DarkGray)),
+                    Span::styled("Store in: ", Style::default().fg(p.dim)),
+                    Span::styled(target_label, Style::default().fg(p.accent)),
+                    Span::styled("  [c] cycle", Style::default().fg(p.dim)),
                 ]));
             }
 
@@ -153,7 +154,7 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     format!("✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
 
@@ -165,22 +166,22 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             let can_send = any_resource && valid_amount;
             let hint = if *amount_mode {
                 Line::from(vec![
-                    Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Tab]", Style::default().fg(p.accent)),
                     Span::raw(" resources  "),
-                    Span::styled("[Enter]", if can_send { Style::default().fg(Color::Green).add_modifier(Modifier::BOLD) } else { Style::default().fg(Color::DarkGray) }),
+                    Span::styled("[Enter]", if can_send { Style::default().fg(p.good).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.dim) }),
                     Span::raw(" send  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])
             } else {
                 Line::from(vec![
-                    Span::styled("[1-4]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[1-4]", Style::default().fg(p.accent)),
                     Span::raw(" toggle  "),
-                    Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Tab]", Style::default().fg(p.accent)),
                     Span::raw(" amount  "),
-                    Span::styled("[Enter]", if can_send { Style::default().fg(Color::Green).add_modifier(Modifier::BOLD) } else { Style::default().fg(Color::DarkGray) }),
+                    Span::styled("[Enter]", if can_send { Style::default().fg(p.good).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.dim) }),
                     Span::raw(" send  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])
             };

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -32,7 +32,7 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
         MineInput::PickAsteroid { manny_name, candidates, selection, .. } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, &format!(" MINE — {manny_name} "), 50, height,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" MINE — {manny_name} "), 50, height,
                 Some("Select mining target:"), &names, *selection, None, "confirm");
         }
 

--- a/src/ui/overlays/missions.rs
+++ b/src/ui/overlays/missions.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -11,37 +12,37 @@ use crate::app::{AppState, MissionsInput};
 
 use super::centered_rect;
 
-fn mission_status_style(s: &MissionStatus) -> (&'static str, Style) {
+fn mission_status_style(s: &MissionStatus, p: Palette) -> (&'static str, Style) {
     match s {
-        MissionStatus::Active => ("active", Style::default().fg(Color::Cyan)),
-        MissionStatus::Completed => ("done", Style::default().fg(Color::Green)),
-        MissionStatus::Failed => ("failed", Style::default().fg(Color::Red)),
-        MissionStatus::Abandoned => ("abandoned", Style::default().fg(Color::DarkGray)),
-        MissionStatus::Unknown => ("?", Style::default().fg(Color::DarkGray)),
+        MissionStatus::Active => ("active", Style::default().fg(p.accent)),
+        MissionStatus::Completed => ("done", Style::default().fg(p.good)),
+        MissionStatus::Failed => ("failed", Style::default().fg(p.crit)),
+        MissionStatus::Abandoned => ("abandoned", Style::default().fg(p.dim)),
+        MissionStatus::Unknown => ("?", Style::default().fg(p.dim)),
     }
 }
 
-fn step_mark(s: &MissionStepStatus) -> (&'static str, Color) {
+fn step_mark(s: &MissionStepStatus, p: Palette) -> (&'static str, Color) {
     match s {
-        MissionStepStatus::Pending => ("○", Color::Yellow),
-        MissionStepStatus::Completed => ("✔", Color::Green),
-        MissionStepStatus::Failed => ("✗", Color::Red),
-        MissionStepStatus::Skipped => ("–", Color::DarkGray),
-        MissionStepStatus::Unknown => ("?", Color::DarkGray),
+        MissionStepStatus::Pending => ("○", p.warn),
+        MissionStepStatus::Completed => ("✔", p.good),
+        MissionStepStatus::Failed => ("✗", p.crit),
+        MissionStepStatus::Skipped => ("–", p.dim),
+        MissionStepStatus::Unknown => ("?", p.dim),
     }
 }
 
-fn mission_lines(m: &Mission, selected: bool) -> Vec<Line<'static>> {
+fn mission_lines(m: &Mission, selected: bool, p: Palette) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
-    let (status_text, status_style) = mission_status_style(&m.status);
+    let (status_text, status_style) = mission_status_style(&m.status, p);
     let marker = if selected { "▸ " } else { "  " };
     let title_style = if selected {
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+        Style::default().fg(p.text).add_modifier(Modifier::BOLD)
     } else {
         Style::default().add_modifier(Modifier::BOLD)
     };
     lines.push(Line::from(vec![
-        Span::styled(marker, Style::default().fg(Color::Cyan)),
+        Span::styled(marker, Style::default().fg(p.accent)),
         Span::styled(m.title.clone(), title_style),
         Span::raw("  "),
         Span::styled(format!("[{status_text}]"), status_style),
@@ -49,22 +50,23 @@ fn mission_lines(m: &Mission, selected: bool) -> Vec<Line<'static>> {
     if let Some(desc) = &m.description {
         lines.push(Line::from(Span::styled(
             format!("    {desc}"),
-            Style::default().fg(Color::Gray),
+            Style::default().fg(p.text),
         )));
     }
     let mut steps: Vec<&_> = m.steps.iter().collect();
     steps.sort_by_key(|s| s.sort_order);
     for step in steps {
-        let (mark, color) = step_mark(&step.status);
+        let (mark, color) = step_mark(&step.status, p);
         lines.push(Line::from(vec![
             Span::styled(format!("    {mark} "), Style::default().fg(color)),
-            Span::styled(step.title.clone(), Style::default().fg(Color::White)),
+            Span::styled(step.title.clone(), Style::default().fg(p.text)),
         ]));
     }
     lines
 }
 
 pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let selection = match state.missions_input {
         MissionsInput::Browsing { selection } => selection,
         MissionsInput::ConfirmAbandon { selection, .. } => selection,
@@ -77,7 +79,7 @@ pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &App
         .title(" MISSIONS ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::White));
+        .border_style(Style::default().fg(p.text));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -90,11 +92,11 @@ pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &App
     if state.missions.is_empty() {
         lines.push(Line::from(Span::styled(
             "No active missions.",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         )));
     } else {
         for (i, m) in state.missions.iter().enumerate() {
-            lines.extend(mission_lines(m, i == selection));
+            lines.extend(mission_lines(m, i == selection, p));
             lines.push(Line::default());
         }
     }
@@ -102,29 +104,29 @@ pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &App
 
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[↑↓]", Style::default().fg(Color::Cyan)),
+            Span::styled("[↑↓]", Style::default().fg(p.accent)),
             Span::raw(" select  "),
-            Span::styled("[a]", Style::default().fg(Color::Yellow)),
+            Span::styled("[a]", Style::default().fg(p.warn)),
             Span::raw(" abandon  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" close"),
         ])),
         rows[1],
     );
 
     if let MissionsInput::ConfirmAbandon { ref mission_title, ref error, .. } = state.missions_input {
-        render_abandon_confirm(frame, area, mission_title, error.as_deref());
+        render_abandon_confirm(frame, area, mission_title, error.as_deref(), p);
     }
 }
 
-fn render_abandon_confirm(frame: &mut Frame, area: Rect, title: &str, error: Option<&str>) {
+fn render_abandon_confirm(frame: &mut Frame, area: Rect, title: &str, error: Option<&str>, p: Palette) {
     let popup = centered_rect(50, 8, area);
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .title(" ABANDON MISSION ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Yellow));
+        .border_style(Style::default().fg(p.warn));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -135,21 +137,21 @@ fn render_abandon_confirm(frame: &mut Frame, area: Rect, title: &str, error: Opt
 
     let mut lines = vec![Line::from(Span::styled(
         format!("Abandon \"{title}\"?"),
-        Style::default().fg(Color::White),
+        Style::default().fg(p.text),
     ))];
     if let Some(err) = error {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.warn).add_modifier(Modifier::BOLD)),
             Span::raw(" abandon  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" keep"),
         ])),
         rows[1],

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -53,9 +53,10 @@ use crate::app::{
     RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
     ScanMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
+use crate::ui::theme::Palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
@@ -173,6 +174,7 @@ pub(crate) fn centered_rect(width: u16, height: u16, r: Rect) -> Rect {
 pub(crate) fn render_pick_list(
     frame: &mut Frame,
     area: Rect,
+    p: Palette,
     title: &str,
     width: u16,
     height: u16,
@@ -188,7 +190,7 @@ pub(crate) fn render_pick_list(
         .title(title.to_owned())
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -198,38 +200,35 @@ pub(crate) fn render_pick_list(
         .split(inner);
 
     let mut lines: Vec<Line> = Vec::new();
-    if let Some(p) = prompt {
-        lines.push(Line::from(Span::styled(p.to_owned(), Style::default().fg(Color::Cyan))));
+    if let Some(prompt) = prompt {
+        lines.push(Line::from(Span::styled(prompt.to_owned(), Style::default().fg(p.accent))));
         lines.push(Line::default());
     }
     for (i, name) in items.iter().enumerate() {
         if i == selection {
             lines.push(Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(Color::Yellow)),
-                Span::styled(name.to_string(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled("▶ ", Style::default().fg(p.accent)),
+                Span::styled(name.to_string(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
             ]));
         } else {
             lines.push(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(name.to_string(), Style::default().fg(Color::DarkGray)),
+                Span::styled(name.to_string(), Style::default().fg(p.dim)),
             ]));
         }
     }
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(
-            format!("✗ {err}"),
-            Style::default().fg(Color::Red),
-        )));
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
             Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(format!(" {action}  ")),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -53,7 +53,7 @@ use crate::app::{
     RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
     ScanMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
 };
-use crate::ui::theme::Palette;
+use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -160,7 +160,7 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
         render_scan_input_overlay(frame, area, state);
     }
     if state.help_open {
-        render_help_overlay(frame, area);
+        render_help_overlay(frame, area, palette(state.color_mode));
     }
 }
 

--- a/src/ui/overlays/object_actions.rs
+++ b/src/ui/overlays/object_actions.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, ObjectActionInput};
 use ratatui::{
     layout::Rect,
@@ -10,14 +11,14 @@ pub(crate) fn render_object_action_overlay(frame: &mut Frame, area: Rect, state:
         ObjectActionInput::PickAction { object_name, actions, selection, .. } => {
             let labels: Vec<&str> = actions.iter().map(|a| a.label()).collect();
             let height = (actions.len() as u16 + 6).min(14);
-            render_pick_list(frame, area, &format!(" {object_name} "), 46, height,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" {object_name} "), 46, height,
                 Some("Action:"), &labels, *selection, None, "select");
         }
         ObjectActionInput::PickManny { object_name, action, mannies, selection, .. } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(16);
             let prompt = format!("{} — select manny:", action.label());
-            render_pick_list(frame, area, &format!(" {object_name} "), 46, height,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" {object_name} "), 46, height,
                 Some(&prompt), &names, *selection, None, "confirm");
         }
         ObjectActionInput::Inactive => {}

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, MindSnapshotInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput, ScutRelayInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -13,7 +14,7 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
         SalvageInput::PickTarget { manny_name, candidates, selection, .. } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, &format!(" SALVAGE — {manny_name} "), 50, height,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" SALVAGE — {manny_name} "), 50, height,
                 Some("Select salvage target:"), &names, *selection, None, "confirm");
         }
 
@@ -365,14 +366,14 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         DeployInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, " DEPLOY WAYPOINT — SELECT MANNY ", 52, height,
+            render_pick_list(frame, area, palette(state.color_mode), " DEPLOY WAYPOINT — SELECT MANNY ", 52, height,
                 None, &names, *selection, None, "confirm");
         }
 
         DeployInput::PickObject { candidates, selection, .. } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, " DEPLOY WAYPOINT ", 52, height,
+            render_pick_list(frame, area, palette(state.color_mode), " DEPLOY WAYPOINT ", 52, height,
                 None, &names, *selection, None, "confirm");
         }
 
@@ -427,7 +428,7 @@ pub(crate) fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppS
     let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
-    render_pick_list(frame, area, &format!(" INSPECT — {manny_name} "), 52, height,
+    render_pick_list(frame, area, palette(state.color_mode), &format!(" INSPECT — {manny_name} "), 52, height,
         Some("Select asteroid to inspect:"), &names, selection, error.as_deref(), "inspect");
 }
 
@@ -436,7 +437,7 @@ pub(crate) fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppS
     let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
-    render_pick_list(frame, area, &format!(" RECOVER — {manny_name} "), 52, height,
+    render_pick_list(frame, area, palette(state.color_mode), &format!(" RECOVER — {manny_name} "), 52, height,
         Some("Select container to recover:"), &names, selection, error.as_deref(), "recover");
 }
 
@@ -445,14 +446,14 @@ pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         DetachInput::PickContainer { manny_name, containers, selection, .. } => {
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, &format!(" DETACH — {manny_name} "), 52, height,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" DETACH — {manny_name} "), 52, height,
                 Some("Select container to detach:"), &names, *selection, None, "next");
         }
 
         DetachInput::PickMode { manny_name, container_name, selection, error, .. } => {
             let names: Vec<&str> = crate::app::DETACH_MODES.iter().map(|(_, l)| *l).collect();
             let prompt = format!("Detach mode  (manny: {manny_name})");
-            render_pick_list(frame, area, &format!(" DETACH — {container_name} "), 52, 10,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" DETACH — {container_name} "), 52, 10,
                 Some(&prompt), &names, *selection, error.as_deref(), "confirm");
         }
 
@@ -460,7 +461,7 @@ pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             let names: Vec<&str> = asteroids.iter().map(|(_, n)| n.as_str()).collect();
             let height = (asteroids.len() as u16 + 8).min(18);
             let prompt = format!("Attach to asteroid  (manny: {manny_name})");
-            render_pick_list(frame, area, &format!(" DETACH — hide {container_name} "), 52, height,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" DETACH — hide {container_name} "), 52, height,
                 Some(&prompt), &names, *selection, error.as_deref(), "hide here");
         }
 

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -2,7 +2,7 @@ use crate::ui::theme::palette;
 use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, MindSnapshotInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput, ScutRelayInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
@@ -10,11 +10,12 @@ use ratatui::{
 
 use super::{centered_rect, render_pick_list};
 pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.salvage {
         SalvageInput::PickTarget { manny_name, candidates, selection, .. } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" SALVAGE — {manny_name} "), 50, height,
+            render_pick_list(frame, area, p, &format!(" SALVAGE — {manny_name} "), 50, height,
                 Some("Select salvage target:"), &names, *selection, None, "confirm");
         }
 
@@ -25,7 +26,7 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
                 .title(format!(" SALVAGE — {manny_name} "))
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Cyan));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -36,22 +37,22 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
 
             let mut lines: Vec<Line> = Vec::new();
             lines.push(Line::from(vec![
-                Span::styled("Target: ", Style::default().fg(Color::DarkGray)),
-                Span::styled(object_name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled("Target: ", Style::default().fg(p.dim)),
+                Span::styled(object_name.as_str(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
             ]));
             if let Some(err) = error {
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     format!("✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
                     Span::raw(" SALVAGE  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 rows[1],
@@ -63,6 +64,7 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
 }
 
 pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let DropCargoInput::Confirm { ref manny_name, ref error, .. } = state.drop_cargo else { return };
 
     let popup = centered_rect(54, 8, area);
@@ -73,7 +75,7 @@ pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &A
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Red));
+        .border_style(Style::default().fg(p.crit));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -85,23 +87,23 @@ pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &A
     let mut lines: Vec<Line> = vec![
         Line::from(Span::styled(
             "Drop cargo and retry docking?",
-            Style::default().fg(Color::White),
+            Style::default().fg(p.text),
         )),
         Line::from(Span::styled(
             "Resource cargo is lost (objects return to sector).",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         )),
     ];
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter/y]", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter/y]", Style::default().fg(p.crit).add_modifier(Modifier::BOLD)),
             Span::raw(" DROP  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -109,6 +111,7 @@ pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &A
 }
 
 pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let RecallInput::Confirm { ref manny_name, remote, ref error, .. } = state.recall else { return };
 
     let popup = centered_rect(52, 8, area);
@@ -123,7 +126,7 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Yellow));
+        .border_style(Style::default().fg(p.warn));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -135,27 +138,27 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
         if remote { "Abandon this Manny's remote task?" } else { "Send recall order?" },
-        Style::default().fg(Color::White),
+        Style::default().fg(p.text),
     )));
     if remote {
         lines.push(Line::from(Span::styled(
             "It will be left forgotten in its sector (no return).",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         )));
     }
     if let Some(err) = error {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.warn).add_modifier(Modifier::BOLD)),
             Span::raw(if remote { " ABANDON  " } else { " RECALL  " }),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -163,6 +166,7 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 }
 
 pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let RefuelInput::Confirm { ref manny_name, ref error, .. } = state.refuel else { return };
 
     let popup = centered_rect(50, 7, area);
@@ -173,7 +177,7 @@ pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Green));
+        .border_style(Style::default().fg(p.good));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -185,21 +189,21 @@ pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
         "Refill the probe deuterium tank?",
-        Style::default().fg(Color::White),
+        Style::default().fg(p.text),
     )));
     if let Some(err) = error {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" REFUEL  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -207,6 +211,7 @@ pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 }
 
 pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let ScutRelayInput::EnterNetworkName { ref manny_name, ref relay_name, ref buf, ref error, .. } =
         state.scut_relay
     else {
@@ -220,7 +225,7 @@ pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &A
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::LightBlue));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -232,25 +237,25 @@ pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &A
     let mut lines = vec![
         Line::from(Span::styled(
             format!("Manny: {manny_name}"),
-            Style::default().fg(Color::Gray),
+            Style::default().fg(p.text),
         )),
         Line::default(),
         Line::from(vec![
-            Span::styled("Network name (optional): ", Style::default().fg(Color::White)),
-            Span::styled(buf.clone(), Style::default().fg(Color::LightBlue)),
-            Span::styled("▏", Style::default().fg(Color::DarkGray)),
+            Span::styled("Network name (optional): ", Style::default().fg(p.text)),
+            Span::styled(buf.clone(), Style::default().fg(p.accent)),
+            Span::styled("▏", Style::default().fg(p.dim)),
         ]),
     ];
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.accent).add_modifier(Modifier::BOLD)),
             Span::raw(" turn on  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -258,6 +263,7 @@ pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &A
 }
 
 pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let MindSnapshotInput::Confirm { ref error } = state.mind_snapshot else { return };
     let alert = state.probe_terminal_alert();
 
@@ -271,7 +277,7 @@ pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state:
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD));
+        .border_style(Style::default().fg(p.crit).add_modifier(Modifier::BOLD));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -284,31 +290,31 @@ pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state:
     if let Some(a) = alert {
         lines.push(Line::from(Span::styled(
             a.message.clone(),
-            Style::default().fg(Color::White),
+            Style::default().fg(p.text),
         )));
         lines.push(Line::default());
     }
     lines.push(Line::from(Span::styled(
         "Reassign your mind snapshot to a fresh probe?",
-        Style::default().fg(Color::White),
+        Style::default().fg(p.text),
     )));
     lines.push(Line::from(Span::styled(
         "The terminal probe is deleted and the local reference frame resets to 0,0,0.",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(p.dim),
     )));
     if let Some(err) = error {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.crit).add_modifier(Modifier::BOLD)),
             Span::raw(" REASSIGN  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -316,6 +322,7 @@ pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state:
 }
 
 pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let RenameMannyInput::Typing { ref manny_name, ref buf, ref error, .. } = state.rename_manny else { return };
 
     let popup = centered_rect(46, 7, area);
@@ -326,7 +333,7 @@ pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: 
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -337,24 +344,24 @@ pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: 
 
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(vec![
-        Span::styled("Name: ", Style::default().fg(Color::Cyan)),
+        Span::styled("Name: ", Style::default().fg(p.accent)),
         Span::raw(buf.as_str()),
-        Span::styled("█", Style::default().fg(Color::Cyan)),
+        Span::styled("█", Style::default().fg(p.accent)),
     ]));
     if let Some(err) = error {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
 
     frame.render_widget(Paragraph::new(lines), rows[0]);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" rename  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],
@@ -362,18 +369,19 @@ pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: 
 }
 
 pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.deploy {
         DeployInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, palette(state.color_mode), " DEPLOY WAYPOINT — SELECT MANNY ", 52, height,
+            render_pick_list(frame, area, p, " DEPLOY WAYPOINT — SELECT MANNY ", 52, height,
                 None, &names, *selection, None, "confirm");
         }
 
         DeployInput::PickObject { candidates, selection, .. } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, palette(state.color_mode), " DEPLOY WAYPOINT ", 52, height,
+            render_pick_list(frame, area, p, " DEPLOY WAYPOINT ", 52, height,
                 None, &names, *selection, None, "confirm");
         }
 
@@ -385,7 +393,7 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 .title(title)
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Cyan));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -396,23 +404,23 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
             let mut lines: Vec<Line> = Vec::new();
             lines.push(Line::from(vec![
-                Span::styled("Name: ", Style::default().fg(Color::Cyan)),
+                Span::styled("Name: ", Style::default().fg(p.accent)),
                 Span::raw(name_buf.as_str()),
-                Span::styled("█", Style::default().fg(Color::Cyan)),
+                Span::styled("█", Style::default().fg(p.accent)),
             ]));
             if let Some(err) = error {
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     format!("✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
                     Span::raw(" DEPLOY  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 rows[1],
@@ -424,36 +432,39 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 }
 
 pub(crate) fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let InspectInput::PickAsteroid { ref manny_name, ref candidates, selection, ref error, .. } = state.inspect else { return };
     let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
-    render_pick_list(frame, area, palette(state.color_mode), &format!(" INSPECT — {manny_name} "), 52, height,
+    render_pick_list(frame, area, p, &format!(" INSPECT — {manny_name} "), 52, height,
         Some("Select asteroid to inspect:"), &names, selection, error.as_deref(), "inspect");
 }
 
 pub(crate) fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let RecoverInput::PickContainer { ref manny_name, ref candidates, selection, ref error, .. } = state.recover else { return };
     let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
-    render_pick_list(frame, area, palette(state.color_mode), &format!(" RECOVER — {manny_name} "), 52, height,
+    render_pick_list(frame, area, p, &format!(" RECOVER — {manny_name} "), 52, height,
         Some("Select container to recover:"), &names, selection, error.as_deref(), "recover");
 }
 
 pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.detach {
         DetachInput::PickContainer { manny_name, containers, selection, .. } => {
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" DETACH — {manny_name} "), 52, height,
+            render_pick_list(frame, area, p, &format!(" DETACH — {manny_name} "), 52, height,
                 Some("Select container to detach:"), &names, *selection, None, "next");
         }
 
         DetachInput::PickMode { manny_name, container_name, selection, error, .. } => {
             let names: Vec<&str> = crate::app::DETACH_MODES.iter().map(|(_, l)| *l).collect();
             let prompt = format!("Detach mode  (manny: {manny_name})");
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" DETACH — {container_name} "), 52, 10,
+            render_pick_list(frame, area, p, &format!(" DETACH — {container_name} "), 52, 10,
                 Some(&prompt), &names, *selection, error.as_deref(), "confirm");
         }
 
@@ -461,7 +472,7 @@ pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             let names: Vec<&str> = asteroids.iter().map(|(_, n)| n.as_str()).collect();
             let height = (asteroids.len() as u16 + 8).min(18);
             let prompt = format!("Attach to asteroid  (manny: {manny_name})");
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" DETACH — hide {container_name} "), 52, height,
+            render_pick_list(frame, area, p, &format!(" DETACH — hide {container_name} "), 52, height,
                 Some(&prompt), &names, *selection, error.as_deref(), "hide here");
         }
 

--- a/src/ui/overlays/remote_mine.rs
+++ b/src/ui/overlays/remote_mine.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -38,7 +39,7 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
             render_pick_list(
-                frame, area, &format!(" REMOTE MINE — {manny_name} "), 52, height,
+                frame, area, palette(state.color_mode), &format!(" REMOTE MINE — {manny_name} "), 52, height,
                 Some("Asteroid in the Manny's sector:"), &names, *selection, None, "next",
             );
         }
@@ -101,7 +102,7 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(16);
             render_pick_list(
-                frame, area, " REMOTE MINE — store in ", 52, height,
+                frame, area, palette(state.color_mode), " REMOTE MINE — store in ", 52, height,
                 Some("Detached container (required):"), &names, *selection, None, "mine",
             );
         }

--- a/src/ui/overlays/remote_mine.rs
+++ b/src/ui/overlays/remote_mine.rs
@@ -1,7 +1,7 @@
 use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
@@ -11,6 +11,7 @@ use crate::app::{AppState, RemoteMineInput, RESOURCE_LABELS};
 use super::{centered_rect, render_pick_list};
 
 pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.remote_mine {
         RemoteMineInput::Loading { manny_name, x, y, z, .. } => {
             let popup = centered_rect(50, 5, area);
@@ -19,16 +20,16 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
                 .title(format!(" REMOTE MINE — {manny_name} "))
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::LightBlue));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
                     Span::styled(
                         format!("scanning sector ({x},{y},{z}) via SCUT… "),
-                        Style::default().fg(Color::Gray),
+                        Style::default().fg(p.text),
                     ),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 inner,
@@ -51,7 +52,7 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
                 .title(format!(" REMOTE MINE → {object_name} "))
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::LightBlue));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -61,37 +62,37 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
                 .split(inner);
 
             let mut lines: Vec<Line> = Vec::new();
-            let res_color = if *amount_mode { Color::DarkGray } else { Color::LightBlue };
+            let res_color = if *amount_mode { p.dim } else { p.accent };
             lines.push(Line::from(Span::styled("Resources  [1-4 toggle]", Style::default().fg(res_color))));
             for (i, &label) in RESOURCE_LABELS.iter().enumerate() {
                 let checked = if resources[i] { "[✓]" } else { "[ ]" };
-                let color = if resources[i] { Color::White } else { Color::DarkGray };
+                let color = if resources[i] { p.text } else { p.dim };
                 lines.push(Line::from(vec![
-                    Span::styled(format!("  {checked} "), Style::default().fg(if resources[i] { Color::Green } else { Color::DarkGray })),
+                    Span::styled(format!("  {checked} "), Style::default().fg(if resources[i] { p.good } else { p.dim })),
                     Span::styled(format!("{} {label}", i + 1), Style::default().fg(color)),
                 ]));
             }
             lines.push(Line::default());
-            let amt_color = if *amount_mode { Color::LightBlue } else { Color::DarkGray };
+            let amt_color = if *amount_mode { p.accent } else { p.dim };
             lines.push(Line::from(vec![
                 Span::styled("Amount: ", Style::default().fg(amt_color)),
-                Span::styled(amount_buf.as_str(), Style::default().fg(if *amount_mode { Color::White } else { Color::DarkGray })),
-                Span::styled(if *amount_mode { "█ ECE" } else { " ECE  [Tab]" }, Style::default().fg(Color::DarkGray)),
+                Span::styled(amount_buf.as_str(), Style::default().fg(if *amount_mode { p.text } else { p.dim })),
+                Span::styled(if *amount_mode { "█ ECE" } else { " ECE  [Tab]" }, Style::default().fg(p.dim)),
             ]));
             if let Some(err) = error {
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[1-4]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[1-4]", Style::default().fg(p.accent)),
                     Span::raw(" res  "),
-                    Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Tab]", Style::default().fg(p.accent)),
                     Span::raw(" amount  "),
-                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
                     Span::raw(" container →  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 rows[1],

--- a/src/ui/overlays/repair.rs
+++ b/src/ui/overlays/repair.rs
@@ -1,15 +1,16 @@
 use crate::app::{AppState, RepairInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-use crate::ui::theme::format_duration;
+use crate::ui::theme::{format_duration, palette};
 use super::centered_rect;
 pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let RepairInput::Typing { ref manny_name, ref buf, ref error, .. } = state.repair else { return };
 
     let max_pct = state.repair_max_percent();
@@ -29,7 +30,7 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         .title(title)
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -44,51 +45,51 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
     // Input line
     lines.push(Line::from(vec![
-        Span::styled("Restore: ", Style::default().fg(Color::Cyan)),
+        Span::styled("Restore: ", Style::default().fg(p.accent)),
         Span::raw(buf.as_str()),
-        Span::styled("█", Style::default().fg(Color::Cyan)),
-        Span::styled("%", Style::default().fg(Color::DarkGray)),
+        Span::styled("█", Style::default().fg(p.accent)),
+        Span::styled("%", Style::default().fg(p.dim)),
     ]));
 
     lines.push(Line::default());
 
     // MAX hint
     lines.push(Line::from(vec![
-        Span::styled("MAX  ", Style::default().fg(Color::DarkGray)),
-        Span::styled(format!("{max_pct:.2}%"), Style::default().fg(Color::White)),
+        Span::styled("MAX  ", Style::default().fg(p.dim)),
+        Span::styled(format!("{max_pct:.2}%"), Style::default().fg(p.text)),
         Span::raw("   "),
-        Span::styled("[M]", Style::default().fg(Color::Yellow)),
-        Span::styled(" fill", Style::default().fg(Color::DarkGray)),
+        Span::styled("[M]", Style::default().fg(p.warn)),
+        Span::styled(" fill", Style::default().fg(p.dim)),
     ]));
 
     lines.push(Line::default());
 
     // Cost preview (only when input is parseable)
     if let (Some(metals), Some(secs)) = (metals_cost, duration_secs) {
-        let metals_color = if insufficient { Color::Red } else { Color::White };
+        let metals_color = if insufficient { p.crit } else { p.text };
         lines.push(Line::from(vec![
-            Span::styled("Metals  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Metals  ", Style::default().fg(p.dim)),
             Span::styled(format!("{metals:.4}"), Style::default().fg(metals_color)),
-            Span::styled(" ECE", Style::default().fg(Color::DarkGray)),
+            Span::styled(" ECE", Style::default().fg(p.dim)),
             if insufficient {
                 Span::styled(
                     format!("  (have {metals_stock:.4})"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )
             } else {
                 Span::raw("")
             },
         ]));
         lines.push(Line::from(vec![
-            Span::styled("Time    ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format_duration(secs), Style::default().fg(Color::Yellow)),
+            Span::styled("Time    ", Style::default().fg(p.dim)),
+            Span::styled(format_duration(secs), Style::default().fg(p.warn)),
         ]));
         if let Some(eff) = effective {
             if parsed.is_some_and(|v| v > max_pct + 0.001) {
                 lines.push(Line::from(vec![
                     Span::styled(
                         format!("  → capped at {eff:.2}% (probe already at max above)"),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(p.dim),
                     ),
                 ]));
             }
@@ -96,7 +97,7 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     } else {
         lines.push(Line::from(Span::styled(
             "type a value to see cost",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         )));
     }
 
@@ -105,7 +106,7 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!("✗ {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(p.crit),
         )));
     }
 
@@ -115,16 +116,16 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     let can_send = parsed.is_some() && !insufficient;
     let hint = if can_send {
         Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" send  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])
     } else {
         Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::DarkGray)),
+            Span::styled("[Enter]", Style::default().fg(p.dim)),
             Span::raw(" send  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])
     };

--- a/src/ui/overlays/scanner.rs
+++ b/src/ui/overlays/scanner.rs
@@ -1,7 +1,8 @@
+use crate::ui::theme::{palette, Palette};
 use crate::app::{AppState, ScanMode};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
@@ -13,21 +14,22 @@ use super::centered_rect;
 /// are handled by the shared scan-input router in `input/mod.rs`; this only
 /// renders the prompt.
 pub(crate) fn render_scan_input_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.scan_mode {
-        ScanMode::Input(buf) => render_coord_input(frame, area, buf),
+        ScanMode::Input(buf) => render_coord_input(frame, area, buf, p),
         ScanMode::DirectionPick => render_direction_pick(frame, area, state),
         ScanMode::Current => {}
     }
 }
 
-fn render_coord_input(frame: &mut Frame, area: Rect, buf: &str) {
+fn render_coord_input(frame: &mut Frame, area: Rect, buf: &str, p: Palette) {
     let popup = centered_rect(52, 7, area);
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .title(" OBSERVE SECTOR ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -39,23 +41,23 @@ fn render_coord_input(frame: &mut Frame, area: Rect, buf: &str) {
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
             "relative coordinates, space-separated",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(p.dim),
         ))),
         rows[0],
     );
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("x y z: ", Style::default().fg(Color::Cyan)),
+            Span::styled("x y z: ", Style::default().fg(p.accent)),
             Span::raw(buf),
-            Span::styled("█", Style::default().fg(Color::Cyan)),
+            Span::styled("█", Style::default().fg(p.accent)),
         ])),
         rows[1],
     );
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" observe  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[2],
@@ -63,13 +65,14 @@ fn render_coord_input(frame: &mut Frame, area: Rect, buf: &str) {
 }
 
 fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let popup = centered_rect(52, 7, area);
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .title(" SCAN NEIGHBORS ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -85,8 +88,8 @@ fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
     frame.render_widget(
         Paragraph::new(vec![
             Line::from(vec![
-                Span::styled("from ", Style::default().fg(Color::DarkGray)),
-                Span::styled(origin, Style::default().fg(Color::White)),
+                Span::styled("from ", Style::default().fg(p.dim)),
+                Span::styled(origin, Style::default().fg(p.text)),
             ]),
             Line::default(),
             Line::from("pick an axis to sweep its two faces:"),
@@ -95,9 +98,9 @@ fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
     );
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[x] [y] [z]", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::styled("[x] [y] [z]", Style::default().fg(p.accent).add_modifier(Modifier::BOLD)),
             Span::raw(" scan  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
         ])),
         rows[1],

--- a/src/ui/overlays/scut_network.rs
+++ b/src/ui/overlays/scut_network.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -24,9 +25,7 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
             let items: Vec<&str> = networks.iter().map(|(_, name)| name.as_str()).collect();
             let height = (items.len() as u16) + 4;
             render_pick_list(
-                frame,
-                area,
-                " SCUT NETWORK ",
+                frame, area, palette(state.color_mode), " SCUT NETWORK ",
                 52,
                 height,
                 Some("Pick a network to inspect"),

--- a/src/ui/overlays/scut_network.rs
+++ b/src/ui/overlays/scut_network.rs
@@ -1,7 +1,7 @@
 use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
@@ -20,6 +20,7 @@ fn rel(sector: &ProbeSector) -> String {
 }
 
 pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.scut_network {
         ScutNetworkInput::Picking { networks, selection } => {
             let items: Vec<&str> = networks.iter().map(|(_, name)| name.as_str()).collect();
@@ -42,7 +43,7 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
                 .title(" SCUT NETWORK ")
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::LightBlue));
+                .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
 
@@ -55,55 +56,55 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
             if let Some(err) = error {
                 lines.push(Line::from(Span::styled(
                     format!("✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             } else if let Some(net) = &state.scut_network_view {
                 lines.push(Line::from(vec![
-                    Span::styled(net.name.clone(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+                    Span::styled(net.name.clone(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
                     Span::raw("   "),
                     Span::styled(
                         format!("{} relays · {} sectors covered", net.relay_count, net.covered_sector_count),
-                        Style::default().fg(Color::Gray),
+                        Style::default().fg(p.text),
                     ),
                 ]));
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled("RELAYS", Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD))));
+                lines.push(Line::from(Span::styled("RELAYS", Style::default().fg(p.accent).add_modifier(Modifier::BOLD))));
                 for r in &net.relays {
                     let (mark, color) = match r.status {
-                        ScutRelayStatus::On => ("●", Color::Green),
-                        ScutRelayStatus::Off => ("○", Color::DarkGray),
-                        ScutRelayStatus::Unknown => ("?", Color::DarkGray),
+                        ScutRelayStatus::On => ("●", p.good),
+                        ScutRelayStatus::Off => ("○", p.dim),
+                        ScutRelayStatus::Unknown => ("?", p.dim),
                     };
                     let by = r.created_by_probe_name.clone().unwrap_or_else(|| "—".into());
                     lines.push(Line::from(vec![
                         Span::styled(format!("  {mark} "), Style::default().fg(color)),
-                        Span::styled(rel(&r.sector), Style::default().fg(Color::White)),
+                        Span::styled(rel(&r.sector), Style::default().fg(p.text)),
                         Span::styled(
                             format!("  r={}  by {by}", r.coverage_radius_sectors),
-                            Style::default().fg(Color::DarkGray),
+                            Style::default().fg(p.dim),
                         ),
                     ]));
                 }
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled("PROBES", Style::default().fg(Color::LightBlue).add_modifier(Modifier::BOLD))));
+                lines.push(Line::from(Span::styled("PROBES", Style::default().fg(p.accent).add_modifier(Modifier::BOLD))));
                 if net.probes.is_empty() {
-                    lines.push(Line::from(Span::styled("  none detected", Style::default().fg(Color::DarkGray))));
+                    lines.push(Line::from(Span::styled("  none detected", Style::default().fg(p.dim))));
                 } else {
-                    for p in &net.probes {
+                    for probe in &net.probes {
                         lines.push(Line::from(vec![
-                            Span::styled("  ◆ ", Style::default().fg(Color::Cyan)),
-                            Span::styled(p.name.clone(), Style::default().fg(Color::White)),
-                            Span::styled(format!("  {}", rel(&p.sector)), Style::default().fg(Color::DarkGray)),
+                            Span::styled("  ◆ ", Style::default().fg(p.accent)),
+                            Span::styled(probe.name.clone(), Style::default().fg(p.text)),
+                            Span::styled(format!("  {}", rel(&probe.sector)), Style::default().fg(p.dim)),
                         ]));
                     }
                 }
             } else {
-                lines.push(Line::from(Span::styled("loading…", Style::default().fg(Color::DarkGray))));
+                lines.push(Line::from(Span::styled("loading…", Style::default().fg(p.dim))));
             }
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" close"),
                 ])),
                 rows[1],

--- a/src/ui/overlays/storage_move.rs
+++ b/src/ui/overlays/storage_move.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, StorageMoveInput, MOVE_RESOURCE_TYPES};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -57,11 +58,11 @@ pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: 
         StorageMoveInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, " STORAGE MOVE — SELECT MANNY ", 52, height,
+            render_pick_list(frame, area, palette(state.color_mode), " STORAGE MOVE — SELECT MANNY ", 52, height,
                 None, &names, *selection, None, "select");
         }
         StorageMoveInput::PickKind { selection, .. } => {
-            render_pick_list(frame, area, " STORAGE MOVE — KIND ", 46, 8,
+            render_pick_list(frame, area, palette(state.color_mode), " STORAGE MOVE — KIND ", 46, 8,
                 None, &["resource", "item"], *selection, None, "select");
         }
         StorageMoveInput::ConfigureResource {

--- a/src/ui/overlays/storage_move.rs
+++ b/src/ui/overlays/storage_move.rs
@@ -1,8 +1,8 @@
-use crate::ui::theme::palette;
+use crate::ui::theme::{palette, Palette};
 use crate::app::{AppState, StorageMoveInput, MOVE_RESOURCE_TYPES};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
     Frame,
@@ -10,14 +10,14 @@ use ratatui::{
 
 use super::{centered_rect, render_pick_list};
 
-fn framed(title: &str, area: Rect, width: u16, height: u16, frame: &mut Frame) -> [Rect; 2] {
+fn framed(p: Palette, title: &str, area: Rect, width: u16, height: u16, frame: &mut Frame) -> [Rect; 2] {
     let popup = centered_rect(width, height, area);
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .title(title.to_owned())
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
     let rows = Layout::default()
@@ -28,11 +28,11 @@ fn framed(title: &str, area: Rect, width: u16, height: u16, frame: &mut Frame) -
 }
 
 /// One `label: < value >` form row, highlighted when active.
-fn field_row(label: &str, value: String, active: bool, editing: bool) -> Line<'static> {
+fn field_row(p: Palette, label: &str, value: String, active: bool, editing: bool) -> Line<'static> {
     let lab_style = if active {
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        Style::default().fg(p.accent).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(p.dim)
     };
     let val = if editing {
         format!("{value}█")
@@ -42,9 +42,9 @@ fn field_row(label: &str, value: String, active: bool, editing: bool) -> Line<'s
         format!("  {value}  ")
     };
     let val_style = if active {
-        Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
+        Style::default().fg(p.text).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::Gray)
+        Style::default().fg(p.text)
     };
     Line::from(vec![
         Span::styled(format!("{label:<10}"), lab_style),
@@ -53,47 +53,48 @@ fn field_row(label: &str, value: String, active: bool, editing: bool) -> Line<'s
 }
 
 pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     match &state.storage_move {
         StorageMoveInput::Inactive => {}
         StorageMoveInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, palette(state.color_mode), " STORAGE MOVE — SELECT MANNY ", 52, height,
+            render_pick_list(frame, area, p, " STORAGE MOVE — SELECT MANNY ", 52, height,
                 None, &names, *selection, None, "select");
         }
         StorageMoveInput::PickKind { selection, .. } => {
-            render_pick_list(frame, area, palette(state.color_mode), " STORAGE MOVE — KIND ", 46, 8,
+            render_pick_list(frame, area, p, " STORAGE MOVE — KIND ", 46, 8,
                 None, &["resource", "item"], *selection, None, "select");
         }
         StorageMoveInput::ConfigureResource {
             containers, resource_idx, from_sel, to_sel, amount_buf, field, error, ..
         } => {
-            let [body, footer] = framed(" STORAGE MOVE — RESOURCE ", area, 56, 9, frame);
+            let [body, footer] = framed(p, " STORAGE MOVE — RESOURCE ", area, 56, 9, frame);
             let cname = |i: usize| containers.get(i).map(|(_, l)| l.clone()).unwrap_or_default();
             let lines = vec![
-                field_row("Resource:", MOVE_RESOURCE_TYPES[*resource_idx].to_string(), *field == 0, false),
-                field_row("From:", cname(*from_sel), *field == 1, false),
-                field_row("To:", cname(*to_sel), *field == 2, false),
-                field_row("Amount:", format!("{amount_buf} ECE"), *field == 3, *field == 3),
-                error_line(error),
+                field_row(p, "Resource:", MOVE_RESOURCE_TYPES[*resource_idx].to_string(), *field == 0, false),
+                field_row(p, "From:", cname(*from_sel), *field == 1, false),
+                field_row(p, "To:", cname(*to_sel), *field == 2, false),
+                field_row(p, "Amount:", format!("{amount_buf} ECE"), *field == 3, *field == 3),
+                error_line(p, error),
             ];
             frame.render_widget(Paragraph::new(lines), body);
-            frame.render_widget(form_footer(), footer);
+            frame.render_widget(form_footer(p), footer);
         }
         StorageMoveInput::ConfigureItem {
             containers, items, to_sel, item_cursor, field, error, ..
         } => {
             let height = (items.len() as u16 + 7).clamp(10, 22);
-            let [body, footer] = framed(" STORAGE MOVE — ITEMS ", area, 60, height, frame);
+            let [body, footer] = framed(p, " STORAGE MOVE — ITEMS ", area, 60, height, frame);
             let rows = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Length(2), Constraint::Min(1)])
                 .split(body);
 
             let dest = containers.get(*to_sel).map(|(_, l)| l.clone()).unwrap_or_default();
-            let mut head = vec![field_row("To:", dest, *field == 1, false)];
+            let mut head = vec![field_row(p, "To:", dest, *field == 1, false)];
             if let Some(err) = error {
-                head.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))));
+                head.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
             }
             frame.render_widget(Paragraph::new(head), rows[0]);
 
@@ -101,10 +102,10 @@ pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: 
                 .iter()
                 .map(|(_, label, sel)| {
                     let mark = if *sel { "[x] " } else { "[ ] " };
-                    let color = if *sel { Color::Green } else { Color::DarkGray };
+                    let color = if *sel { p.good } else { p.dim };
                     ListItem::new(Line::from(vec![
                         Span::styled(mark, Style::default().fg(color)),
-                        Span::styled(label.clone(), Style::default().fg(Color::White)),
+                        Span::styled(label.clone(), Style::default().fg(p.text)),
                     ]))
                 })
                 .collect();
@@ -119,42 +120,42 @@ pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: 
                 ls.select(Some((*item_cursor).min(items.len() - 1)));
             }
             frame.render_stateful_widget(list, rows[1], &mut ls);
-            frame.render_widget(item_footer(), footer);
+            frame.render_widget(item_footer(p), footer);
         }
     }
 }
 
-fn error_line(error: &Option<String>) -> Line<'static> {
+fn error_line(p: Palette, error: &Option<String>) -> Line<'static> {
     match error {
-        Some(err) => Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(Color::Red))),
+        Some(err) => Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))),
         None => Line::default(),
     }
 }
 
-fn form_footer() -> Paragraph<'static> {
+fn form_footer(p: Palette) -> Paragraph<'static> {
     Paragraph::new(Line::from(vec![
-        Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+        Span::styled("[↑/↓]", Style::default().fg(p.accent)),
         Span::raw(" field  "),
-        Span::styled("[←/→]", Style::default().fg(Color::Cyan)),
+        Span::styled("[←/→]", Style::default().fg(p.accent)),
         Span::raw(" change  "),
-        Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+        Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
         Span::raw(" move  "),
-        Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+        Span::styled("[Esc]", Style::default().fg(p.accent)),
         Span::raw(" cancel"),
     ]))
 }
 
-fn item_footer() -> Paragraph<'static> {
+fn item_footer(p: Palette) -> Paragraph<'static> {
     Paragraph::new(Line::from(vec![
-        Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
+        Span::styled("[Tab]", Style::default().fg(p.accent)),
         Span::raw(" pane  "),
-        Span::styled("[Space]", Style::default().fg(Color::Cyan)),
+        Span::styled("[Space]", Style::default().fg(p.accent)),
         Span::raw(" toggle  "),
-        Span::styled("[←/→]", Style::default().fg(Color::Cyan)),
+        Span::styled("[←/→]", Style::default().fg(p.accent)),
         Span::raw(" dest  "),
-        Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+        Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
         Span::raw(" move  "),
-        Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+        Span::styled("[Esc]", Style::default().fg(p.accent)),
         Span::raw(" cancel"),
     ]))
 }

--- a/src/ui/overlays/travel.rs
+++ b/src/ui/overlays/travel.rs
@@ -1,15 +1,16 @@
 use crate::app::{AppState, TravelInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-use crate::ui::theme::format_duration;
+use crate::ui::theme::{format_duration, palette};
 use super::centered_rect;
 pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let popup = centered_rect(46, 11, area);
     frame.render_widget(Clear, popup);
 
@@ -17,7 +18,7 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         .title(" TRAVEL ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Yellow));
+        .border_style(Style::default().fg(p.warn));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -36,40 +37,40 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
             if let Some((px, py, pz)) = state.probe_sector_coords() {
                 lines.push(Line::from(vec![
-                    Span::styled("From: ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("From: ", Style::default().fg(p.dim)),
                     Span::styled(
                         format!("({px},{py},{pz})"),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(p.text),
                     ),
                 ]));
             }
 
             lines.push(Line::from(vec![
-                Span::styled("Destination (x y z): ", Style::default().fg(Color::Cyan)),
+                Span::styled("Destination (x y z): ", Style::default().fg(p.accent)),
                 Span::raw(buf.as_str()),
-                Span::styled("█", Style::default().fg(Color::Cyan)),
+                Span::styled("█", Style::default().fg(p.accent)),
             ]));
             lines.push(Line::from(Span::styled(
                 "prefix with + for relative (e.g. +2 0 -2)",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(p.dim),
             )));
 
             // Live resolution + parity check
             if let Some((x, y, z)) = state.resolve_travel_target() {
                 let parity_ok = (x + y + z) % 2 == 0;
                 let mut spans = vec![
-                    Span::styled("→ ", Style::default().fg(Color::Yellow)),
+                    Span::styled("→ ", Style::default().fg(p.warn)),
                     Span::styled(
                         format!("({x},{y},{z})"),
-                        Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                        Style::default().fg(p.text).add_modifier(Modifier::BOLD),
                     ),
                 ];
                 if parity_ok {
-                    spans.push(Span::styled("  ✓", Style::default().fg(Color::Green)));
+                    spans.push(Span::styled("  ✓", Style::default().fg(p.good)));
                 } else {
                     spans.push(Span::styled(
                         "  ✗ x+y+z must be even",
-                        Style::default().fg(Color::Red),
+                        Style::default().fg(p.crit),
                     ));
                 }
                 lines.push(Line::default());
@@ -78,16 +79,16 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 lines.push(Line::default());
                 lines.push(Line::from(Span::styled(
                     "✗ relative input needs a known probe position",
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
 
             frame.render_widget(Paragraph::new(lines), body);
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Enter]", Style::default().fg(p.accent)),
                     Span::raw(" preview  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])),
                 hint_area,
@@ -98,34 +99,34 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             let mut lines: Vec<Line> = Vec::new();
 
             lines.push(Line::from(vec![
-                Span::styled("→  ", Style::default().fg(Color::Yellow)),
+                Span::styled("→  ", Style::default().fg(p.warn)),
                 Span::styled(
                     format!("({x}, {y}, {z})"),
-                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    Style::default().fg(p.text).add_modifier(Modifier::BOLD),
                 ),
             ]));
 
             if let Some(dist) = sector_distance {
                 lines.push(Line::from(vec![
-                    Span::styled("   Distance  ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("   Distance  ", Style::default().fg(p.dim)),
                     Span::raw(format!("{dist} sector(s)")),
                 ]));
             }
 
             if let Some(fuel) = fuel_cost {
                 lines.push(Line::from(vec![
-                    Span::styled("   Fuel      ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(format!("{fuel:.4}"), Style::default().fg(Color::Cyan)),
-                    Span::styled(" units", Style::default().fg(Color::DarkGray)),
+                    Span::styled("   Fuel      ", Style::default().fg(p.dim)),
+                    Span::styled(format!("{fuel:.4}"), Style::default().fg(p.accent)),
+                    Span::styled(" units", Style::default().fg(p.dim)),
                 ]));
             }
 
             if let Some(mins) = eta_minutes {
                 lines.push(Line::from(vec![
-                    Span::styled("   ETA       ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("   ETA       ", Style::default().fg(p.dim)),
                     Span::styled(
                         format_duration(mins * 60),
-                        Style::default().fg(Color::Yellow),
+                        Style::default().fg(p.warn),
                     ),
                 ]));
             }
@@ -134,7 +135,7 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 lines.push(Line::from(""));
                 lines.push(Line::from(Span::styled(
                     format!("   ✗ {err}"),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(p.crit),
                 )));
             }
 
@@ -142,14 +143,14 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
             let hint = if error.is_some() {
                 Line::from(vec![
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])
             } else {
                 Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
                     Span::raw(" GO  "),
-                    Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+                    Span::styled("[Esc]", Style::default().fg(p.accent)),
                     Span::raw(" cancel"),
                 ])
             };

--- a/src/ui/overlays/waypoints.rs
+++ b/src/ui/overlays/waypoints.rs
@@ -1,7 +1,8 @@
+use crate::ui::theme::palette;
 use crate::app::{AppState, WaypointKind, WaypointsInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
     Frame,
@@ -9,6 +10,7 @@ use ratatui::{
 
 use super::centered_rect;
 pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let p = palette(state.color_mode);
     let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
 
     let height = (entries.len() as u16 + 5).min(20);
@@ -18,7 +20,7 @@ pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &Ap
         .title(" WAYPOINTS ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(p.accent));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -31,18 +33,18 @@ pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &Ap
         .iter()
         .map(|e| {
             let (icon, color) = match e.kind {
-                WaypointKind::Bookmark => ("◎", Color::Cyan),
-                WaypointKind::Star => ("★", Color::Yellow),
-                WaypointKind::Minable => ("◆", Color::White),
+                WaypointKind::Bookmark => ("◎", p.accent),
+                WaypointKind::Star => ("★", p.warn),
+                WaypointKind::Minable => ("◆", p.text),
             };
             ListItem::new(Line::from(vec![
                 Span::styled(format!("{icon} "), Style::default().fg(color)),
                 Span::raw(format!("{:<28}", e.label)),
                 Span::styled(
                     format!("({},{},{})", e.x, e.y, e.z),
-                    Style::default().fg(Color::White),
+                    Style::default().fg(p.text),
                 ),
-                Span::styled(format!("  d:{}", e.distance), Style::default().fg(Color::DarkGray)),
+                Span::styled(format!("  d:{}", e.distance), Style::default().fg(p.dim)),
             ]))
         })
         .collect();
@@ -56,11 +58,11 @@ pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &Ap
 
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(Color::Cyan)),
+            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
             Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
             Span::raw(" travel  "),
-            Span::styled("[Esc]", Style::default().fg(Color::Cyan)),
+            Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" close"),
         ])),
         rows[1],

--- a/src/ui/panels/scanner.rs
+++ b/src/ui/panels/scanner.rs
@@ -1,4 +1,4 @@
-use crate::api::types::{DangerLevel, SectorObject, SectorObjectType, SensorMode};
+use crate::api::types::{DangerLevel, ResourceShares, SectorObject, SectorObjectType, SensorMode};
 use crate::app::AppState;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -301,6 +301,35 @@ pub(crate) fn sector_interest_color(s: &crate::api::types::SectorObservation, p:
     p.dim
 }
 
+/// A one-line breakdown of the four mineable resources, skipping zeros.
+/// `percent` renders shares as `40%`; otherwise reserves as `1.20`.
+pub(crate) fn resource_shares_line<'a>(
+    label: &'a str,
+    shares: Option<&ResourceShares>,
+    percent: bool,
+    p: Palette,
+) -> Option<Line<'a>> {
+    let s = shares?;
+    let parts = [
+        ("metals", s.metals),
+        ("ice", s.ice),
+        ("carbon", s.carbon_compounds),
+        ("deut", s.deuterium),
+    ];
+    let mut spans = vec![Span::styled(label, Style::default().fg(p.dim))];
+    let mut any = false;
+    for (name, v) in parts {
+        if v <= 0.0 {
+            continue;
+        }
+        any = true;
+        let val = if percent { format!("{:.0}%", v * 100.0) } else { format!("{v:.2}") };
+        spans.push(Span::styled(format!("{name} "), Style::default().fg(p.dim)));
+        spans.push(Span::styled(format!("{val}  "), Style::default().fg(p.text)));
+    }
+    any.then_some(Line::from(spans))
+}
+
 /// Lines for one scanned object. `compact` drops the scientific detail
 /// (mass / radius / uid and nested-body dimensions) shown only in the zoom view.
 pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: Palette) -> Vec<Line<'a>> {
@@ -379,6 +408,29 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
                 detail_spans.push(Span::styled(uid.as_str(), text));
             }
             lines.push(Line::from(detail_spans));
+        }
+
+        // Planet / asteroid science (v63 fields).
+        if let Some(cat) = &obj.category {
+            lines.push(Line::from(vec![Span::styled("  class ", dim), Span::styled(cat.as_str(), text)]));
+        }
+        if let Some(h) = obj.habitability_score {
+            lines.push(Line::from(vec![
+                Span::styled("  habitability ", dim),
+                Span::styled(format!("{:.0}%", h * 100.0), Style::default().fg(ratio_color(h, p))),
+            ]));
+        }
+        if let Some(comp) = &obj.composition {
+            lines.push(Line::from(vec![Span::styled("  composition ", dim), Span::styled(comp.as_str(), text)]));
+        }
+        if obj.manny_mineable == Some(true) {
+            lines.push(Line::from(Span::styled("  ⛏ mineable", Style::default().fg(p.warn))));
+        }
+        if let Some(line) = resource_shares_line("  shares ", obj.resource_composition.as_ref(), true, p) {
+            lines.push(line);
+        }
+        if let Some(line) = resource_shares_line("  reserves ", obj.resource_amounts.as_ref(), false, p) {
+            lines.push(line);
         }
     }
 

--- a/src/ui/panels/scanner.rs
+++ b/src/ui/panels/scanner.rs
@@ -9,8 +9,8 @@ use ratatui::{
 };
 
 use crate::ui::theme::{
-    knowledge_color, knowledge_label, map_cell_style, object_color, object_icon, palette,
-    pane_block, ratio_color, Palette,
+    knowledge_color, knowledge_label, map_cell_style, object_color, object_icon, object_type_label,
+    palette, pane_block, ratio_color, Palette,
 };
 // ── Scanner panel ─────────────────────────────────────────────────────────────
 //
@@ -338,7 +338,11 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
     let glyph = object_icon(&obj.object_type).0;
     let color = object_color(&obj.object_type, p);
     let estimated = if obj.estimated.unwrap_or(false) { "~ " } else { "" };
-    let name = obj.name.as_deref().unwrap_or("unnamed");
+    let name = obj
+        .name
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| object_type_label(&obj.object_type));
     let danger = obj
         .danger_level
         .as_ref()
@@ -440,7 +444,7 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
         for target in targets {
             let tglyph = object_icon(&target.object_type).0;
             let tcolor = object_color(&target.object_type, p);
-            let name = target.name.as_deref().unwrap_or("unnamed");
+            let name = target.name.as_deref().filter(|s| !s.trim().is_empty()).unwrap_or_else(|| object_type_label(&target.object_type));
             let mut spans: Vec<Span> = vec![
                 Span::raw("  "),
                 Span::styled(tglyph, Style::default().fg(tcolor)),
@@ -468,7 +472,7 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
     for target in &obj.bookmark_targets {
         let tglyph = object_icon(&target.object_type).0;
         let tcolor = object_color(&target.object_type, p);
-        let name = target.name.as_deref().unwrap_or("unnamed");
+        let name = target.name.as_deref().filter(|s| !s.trim().is_empty()).unwrap_or_else(|| object_type_label(&target.object_type));
         let mut spans: Vec<Span> = vec![
             Span::raw("  "),
             Span::styled(tglyph, Style::default().fg(tcolor)),

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -179,6 +179,25 @@ pub(crate) fn object_color(t: &SectorObjectType, p: Palette) -> Color {
     }
 }
 
+/// Human label for an object type, used to synthesize a name (`asteroid #2`)
+/// when the API returns none.
+pub(crate) fn object_type_label(t: &SectorObjectType) -> &'static str {
+    match t {
+        SectorObjectType::Star => "star",
+        SectorObjectType::Planet => "planet",
+        SectorObjectType::Asteroid => "asteroid",
+        SectorObjectType::DustCloud => "dust cloud",
+        SectorObjectType::BlackHole => "black hole",
+        SectorObjectType::SolarSystem => "solar system",
+        SectorObjectType::Manny => "manny",
+        SectorObjectType::DriftingItem => "drifting item",
+        SectorObjectType::DetachedContainer => "container",
+        SectorObjectType::DeuteriumRefuelStation => "fuel station",
+        SectorObjectType::ScutRelay => "SCUT relay",
+        SectorObjectType::Unknown => "object",
+    }
+}
+
 pub(crate) fn object_icon(t: &SectorObjectType) -> (&'static str, Color) {
     match t {
         SectorObjectType::Star => ("★", Color::Yellow),


### PR DESCRIPTION
Fixes the SECTOR pane: palette-aware, and surfaces the v63 planet/asteroid fields we were dropping.

## New API fields captured (SectorObject)
`category`, `composition`, `mannyMineable`, `resources`, `resourceTypes`, `resourceComposition` (normalized shares), `resourceAmounts` (remaining reserves, ECE), and solar-system `starCount`/`planetCount`/`orbitalBodyCount` — via a new `ResourceShares` type. (`habitabilityScore` already existed, now displayed.)

## Views
- **Palette-aware** — uses `object_color`, no more hardcoded ANSI.
- **Compact** — navigable object list; each row tagged with its headline datum: planet habitability / class, asteroid composition, or a ⛏ mineable marker.
- **Zoom** — the science station: full per-object detail (class, habitability colour-graded, composition, mineability, mass/radius, resource shares & reserves) via the scanner's `sector_object_lines` verbose branch + a new `resource_shares_line` helper.

178 tests green (new serde tests for the planet/asteroid fields), clippy clean.