### PR TITLE
feat(cockpit): wire Map + Travel (+ jump to visited, scanner travel-here)

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -293,6 +293,7 @@ impl super::AppState {
                     | Pane::Storage
                     | Pane::Sector
                     | Pane::Scanner
+                    | Pane::Map
             )
         {
             parts.push("Enter act");

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -37,6 +37,17 @@ pub enum TravelInput {
     },
 }
 
+/// Picker over the probe's visited sectors; selecting one launches the travel
+/// wizard (confirm step) for its coordinates.
+#[derive(Default)]
+pub enum GotoVisitedInput {
+    #[default]
+    Inactive,
+    Picking {
+        selection: usize,
+    },
+}
+
 pub const RESOURCE_TYPES: [&str; 4] = ["deuterium", "metals", "ice", "carbon_compounds"];
 
 pub const RESOURCE_LABELS: [&str; 4] = ["deuterium", "metals", "ice", "carbon"];

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -88,6 +88,7 @@ pub struct AppState {
     /// Sectors already visited by the probe (server-side history).
     pub visited_sectors: Vec<VisitedSector>,
     pub travel: TravelInput,
+    pub goto_visited: GotoVisitedInput,
     pub repair: RepairInput,
     pub mine: MineInput,
     pub remote_mine: RemoteMineInput,

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -148,18 +148,6 @@ impl super::AppState {
         let here = self.viewing_probe_sector();
         let items = vec![
             MenuItem {
-                action: MenuAction::ScanTravel,
-                label: "Travel here".into(),
-                enabled: has_selection && !here,
-                disabled_reason: if !has_selection {
-                    Some("no sector selected".to_string())
-                } else if here {
-                    Some("already here".to_string())
-                } else {
-                    None
-                },
-            },
-            MenuItem {
                 action: MenuAction::ScanAround,
                 label: "Scan around (neighbors)".into(),
                 enabled: has_pos,
@@ -182,6 +170,19 @@ impl super::AppState {
                 label: format!("Cycle filter (now: {})", self.scan_filter.label()),
                 enabled: !self.scan_history.is_empty(),
                 disabled_reason: self.scan_history.is_empty().then(|| "no history".to_string()),
+            },
+            // Travel is the terminal action — kept last, below the scan verbs.
+            MenuItem {
+                action: MenuAction::ScanTravel,
+                label: "Travel here".into(),
+                enabled: has_selection && !here,
+                disabled_reason: if !has_selection {
+                    Some("no sector selected".to_string())
+                } else if here {
+                    Some("already here".to_string())
+                } else {
+                    None
+                },
             },
         ];
         let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -37,6 +37,11 @@ pub enum MenuAction {
     ScanDirection,
     ScanObserve,
     ScanFilter,
+    ScanTravel,
+    // Map pane
+    OpenMap,
+    Travel,
+    GotoVisited,
 }
 
 /// A single entry in a contextual action menu.
@@ -103,15 +108,57 @@ impl super::AppState {
             super::Pane::Probe => self.probe_context_menu(),
             super::Pane::Storage => self.storage_context_menu(),
             super::Pane::Scanner => Some(self.scanner_context_menu()),
+            super::Pane::Map => Some(self.map_context_menu()),
             _ => None,
         }
+    }
+
+    fn map_context_menu(&self) -> ContextMenu {
+        let has_visited = !self.visited_sectors.is_empty();
+        let items = vec![
+            MenuItem {
+                action: MenuAction::OpenMap,
+                label: "Open map".into(),
+                enabled: true,
+                disabled_reason: None,
+            },
+            MenuItem {
+                action: MenuAction::Travel,
+                label: "Travel to coordinates…".into(),
+                enabled: true,
+                disabled_reason: None,
+            },
+            MenuItem {
+                action: MenuAction::GotoVisited,
+                label: "Jump to visited sector…".into(),
+                enabled: has_visited,
+                disabled_reason: (!has_visited).then(|| "none visited".to_string()),
+            },
+        ];
+        ContextMenu { title: "MAP".into(), items, cursor: 0 }
     }
 
     fn scanner_context_menu(&self) -> ContextMenu {
         // Batch scans need a known probe position to offset from.
         let has_pos = self.probe_sector_coords().is_some();
         let pos_reason = (!has_pos).then(|| "unknown position".to_string());
+        // Travel to the observation under the history cursor — unless it is the
+        // sector we are already in.
+        let has_selection = self.current_sector().is_some();
+        let here = self.viewing_probe_sector();
         let items = vec![
+            MenuItem {
+                action: MenuAction::ScanTravel,
+                label: "Travel here".into(),
+                enabled: has_selection && !here,
+                disabled_reason: if !has_selection {
+                    Some("no sector selected".to_string())
+                } else if here {
+                    Some("already here".to_string())
+                } else {
+                    None
+                },
+            },
             MenuItem {
                 action: MenuAction::ScanAround,
                 label: "Scan around (neighbors)".into(),
@@ -137,7 +184,8 @@ impl super::AppState {
                 disabled_reason: self.scan_history.is_empty().then(|| "no history".to_string()),
             },
         ];
-        ContextMenu { title: "SCANNER".into(), items, cursor: 0 }
+        let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
+        ContextMenu { title: "SCANNER".into(), items, cursor }
     }
 
     fn storage_context_menu(&self) -> Option<ContextMenu> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1540,3 +1540,34 @@ fn mine_reserve_max_falls_back_to_free_capacity_without_reserves() {
     // No resourceAmounts → reserves are 0 → fall back to free capacity (0.5).
     assert_eq!(state.mine_reserve_max("ast-1", [false, true, false, false]), 0.5);
 }
+
+// ── map & travel context menus ────────────────────────────────────────────
+
+#[test]
+fn map_context_menu_goto_disabled_without_visited() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Map;
+    let menu = state.build_context_menu().expect("map menu");
+    assert_eq!(menu.items.len(), 3);
+    let goto = menu.items.iter().find(|i| i.action == MenuAction::GotoVisited).unwrap();
+    assert!(!goto.enabled, "no visited sectors → jump disabled");
+    // Open map / travel are always available.
+    assert!(menu.items.iter().find(|i| i.action == MenuAction::Travel).unwrap().enabled);
+}
+
+#[test]
+fn scanner_travel_here_enabled_for_remote_selection_only() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Scanner;
+    state.probe = Some(probe_at(0., 0., 0.));
+    // Remote observation selected → Travel here enabled.
+    state.scan_history = vec![make_sector(2., 0., 0.)];
+    let travel = state.build_context_menu().unwrap().items.into_iter()
+        .find(|i| i.action == MenuAction::ScanTravel).unwrap();
+    assert!(travel.enabled);
+    // Current sector selected → disabled ("already here").
+    state.scan_history = vec![make_sector(0., 0., 0.)];
+    let travel = state.build_context_menu().unwrap().items.into_iter()
+        .find(|i| i.action == MenuAction::ScanTravel).unwrap();
+    assert!(!travel.enabled);
+}

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -19,8 +19,8 @@ use crate::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DetachInput, DropCargoInput,
     DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction, MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
-    RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
-    ScanMode, StorageMoveInput,
+    GotoVisitedInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput,
+    RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput,
 };
 
 pub fn handle_cockpit_event(
@@ -47,6 +47,9 @@ pub fn handle_cockpit_event(
         KeyCode::Left | KeyCode::Char('h') => {
             drill_out(state);
         }
+        // The Map pane has no in-pane zoom view — `z` opens the full isometric
+        // map overlay (its own pan/travel controls take over).
+        KeyCode::Char('z') if state.active_pane == Pane::Map => state.open_map(),
         KeyCode::Char('z') => state.toggle_zoom(),
         KeyCode::Char('?') => state.help_open = true,
         KeyCode::F(1) => state.hints_visible = !state.hints_visible,
@@ -73,7 +76,7 @@ pub fn handle_cockpit_event(
 /// the contextual menu; panes backed by a rich wizard reuse its overlay.
 fn open_actions(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     match state.active_pane {
-        Pane::Mannies | Pane::Inventory | Pane::Probe | Pane::Storage | Pane::Scanner => {
+        Pane::Mannies | Pane::Inventory | Pane::Probe | Pane::Storage | Pane::Scanner | Pane::Map => {
             match state.build_context_menu() {
                 Some(menu) if !menu.items.is_empty() => state.mode = InputMode::Menu(menu),
                 _ => state.set_toast("no actions here"),
@@ -93,7 +96,6 @@ fn open_actions(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiM
             fetch_sent_messages(client.clone(), tx.clone());
         }
         Pane::Sector => open_sector_object_actions(state),
-        _ => state.set_toast("no actions here"),
     }
 }
 
@@ -269,6 +271,28 @@ fn fire_menu_action(
         MenuAction::ScanFilter => {
             state.cycle_scan_filter();
             state.set_toast(format!("filter: {}", state.scan_filter.label()));
+            return;
+        }
+        MenuAction::ScanTravel => {
+            if let Some(s) = state.current_sector() {
+                let c = &s.relative_coordinates;
+                let (x, y, z) = (c.x.round() as i32, c.y.round() as i32, c.z.round() as i32);
+                state.travel_go_sector(x, y, z);
+            }
+            return;
+        }
+        MenuAction::OpenMap => {
+            state.open_map();
+            return;
+        }
+        MenuAction::Travel => {
+            state.travel = TravelInput::Typing(String::new());
+            return;
+        }
+        MenuAction::GotoVisited => {
+            if !state.visited_sectors.is_empty() {
+                state.goto_visited = GotoVisitedInput::Picking { selection: 0 };
+            }
             return;
         }
         _ => {}

--- a/src/input/map.rs
+++ b/src/input/map.rs
@@ -1,6 +1,33 @@
 use crossterm::event::KeyCode;
 
-use crate::app::AppState;
+use crate::app::{AppState, GotoVisitedInput};
+
+use super::geometry::list_nav;
+
+/// Picker over visited sectors: navigate the list, `Enter` launches the travel
+/// confirm for the chosen sector, `Esc` cancels.
+pub(super) fn handle_goto_visited_event(code: KeyCode, state: &mut AppState) {
+    let GotoVisitedInput::Picking { selection } = state.goto_visited else { return };
+    let count = state.visited_sectors.len();
+    match code {
+        KeyCode::Esc => state.goto_visited = GotoVisitedInput::Inactive,
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+            if let Some(ns) = list_nav(code, selection, count) {
+                state.goto_visited = GotoVisitedInput::Picking { selection: ns };
+            }
+        }
+        KeyCode::Enter => {
+            if let Some(v) = state.visited_sectors.get(selection) {
+                let c = &v.relative_coordinates;
+                let (x, y, z) = (c.x.round() as i32, c.y.round() as i32, c.z.round() as i32);
+                state.goto_visited = GotoVisitedInput::Inactive;
+                state.travel_go_sector(x, y, z);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub(super) fn handle_map_event(code: KeyCode, state: &mut AppState) {
     // Coordinate-input mode ([c]) captures keys first.
     if let Some(buf) = state.map.coord_input.as_mut() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -9,7 +9,8 @@ use crate::app::{
     DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
     MessagesInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
     RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode,
-    ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
+    GotoVisitedInput, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput,
+    WaypointsInput,
 };
 mod alerts;
 mod cockpit;
@@ -35,7 +36,7 @@ use containers::{
 use craft::{handle_atomic_printer_craft_event, handle_craft_event};
 use geometry::face_d2;
 use jettison::handle_jettison_event;
-use map::handle_map_event;
+use map::{handle_goto_visited_event, handle_map_event};
 use messages::handle_messages_event;
 use mine::{handle_mine_event, handle_remote_mine_event};
 use missions::handle_missions_event;
@@ -126,6 +127,11 @@ pub fn handle_event(
 
     if state.map.open {
         handle_map_event(k.code, state);
+        return;
+    }
+
+    if matches!(state.goto_visited, GotoVisitedInput::Picking { .. }) {
+        handle_goto_visited_event(k.code, state);
         return;
     }
 

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -72,7 +72,7 @@ pub fn render_map(frame: &mut Frame, area: Rect, state: &AppState, active: bool,
     } else {
         lines.push(Line::styled(format!("≣ SCUT: {} network(s)", nets.len()), Style::default().fg(p.accent)));
     }
-    lines.push(Line::styled("[z] zoom for full map", dim));
+    lines.push(Line::styled("z open map · Enter travel", dim));
     render_body(frame, area, " MAP ", active, p, lines);
 }
 

--- a/src/ui/overlays/map.rs
+++ b/src/ui/overlays/map.rs
@@ -11,7 +11,38 @@ use ratatui::{
 };
 
 use crate::ui::theme::{format_duration, map_cell_symbol, palette};
-use super::centered_rect;
+use super::{centered_rect, render_pick_list};
+
+/// Picker over visited sectors (most-recent first, as returned by the API):
+/// coordinates, distance from the probe, and visit count.
+pub(crate) fn render_goto_visited_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let crate::app::GotoVisitedInput::Picking { selection } = state.goto_visited else {
+        return;
+    };
+    let p = palette(state.color_mode);
+    let probe = state.probe_sector_coords();
+    let labels: Vec<String> = state
+        .visited_sectors
+        .iter()
+        .map(|v| {
+            let c = &v.relative_coordinates;
+            let (x, y, z) = (c.x.round() as i32, c.y.round() as i32, c.z.round() as i32);
+            let dist = probe
+                .map(|(px, py, pz)| (x - px).abs().max((y - py).abs()).max((z - pz).abs()))
+                .map(|d| format!("  d{d}"))
+                .unwrap_or_default();
+            let times = if v.visit_count > 1 { format!("  ×{}", v.visit_count) } else { String::new() };
+            format!("({x}, {y}, {z}){dist}{times}")
+        })
+        .collect();
+    let refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+    let height = (refs.len() as u16 + 6).clamp(8, 20);
+    render_pick_list(
+        frame, area, p, " JUMP TO VISITED SECTOR ", 46, height,
+        Some("Travel to:"), &refs, selection, None, "travel",
+    );
+}
+
 pub(crate) fn sector_brief(s: &SectorObservation) -> String {
     let Some(objects) = &s.objects else {
         return "estimated only".into();

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use drop_container::render_drop_container_overlay;
 pub(crate) use help::render_help_overlay;
 pub(crate) use inventory_detail::render_inventory_detail_overlay;
 pub(crate) use jettison::render_jettison_overlay;
-pub(crate) use map::render_map_overlay;
+pub(crate) use map::{render_goto_visited_overlay, render_map_overlay};
 pub(crate) use messages::render_messages_overlay;
 pub(crate) use mine::render_mine_overlay;
 pub(crate) use remote_mine::render_remote_mine_overlay;
@@ -47,8 +47,8 @@ pub(crate) use waypoints::render_waypoints_overlay;
 
 use crate::app::{
     AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
-    CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput,
-    JettisonInput, MineInput,
+    CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput,
+    GotoVisitedInput, InspectInput, JettisonInput, MineInput,
     MessagesInput, MindSnapshotInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput,
     RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
     ScanMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
@@ -82,6 +82,9 @@ pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppS
     }
     if state.map.open {
         render_map_overlay(frame, area, state);
+    }
+    if matches!(state.goto_visited, GotoVisitedInput::Picking { .. }) {
+        render_goto_visited_overlay(frame, area, state);
     }
     if !matches!(state.jettison, JettisonInput::Inactive) {
         render_jettison_overlay(frame, area, state);


### PR DESCRIPTION
Travel and the isometric map existed but were orphaned from the unified cockpit — you couldn't move. This wires them in.

## Map pane
- **z** → opens the full isometric map overlay (pan `hjkl`, `g` travels to the centred sector, `c` coordinate center, `Esc` close — all pre-existing).
- **Enter** → context menu:
  - **Open map**
  - **Travel to coordinates…** — launches the travel wizard (absolute or relative `+dx dy dz`, parity check, fuel/ETA preview, confirm)
  - **Jump to visited sector…** — new picker over `visited_sectors` (coords · distance · visit count) → travel confirm

## Scanner pane
- **Enter → Travel here** — travel to the sector under the history cursor (disabled when it's the current sector). Scan a distant sector, then go there.

## Notes
- New `GotoVisitedInput` picker (handler + `render_pick_list` overlay), all routed through the existing `travel_go_sector` → confirm step (fuel/ETA), so the move API path is unchanged.
- `open_actions` now covers all nine panes (dropped the unreachable catch-all).

183 tests green (2 new menu tests), clippy clean.