### PR TITLE
feat(cockpit): wire waypoints launcher

### DIFF
--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -42,6 +42,7 @@ pub enum MenuAction {
     OpenMap,
     Travel,
     GotoVisited,
+    Waypoints,
 }
 
 /// A single entry in a contextual action menu.
@@ -133,6 +134,15 @@ impl super::AppState {
                 label: "Jump to visited sector…".into(),
                 enabled: has_visited,
                 disabled_reason: (!has_visited).then(|| "none visited".to_string()),
+            },
+            {
+                let has_wp = !self.collect_waypoints().is_empty();
+                MenuItem {
+                    action: MenuAction::Waypoints,
+                    label: "Waypoints…".into(),
+                    enabled: has_wp,
+                    disabled_reason: (!has_wp).then(|| "no waypoints".to_string()),
+                }
             },
         ];
         ContextMenu { title: "MAP".into(), items, cursor: 0 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1548,7 +1548,7 @@ fn map_context_menu_goto_disabled_without_visited() {
     let mut state = AppState::default();
     state.active_pane = Pane::Map;
     let menu = state.build_context_menu().expect("map menu");
-    assert_eq!(menu.items.len(), 3);
+    assert_eq!(menu.items.len(), 4);
     let goto = menu.items.iter().find(|i| i.action == MenuAction::GotoVisited).unwrap();
     assert!(!goto.enabled, "no visited sectors → jump disabled");
     // Open map / travel are always available.
@@ -1570,4 +1570,14 @@ fn scanner_travel_here_enabled_for_remote_selection_only() {
     let travel = state.build_context_menu().unwrap().items.into_iter()
         .find(|i| i.action == MenuAction::ScanTravel).unwrap();
     assert!(!travel.enabled);
+}
+
+#[test]
+fn map_menu_has_waypoints_disabled_when_empty() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Map;
+    let menu = state.build_context_menu().expect("map menu");
+    assert_eq!(menu.items.len(), 4);
+    let wp = menu.items.iter().find(|i| i.action == MenuAction::Waypoints).unwrap();
+    assert!(!wp.enabled, "no waypoints → disabled");
 }

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -20,7 +20,7 @@ use crate::app::{
     DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction, MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
     GotoVisitedInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput,
+    RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
 };
 
 pub fn handle_cockpit_event(
@@ -292,6 +292,13 @@ fn fire_menu_action(
         MenuAction::GotoVisited => {
             if !state.visited_sectors.is_empty() {
                 state.goto_visited = GotoVisitedInput::Picking { selection: 0 };
+            }
+            return;
+        }
+        MenuAction::Waypoints => {
+            let entries = state.collect_waypoints();
+            if !entries.is_empty() {
+                state.waypoints = WaypointsInput::Browsing { entries, selection: 0 };
             }
             return;
         }


### PR DESCRIPTION
The waypoints quick-travel list existed (handler + palette overlay) but was orphaned. Adds a **Waypoints…** item to the Map pane's Enter menu (disabled when there are none): browse bookmarks / stars / mineable targets by coords → Enter travels there via the existing confirm step (fuel/ETA).

184 tests green, clippy clean.