### PR TITLE
feat(cockpit): richer crafting picker (affordability + detail)

### DIFF
--- a/src/app/inventory.rs
+++ b/src/app/inventory.rs
@@ -1,4 +1,4 @@
-use crate::api::types::{CraftingRecipe, ProbeInventory};
+use crate::api::types::{CraftingRecipe, CraftingRecipeIngredient, ProbeInventory};
 use super::*;
 
 /// Active items (manny, atomic printer) are listed individually in the
@@ -185,6 +185,27 @@ impl AppState {
         self.recipes.iter()
             .filter(|r| r.craftable_by.iter().any(|c| c == "manny"))
             .collect()
+    }
+
+    /// How much of a recipe ingredient the probe inventory holds: a unit count
+    /// for `item` ingredients, or the resource stock amount (ECE) otherwise.
+    pub fn recipe_ingredient_have(&self, ing: &CraftingRecipeIngredient) -> f64 {
+        let Some(probe) = &self.probe else { return 0.0 };
+        if ing.unit == "item" {
+            probe.inventory.items.iter().filter(|it| it.item_type == ing.ingredient_type).count() as f64
+        } else {
+            probe
+                .inventory
+                .resource_stocks
+                .iter()
+                .find(|s| s.stock_type == ing.ingredient_type)
+                .map_or(0.0, |s| s.amount)
+        }
+    }
+
+    /// Whether every ingredient of a recipe is currently on hand.
+    pub fn recipe_affordable(&self, recipe: &CraftingRecipe) -> bool {
+        recipe.ingredients.iter().all(|ing| self.recipe_ingredient_have(ing) >= ing.quantity)
     }
 
     pub fn inventory_waypoint_bookmark_id(&self) -> Option<String> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1581,3 +1581,32 @@ fn map_menu_has_waypoints_disabled_when_empty() {
     let wp = menu.items.iter().find(|i| i.action == MenuAction::Waypoints).unwrap();
     assert!(!wp.enabled, "no waypoints → disabled");
 }
+
+// ── recipe affordability ──────────────────────────────────────────────────
+
+#[test]
+fn recipe_affordable_checks_stocks_and_items() {
+    use crate::api::types::CraftingRecipe;
+    let mut state = AppState::default();
+    state.probe = Some(probe_with_inventory(
+        r#"[{"id":"i1","type":"integrated_circuit","name":"IC","containerSpace":0.0,"taskProgressPercent":0.0}]"#,
+        r#"[{"id":"s1","type":"metals","name":"Metals","amount":5.0,"containerSpace":0.0}]"#,
+    ));
+    let recipe: CraftingRecipe = serde_json::from_str(r#"{
+        "id":"r","name":"Steel plate","craftableBy":["manny"],
+        "ingredients":[{"type":"metals","quantity":2.0,"unit":"ece","kind":null}],
+        "durationSeconds":600,
+        "output":{"type":"steel_plate","name":"Steel plate","containerSpace":0.1,"containerSpaceUnit":"ece","capacityBonus":null}
+    }"#).unwrap();
+    assert!(state.recipe_affordable(&recipe), "have 5.0 metals ≥ 2.0");
+
+    // Needs 2 integrated circuits but only 1 on hand.
+    let hungry: CraftingRecipe = serde_json::from_str(r#"{
+        "id":"r2","name":"Board","craftableBy":["manny"],
+        "ingredients":[{"type":"integrated_circuit","quantity":2.0,"unit":"item","kind":null}],
+        "durationSeconds":600,
+        "output":{"type":"board","name":"Board","containerSpace":0.1,"containerSpaceUnit":"ece","capacityBonus":null}
+    }"#).unwrap();
+    assert!(!state.recipe_affordable(&hungry));
+    assert_eq!(state.recipe_ingredient_have(&hungry.ingredients[0]), 1.0);
+}

--- a/src/ui/overlays/craft.rs
+++ b/src/ui/overlays/craft.rs
@@ -1,104 +1,64 @@
-use crate::ui::theme::palette;
+use crate::api::types::CraftingRecipe;
 use crate::app::{AppState, AtomicPrinterCraftInput, CraftInput};
+use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
 use super::centered_rect;
+
 pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let CraftInput::PickRecipe { ref manny_name, selection, ref error, .. } = state.craft else {
+        return;
+    };
     let p = palette(state.color_mode);
-    let CraftInput::PickRecipe { ref manny_name, selection, ref error, .. } = state.craft else { return };
-
     let recipes = state.manny_craft_recipes();
-    let height = (recipes.len() as u16 + 6).min(16);
-    let popup = centered_rect(58, height, area);
-    frame.render_widget(Clear, popup);
-
-    let title = format!(" CRAFT — {manny_name} ");
-    let block = Block::default()
-        .title(title)
-        .title_alignment(Alignment::Center)
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(p.accent));
-    let inner = block.inner(popup);
-    frame.render_widget(block, popup);
-
-    let rows = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(inner);
-
-    let mut lines: Vec<Line> = Vec::new();
-    if recipes.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "loading recipes…",
-            Style::default().fg(p.dim),
-        )));
-    }
-    for (i, recipe) in recipes.iter().enumerate() {
-        let selected = i == selection;
-        let duration_min = recipe.duration_seconds / 60;
-        let ingredients: String = recipe.ingredients.iter().map(|ing| {
-            if ing.unit == "item" {
-                format!("{} × {}", ing.quantity as u32, ing.ingredient_type)
-            } else {
-                format!("{:.2} ECE {}", ing.quantity, ing.ingredient_type)
-            }
-        }).collect::<Vec<_>>().join(", ");
-        let detail = format!("  {}m  {}", duration_min, ingredients);
-        if selected {
-            lines.push(Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(p.warn)),
-                Span::styled(recipe.name.as_str(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
-                Span::styled(detail, Style::default().fg(p.dim)),
-            ]));
-        } else {
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(recipe.name.as_str(), Style::default().fg(p.dim)),
-            ]));
-        }
-    }
-    if let Some(err) = error {
-        lines.push(Line::default());
-        lines.push(Line::from(Span::styled(
-            format!("✗ {err}"),
-            Style::default().fg(p.crit),
-        )));
-    }
-
-    frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
-            Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" start  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
+    render_recipe_picker(
+        frame, area, state, p, &format!(" CRAFT — {manny_name} "), p.accent, &recipes, selection,
+        error.as_deref(),
     );
 }
 
 pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    let AtomicPrinterCraftInput::PickRecipe { selection, ref error } = state.atomic_printer_craft else {
+        return;
+    };
     let p = palette(state.color_mode);
-    let AtomicPrinterCraftInput::PickRecipe { selection, ref error } = state.atomic_printer_craft else { return };
-
     let recipes = state.atomic_printer_recipes();
-    let height = (recipes.len() as u16 + 6).min(16);
-    let popup = centered_rect(58, height, area);
-    frame.render_widget(Clear, popup);
+    render_recipe_picker(
+        frame, area, state, p, " ATOMIC PRINTER — SELECT RECIPE ", p.crit, &recipes, selection,
+        error.as_deref(),
+    );
+}
 
+/// Shared recipe picker: a list marked by affordability, plus a detail block
+/// for the selected recipe (output, duration, per-ingredient have/need).
+#[allow(clippy::too_many_arguments)]
+fn render_recipe_picker(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AppState,
+    p: Palette,
+    title: &str,
+    border: Color,
+    recipes: &[&CraftingRecipe],
+    selection: usize,
+    error: Option<&str>,
+) {
+    let sel = recipes.get(selection);
+    let ing_rows = sel.map_or(0, |r| r.ingredients.len());
+    let height = (recipes.len() as u16 + ing_rows as u16 + 7).clamp(9, 24);
+    let popup = centered_rect(60, height, area);
+    frame.render_widget(Clear, popup);
     let block = Block::default()
-        .title(" ATOMIC PRINTER — SELECT RECIPE ")
+        .title(title.to_owned())
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(p.crit));
+        .border_style(Style::default().fg(border));
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
@@ -107,50 +67,84 @@ pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect,
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
 
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
     let mut lines: Vec<Line> = Vec::new();
+
     if recipes.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "loading recipes…",
-            Style::default().fg(p.dim),
-        )));
+        lines.push(Line::from(Span::styled("loading recipes…", dim)));
     }
     for (i, recipe) in recipes.iter().enumerate() {
         let selected = i == selection;
-        let duration_min = recipe.duration_seconds / 60;
-        let ingredients: String = recipe.ingredients.iter().map(|ing| {
-            if ing.unit == "item" {
-                format!("{} × {}", ing.quantity as u32, ing.ingredient_type)
-            } else {
-                format!("{:.2} ECE {}", ing.quantity, ing.ingredient_type)
-            }
-        }).collect::<Vec<_>>().join(", ");
-        let detail = format!("  {}m  {}", duration_min, ingredients);
-        if selected {
-            lines.push(Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(p.warn)),
-                Span::styled(recipe.name.as_str(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
-                Span::styled(detail, Style::default().fg(p.dim)),
-            ]));
+        let affordable = state.recipe_affordable(recipe);
+        let (mark, mark_color) = if affordable { ("✓", p.good) } else { ("✗", p.crit) };
+        let name_style = if selected {
+            Style::default().fg(p.text).add_modifier(Modifier::BOLD)
+        } else if affordable {
+            text
         } else {
+            dim
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if selected { "▶ " } else { "  " }, Style::default().fg(p.accent)),
+            Span::styled(format!("{mark} "), Style::default().fg(mark_color)),
+            Span::styled(format!("{:<20}", recipe.name), name_style),
+            Span::styled(format!(" {}m", recipe.duration_seconds / 60), dim),
+        ]));
+    }
+
+    // Detail block for the selected recipe.
+    if let Some(recipe) = sel {
+        lines.push(Line::default());
+        let mut out = vec![
+            Span::styled("→ ", dim),
+            Span::styled(recipe.output.name.as_str(), Style::default().fg(p.accent)),
+        ];
+        if let Some(bonus) = recipe.output.capacity_bonus {
+            if bonus != 0.0 {
+                out.push(Span::styled(format!("  +{bonus:.2} cap"), dim));
+            }
+        }
+        lines.push(Line::from(out));
+        for ing in &recipe.ingredients {
+            let have = state.recipe_ingredient_have(ing);
+            let ok = have >= ing.quantity;
+            let need = if ing.unit == "item" {
+                format!("{}", ing.quantity as u32)
+            } else {
+                format!("{:.2}", ing.quantity)
+            };
+            let have_str = if ing.unit == "item" {
+                format!("{}", have as u32)
+            } else {
+                format!("{have:.2}")
+            };
             lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(recipe.name.as_str(), Style::default().fg(p.dim)),
+                Span::styled(if ok { "  ✓ " } else { "  ✗ " }, Style::default().fg(if ok { p.good } else { p.crit })),
+                Span::styled(format!("{:<18}", ing.ingredient_type), text),
+                Span::styled(format!("{have_str}/{need}"), Style::default().fg(if ok { p.text } else { p.crit })),
             ]));
         }
     }
+
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(
-            format!("✗ {err}"),
-            Style::default().fg(p.crit),
-        )));
+        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
+
+    // Footer — Enter dimmed when the selected recipe isn't affordable.
+    let can = sel.map(|r| state.recipe_affordable(r)).unwrap_or(false);
+    let enter_style = if can {
+        Style::default().fg(p.good).add_modifier(Modifier::BOLD)
+    } else {
+        dim
+    };
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled("[↑/↓]", Style::default().fg(p.accent)),
             Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
+            Span::styled("[Enter]", enter_style),
             Span::raw(" start  "),
             Span::styled("[Esc]", Style::default().fg(p.accent)),
             Span::raw(" cancel"),
@@ -158,4 +152,3 @@ pub(crate) fn render_atomic_printer_craft_overlay(frame: &mut Frame, area: Rect,
         rows[1],
     );
 }
-


### PR DESCRIPTION
Improves the crafting interface (both manny craft and atomic printer, unified into one renderer).

## Before
A recipe name list; only the selected row showed its ingredients, cramped on one line. Nothing told you whether you could actually craft it.

## After
- **Affordability** — each recipe is marked ✓/✗ against probe stocks + item counts; unaffordable recipes are dimmed.
- **Detail block** for the selected recipe: output (+ capacity bonus), duration, and every ingredient as **have/need** coloured good/crit.
- **Enter** dims when the selection can't be afforded.
- The two near-identical overlays are now one shared `render_recipe_picker`.

New `AppState::recipe_ingredient_have` / `recipe_affordable` (unit-tested). 185 tests green, clippy clean.