### PR TITLE
feat(cockpit): command mode (:) — U6

### DIFF
--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+/// Command verbs recognised by `:` mode. Kept as a table so the input layer can
+/// offer Tab-completion and a `:help`-style listing.
+pub const COMMANDS: [&str; 9] =
+    ["focus", "travel", "goto", "filter", "refresh", "theme", "zoom", "help", "quit"];
+
+fn pane_from_name(name: &str) -> Option<Pane> {
+    Pane::ALL.into_iter().find(|p| p.label().eq_ignore_ascii_case(name))
+}
+
+fn color_from_name(name: &str) -> Option<ColorMode> {
+    [
+        ColorMode::MonoGreen,
+        ColorMode::MonoAmber,
+        ColorMode::PhosphorSemantic,
+        ColorMode::Modern16,
+    ]
+    .into_iter()
+    .find(|m| m.label() == name)
+}
+
+fn filter_from_name(name: &str) -> Option<ScanFilter> {
+    match name {
+        "all" => Some(ScanFilter::All),
+        "objects" => Some(ScanFilter::Objects),
+        "minable" => Some(ScanFilter::Minable),
+        "danger" => Some(ScanFilter::Danger),
+        _ => None,
+    }
+}
+
+/// Parse `x y z` (also accepting commas or a leading `+` for relative) into a
+/// coordinate triple, joined from whatever arg tokens were given.
+fn parse_coords(args: &[&str]) -> Option<(i32, i32, i32)> {
+    let joined = args.join(" ").replace(',', " ");
+    let parts: Vec<i32> = joined.split_whitespace().filter_map(|s| s.parse().ok()).collect();
+    match parts.as_slice() {
+        [x, y, z] => Some((*x, *y, *z)),
+        _ => None,
+    }
+}
+
+impl AppState {
+    /// Parse and execute a `:` command line. Returns `true` when the caller
+    /// should trigger a full data refresh (`fetch_all`) — the one effect this
+    /// method can't perform itself. Unknown or malformed commands set a toast.
+    pub fn run_command(&mut self, line: &str) -> bool {
+        let line = line.trim();
+        let mut parts = line.split_whitespace();
+        let Some(verb) = parts.next() else { return false };
+        let args: Vec<&str> = parts.collect();
+
+        match verb {
+            "focus" => match args.first().and_then(|n| pane_from_name(n)) {
+                Some(pane) => {
+                    self.active_pane = pane;
+                    self.zoomed = true;
+                }
+                None => self.set_toast("usage: focus <pane>"),
+            },
+            "travel" => {
+                // Accept "x y z" or "+dx dy dz" (commas tolerated).
+                let buf = args.join(" ").replace(',', " ");
+                self.travel = TravelInput::Typing(buf);
+                self.travel_submit();
+            }
+            "goto" => match parse_coords(&args) {
+                Some((x, y, z)) => {
+                    self.open_map();
+                    self.map.center_x = x;
+                    self.map.y_layer = y;
+                    self.map.center_z = z;
+                }
+                None => self.set_toast("usage: goto <x y z>"),
+            },
+            "filter" => match args.first().and_then(|n| filter_from_name(n)) {
+                Some(f) => self.set_scan_filter(f),
+                None => self.set_toast("usage: filter <all|objects|minable|danger>"),
+            },
+            "refresh" => return true,
+            "theme" => match args.first().and_then(|n| color_from_name(n)) {
+                Some(m) => {
+                    self.color_mode = m;
+                    self.set_toast(format!("color mode: {}", m.label()));
+                }
+                None => self.set_toast("usage: theme <mono-green|mono-amber|phosphor-semantic|modern-16>"),
+            },
+            "zoom" => self.toggle_zoom(),
+            "help" => self.help_open = true,
+            "q" | "quit" => self.set_quit(),
+            other => self.set_toast(format!("unknown command: {other}")),
+        }
+        false
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 mod boot;
 mod color;
+mod command;
 mod containers;
 mod grid;
 mod inputs;
@@ -16,6 +17,7 @@ mod tests;
 
 pub use boot::{BOOT_CHARS_PER_FRAME, BOOT_LINE_STRIDE};
 pub use color::*;
+pub use command::COMMANDS;
 pub use grid::*;
 pub use inputs::*;
 pub use inventory::*;

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -342,7 +342,13 @@ impl AppState {
     }
 
     pub fn cycle_scan_filter(&mut self) {
-        self.scan_filter = self.scan_filter.next();
+        self.set_scan_filter(self.scan_filter.next());
+    }
+
+    /// Set the scan filter and snap the history cursor onto the first entry it
+    /// keeps visible.
+    pub fn set_scan_filter(&mut self, filter: ScanFilter) {
+        self.scan_filter = filter;
         let idxs = self.filtered_history_indices();
         if !idxs.contains(&self.scan_history_idx) {
             if let Some(&first) = idxs.first() {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1610,3 +1610,49 @@ fn recipe_affordable_checks_stocks_and_items() {
     assert!(!state.recipe_affordable(&hungry));
     assert_eq!(state.recipe_ingredient_have(&hungry.ingredients[0]), 1.0);
 }
+
+// ── command mode (:) ──────────────────────────────────────────────────────
+
+#[test]
+fn run_command_focus_zoom_theme_filter() {
+    let mut state = AppState::default();
+    assert!(!state.run_command("focus mannies"));
+    assert_eq!(state.active_pane, Pane::Mannies);
+    assert!(state.zoomed);
+
+    state.run_command("zoom"); // toggles off
+    assert!(!state.zoomed);
+
+    state.run_command("theme mono-amber");
+    assert_eq!(state.color_mode, ColorMode::MonoAmber);
+
+    state.run_command("filter minable");
+    assert_eq!(state.scan_filter, ScanFilter::Minable);
+}
+
+#[test]
+fn run_command_refresh_signals_fetch() {
+    let mut state = AppState::default();
+    assert!(state.run_command("refresh"), "refresh asks the caller to fetch_all");
+    assert!(!state.run_command("zoom"), "other commands do not");
+}
+
+#[test]
+fn run_command_travel_and_goto() {
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    // even-sum target → travel confirm
+    state.run_command("travel 2 0 -2");
+    assert!(matches!(state.travel, TravelInput::Confirming { x: 2, y: 0, z: -2, .. }));
+
+    state.run_command("goto 1 1 0");
+    assert!(state.map.open);
+    assert_eq!((state.map.center_x, state.map.y_layer, state.map.center_z), (1, 1, 0));
+}
+
+#[test]
+fn run_command_unknown_sets_toast() {
+    let mut state = AppState::default();
+    assert!(!state.run_command("frobnicate"));
+    assert!(state.active_toast().is_some());
+}

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -17,7 +17,8 @@ use crate::api::tasks::{
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
     ApiMessage, AppState, AtomicPrinterCraftInput, CraftInput, DetachInput, DropCargoInput,
-    DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction, MessagesInput,
+    CommandLine, DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction,
+    MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
     GotoVisitedInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput,
     RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
@@ -51,6 +52,7 @@ pub fn handle_cockpit_event(
         // map overlay (its own pan/travel controls take over).
         KeyCode::Char('z') if state.active_pane == Pane::Map => state.open_map(),
         KeyCode::Char('z') => state.toggle_zoom(),
+        KeyCode::Char(':') => state.mode = InputMode::Command(CommandLine::default()),
         KeyCode::Char('?') => state.help_open = true,
         KeyCode::F(1) => state.hints_visible = !state.hints_visible,
         // Esc backs out one step: leave zoom first, then drill up.

--- a/src/input/command.rs
+++ b/src/input/command.rs
@@ -1,0 +1,58 @@
+use crossterm::event::KeyCode;
+use tokio::sync::mpsc;
+
+use crate::api::client::ApiClient;
+use crate::api::tasks::fetch_all;
+use crate::app::{ApiMessage, AppState, CommandLine, InputMode, COMMANDS};
+
+/// Route a key while the `:` command line is open. Typed characters are literal
+/// input; `Enter` runs the command, `Tab` completes the verb, `Esc` cancels.
+pub(super) fn handle_command_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let InputMode::Command(ref mut cmd) = state.mode else { return };
+    match code {
+        KeyCode::Esc => state.mode = InputMode::Normal,
+        KeyCode::Enter => {
+            let line = cmd.input.clone();
+            state.mode = InputMode::Normal;
+            if state.run_command(&line) {
+                state.clear_error();
+                state.loading = true;
+                fetch_all(client.clone(), tx.clone());
+            }
+        }
+        KeyCode::Tab => complete_verb(cmd),
+        KeyCode::Backspace => {
+            if cmd.cursor > 0 {
+                cmd.cursor -= 1;
+                cmd.input.remove(cmd.cursor);
+            }
+        }
+        KeyCode::Left => cmd.cursor = cmd.cursor.saturating_sub(1),
+        KeyCode::Right => cmd.cursor = (cmd.cursor + 1).min(cmd.input.chars().count()),
+        KeyCode::Char(c) => {
+            let byte = cmd.input.char_indices().nth(cmd.cursor).map_or(cmd.input.len(), |(b, _)| b);
+            cmd.input.insert(byte, c);
+            cmd.cursor += 1;
+        }
+        _ => {}
+    }
+}
+
+/// Tab-complete the verb (first token) to the unique matching command.
+fn complete_verb(cmd: &mut CommandLine) {
+    // Only complete while still typing the verb (no space yet).
+    if cmd.input.contains(' ') {
+        return;
+    }
+    let prefix = cmd.input.as_str();
+    let matches: Vec<&&str> = COMMANDS.iter().filter(|c| c.starts_with(prefix)).collect();
+    if let [only] = matches.as_slice() {
+        cmd.input = format!("{only} ");
+        cmd.cursor = cmd.input.chars().count();
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -9,11 +9,12 @@ use crate::app::{
     DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
     MessagesInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
     RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode,
-    GotoVisitedInput, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput,
+    GotoVisitedInput, InputMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput,
     WaypointsInput,
 };
 mod alerts;
 mod cockpit;
+mod command;
 mod containers;
 mod craft;
 mod geometry;
@@ -36,6 +37,7 @@ use containers::{
 use craft::{handle_atomic_printer_craft_event, handle_craft_event};
 use geometry::face_d2;
 use jettison::handle_jettison_event;
+use command::handle_command_event;
 use map::{handle_goto_visited_event, handle_map_event};
 use messages::handle_messages_event;
 use mine::{handle_mine_event, handle_remote_mine_event};
@@ -132,6 +134,11 @@ pub fn handle_event(
 
     if matches!(state.goto_visited, GotoVisitedInput::Picking { .. }) {
         handle_goto_visited_event(k.code, state);
+        return;
+    }
+
+    if matches!(state.mode, InputMode::Command(_)) {
+        handle_command_event(k.code, state, client, tx);
         return;
     }
 

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -176,7 +176,11 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
 }
 
 fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette, visible: &[Pane]) {
-    let (bar, hints) = if state.hints_visible && area.height >= 2 {
+    // The command line always claims the second row while `:` is open, even if
+    // the hints line is toggled off.
+    let command = if let crate::app::InputMode::Command(cmd) = &state.mode { Some(cmd) } else { None };
+    let want_second = state.hints_visible || command.is_some();
+    let (bar, second) = if want_second && area.height >= 2 {
         let rows = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(1), Constraint::Length(1)])
@@ -187,12 +191,17 @@ fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette, vi
     };
 
     render_status_line(frame, bar, state, p, visible);
-    if let Some(hints_area) = hints {
-        let line = Line::from(Span::styled(
-            format!(" {}", state.pane_hints()),
-            Style::default().fg(p.dim),
-        ));
-        frame.render_widget(Paragraph::new(line), hints_area);
+    if let Some(second_area) = second {
+        let line = if let Some(cmd) = command {
+            // `:verb args` with a caret; accent to signal text-entry mode.
+            Line::from(vec![
+                Span::styled(format!(" :{}", cmd.input), Style::default().fg(p.accent)),
+                Span::styled("█", Style::default().fg(p.accent)),
+            ])
+        } else {
+            Line::from(Span::styled(format!(" {}", state.pane_hints()), Style::default().fg(p.dim)))
+        };
+        frame.render_widget(Paragraph::new(line), second_area);
     }
 }
 

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -58,6 +58,7 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect, p: Palette) {
         Line::default(),
         help_section("Act & global", p),
         help_key_line("Enter", "contextual action menu", p),
+        help_key_line(":", "command line (travel, goto, focus…)", p),
         help_key_line("F1", "toggle hints line", p),
         help_key_line("F2", "cycle color mode", p),
         help_key_line("F5", "refresh", p),


### PR DESCRIPTION
Implements the last unbuilt bloc, U6 — the vim-style `:` command line (the `InputMode::Command` variant had been stubbed since U1).

## Behavior
- **`:`** opens the command line. It claims the status bar's second row (even when the hints line is off) and shows `:verb args█`; the mode tag reads `CMD`.
- **Verbs**: `focus <pane>` · `travel <x y z | +dx dy dz>` · `goto <x y z>` · `filter <all|objects|minable|danger>` · `refresh` · `theme <mode>` · `zoom` · `help` · `q`/`quit`. Unknown/malformed → toast.
- **Tab** completes the verb to its unique match.
- `Enter` runs it, `Esc` cancels, `←/→`/`Backspace` edit.

## Structure
- `AppState::run_command` (in `app/command.rs`) does all state-only work and returns `true` when the caller must `fetch_all` (`:refresh`) — keeping the API effect in the input layer.
- Factored `set_scan_filter` out of `cycle_scan_filter`.
- `run_command` unit-tested (focus/zoom/theme/filter/refresh/travel/goto/unknown); help overlay now lists `:`.

189 tests green, clippy clean.