### PR TITLE
refactor(ui): unify modal footer hints via shared render_footer helper

### DIFF
--- a/src/ui/cockpit_v2/menu.rs
+++ b/src/ui/cockpit_v2/menu.rs
@@ -5,10 +5,10 @@
 //! the menu teaches what is (not yet) possible rather than hiding it.
 
 use crate::app::ContextMenu;
-use crate::ui::overlays::centered_rect;
+use crate::ui::overlays::{centered_rect, render_footer, FooterKey};
 use crate::ui::theme::Palette;
 use ratatui::{
-    layout::Rect,
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
@@ -25,9 +25,12 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
         })
         .max()
         .unwrap_or(0)
-        .max(menu.title.chars().count());
+        .max(menu.title.chars().count())
+        // Keep the popup wide enough for the footer hint line.
+        .max(FOOTER_WIDTH);
     let w = (widest as u16 + 4).clamp(18, 48);
-    let h = menu.items.len() as u16 + 2;
+    // items + footer + two border rows
+    let h = menu.items.len() as u16 + 3;
     let rect = centered_rect(w, h, area);
 
     frame.render_widget(Clear, rect);
@@ -62,5 +65,24 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
             Line::from(Span::styled(format!(" {}", item.label), style))
         })
         .collect();
-    frame.render_widget(Paragraph::new(lines), inner);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::nav("[↑/↓]", "move"),
+            FooterKey::nav("[Enter]", "select"),
+            FooterKey::nav("[Esc]", "close"),
+        ],
+    );
 }
+
+/// Character width of the footer hint line (`[↑/↓] move  [Enter] select  [Esc]
+/// close`), used to size the popup.
+const FOOTER_WIDTH: usize = 39;

--- a/src/ui/overlays/alerts.rs
+++ b/src/ui/overlays/alerts.rs
@@ -9,7 +9,7 @@ use ratatui::{
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 
 fn alert_type_label(t: &AlertType) -> &'static str {
     match t {
@@ -124,17 +124,10 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     }
 
     // ── Footer ──
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
-            Span::raw(" select  "),
-            Span::styled("[Tab]", Style::default().fg(p.accent)),
-            Span::raw(" switch  "),
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" ack  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" close"),
-        ])),
-        rows[2],
-    );
+    render_footer(frame, rows[2], p, &[
+        FooterKey::nav("[↑/↓]", "select"),
+        FooterKey::nav("[Tab]", "switch"),
+        FooterKey::commit("[Enter]", "ACK"),
+        FooterKey::nav("[Esc]", "close"),
+    ]);
 }

--- a/src/ui/overlays/containers.rs
+++ b/src/ui/overlays/containers.rs
@@ -8,7 +8,7 @@ use ratatui::{
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 
 pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
@@ -44,15 +44,10 @@ pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, sta
     }
 
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" rename  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::commit("[Enter]", "RENAME"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }
 
 pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -128,19 +123,20 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
     }
     frame.render_stateful_widget(list, rows[1], &mut ls);
 
-    let footer = if let Some(err) = error {
-        Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit)))
+    if let Some(err) = error {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!("✗ {err}"),
+                Style::default().fg(p.crit),
+            ))),
+            rows[2],
+        );
     } else {
-        Line::from(vec![
-            Span::styled("[Space]", Style::default().fg(p.accent)),
-            Span::raw(" cycle  "),
-            Span::styled("[Del]", Style::default().fg(p.accent)),
-            Span::raw(" clear  "),
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" save  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])
-    };
-    frame.render_widget(Paragraph::new(footer), rows[2]);
+        render_footer(frame, rows[2], p, &[
+            FooterKey::nav("[Space]", "cycle"),
+            FooterKey::nav("[Del]", "clear"),
+            FooterKey::commit("[Enter]", "SAVE"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ]);
+    }
 }

--- a/src/ui/overlays/craft.rs
+++ b/src/ui/overlays/craft.rs
@@ -9,7 +9,7 @@ use ratatui::{
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey, KeyTone};
 
 pub(crate) fn render_craft_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let CraftInput::PickRecipe { ref manny_name, selection, ref error, .. } = state.craft else {
@@ -135,20 +135,14 @@ fn render_recipe_picker(
 
     // Footer — Enter dimmed when the selected recipe isn't affordable.
     let can = sel.map(|r| state.recipe_affordable(r)).unwrap_or(false);
-    let enter_style = if can {
-        Style::default().fg(p.good).add_modifier(Modifier::BOLD)
+    let craft_key = if can {
+        FooterKey::commit("[Enter]", "CRAFT")
     } else {
-        dim
+        FooterKey { key: "[Enter]", label: "CRAFT", tone: KeyTone::Disabled }
     };
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
-            Span::raw(" select  "),
-            Span::styled("[Enter]", enter_style),
-            Span::raw(" start  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::nav("[↑/↓]", "select"),
+        craft_key,
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }

--- a/src/ui/overlays/drop_container.rs
+++ b/src/ui/overlays/drop_container.rs
@@ -18,7 +18,7 @@ pub(crate) fn render_drop_container_overlay(frame: &mut Frame, area: Rect, state
             let height = (planets.len() as u16 + 7).min(18);
             let prompt = format!("Drop {container_name} on planet:");
             render_pick_list(frame, area, palette(state.color_mode), " DROP CONTAINER — SELECT PLANET ", 54, height,
-                Some(&prompt), &names, *selection, error.as_deref(), "drop");
+                Some(&prompt), &names, *selection, error.as_deref(), "DROP");
         }
     }
 }

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -7,7 +7,7 @@ use ratatui::{
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 // ── Help overlay ──────────────────────────────────────────────────────────────
 
 pub(crate) fn help_key_line(key: &'static str, desc: &'static str, p: Palette) -> Line<'static> {
@@ -91,12 +91,6 @@ pub(crate) fn render_help_overlay(frame: &mut Frame, area: Rect, p: Palette) {
 
     frame.render_widget(Paragraph::new(left), cols[0]);
     frame.render_widget(Paragraph::new(right), cols[1]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Esc/?]", Style::default().fg(p.accent)),
-            Span::raw(" close"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc/?]", "close")]);
 }
 

--- a/src/ui/overlays/inventory_detail.rs
+++ b/src/ui/overlays/inventory_detail.rs
@@ -8,7 +8,7 @@ use ratatui::{
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 // ── Inventory detail overlay ──────────────────────────────────────────────────
 
 pub(crate) fn detail_kv(p: Palette, key: &str, value: String) -> Line<'static> {
@@ -121,12 +121,6 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" close"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc]", "close")]);
 }
 

--- a/src/ui/overlays/jettison.rs
+++ b/src/ui/overlays/jettison.rs
@@ -2,13 +2,13 @@ use crate::ui::theme::palette;
 use crate::app::{AppState, JettisonInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
     match &state.jettison {
@@ -41,15 +41,10 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.crit).add_modifier(Modifier::BOLD)),
-                    Span::raw(" EJECT  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[
+                FooterKey::danger("[Enter]", "EJECT"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         JettisonInput::ConfirmRelay { error, .. } => {
@@ -80,15 +75,10 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.accent).add_modifier(Modifier::BOLD)),
-                    Span::raw(" DEPLOY  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[
+                FooterKey::commit("[Enter]", "DEPLOY"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         JettisonInput::EnterAmount { item_name, max_amount, buf, error, .. } => {
@@ -129,15 +119,10 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-                    Span::raw(" confirm  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[
+                FooterKey::danger("[Enter]", "JETTISON"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         JettisonInput::Inactive => {}

--- a/src/ui/overlays/map.rs
+++ b/src/ui/overlays/map.rs
@@ -11,7 +11,7 @@ use ratatui::{
 };
 
 use crate::ui::theme::{format_duration, map_cell_symbol, palette};
-use super::{centered_rect, render_pick_list};
+use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 /// Picker over visited sectors (most-recent first, as returned by the API):
 /// coordinates, distance from the probe, and visit count.
@@ -235,23 +235,14 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
             hint_area,
         );
     } else {
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled("[hjkl]", Style::default().fg(p.accent)),
-                Span::raw(" pan  "),
-                Span::styled("[u/d]", Style::default().fg(p.accent)),
-                Span::raw(" y±1  "),
-                Span::styled("[0]", Style::default().fg(p.accent)),
-                Span::raw(" probe  "),
-                Span::styled("[c]", Style::default().fg(p.accent)),
-                Span::raw(" go to  "),
-                Span::styled("[g]", Style::default().fg(p.warn)),
-                Span::raw(" travel  "),
-                Span::styled("[b/Esc]", Style::default().fg(p.accent)),
-                Span::raw(" close"),
-            ])),
-            hint_area,
-        );
+        render_footer(frame, hint_area, p, &[
+            FooterKey::nav("[hjkl]", "pan"),
+            FooterKey::nav("[u/d]", "y±1"),
+            FooterKey::nav("[0]", "probe"),
+            FooterKey::nav("[c]", "go to"),
+            FooterKey::commit("[g]", "TRAVEL"),
+            FooterKey::nav("[b/Esc]", "close"),
+        ]);
     }
     let w = map_area.width as i32;
     let h = map_area.height as i32;

--- a/src/ui/overlays/messages.rs
+++ b/src/ui/overlays/messages.rs
@@ -9,7 +9,7 @@ use ratatui::{
 
 use crate::api::types::MessageStatus;
 use crate::app::{AppState, MessagesInput};
-use super::{centered_rect, render_pick_list};
+use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 fn preview(body: &str) -> String {
     let one = body.replace('\n', " ");
@@ -83,19 +83,12 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             }
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[1]);
 
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Tab]", Style::default().fg(p.accent)),
-                    Span::raw(" inbox/sent  "),
-                    Span::styled("[Enter]", Style::default().fg(p.accent)),
-                    Span::raw(" read  "),
-                    Span::styled("[c]", Style::default().fg(p.accent)),
-                    Span::raw(" compose  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" close"),
-                ])),
-                rows[2],
-            );
+            render_footer(frame, rows[2], p, &[
+                FooterKey::nav("[Tab]", "inbox/sent"),
+                FooterKey::nav("[Enter]", "read"),
+                FooterKey::nav("[c]", "compose"),
+                FooterKey::nav("[Esc]", "close"),
+            ]);
         }
 
         MessagesInput::PickRecipient { recipients, selection } => {
@@ -135,15 +128,10 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
                 lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
             }
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-                    Span::raw(" send  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[
+                FooterKey::commit("[Enter]", "SEND"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         MessagesInput::Inactive => {}

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -1,14 +1,14 @@
 use crate::app::{AppState, MineInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
 use crate::ui::theme::{format_duration, palette};
-use super::{centered_rect, render_pick_list};
+use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
 pub(crate) fn estimate_mine_duration(target_amount: f64) -> (i64, i64) {
     const CARGO_CAP: f64 = 0.30;
     const TRAVEL_SECS: i64 = 1800; // 900s each way
@@ -164,28 +164,22 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             let any_resource = resources.iter().any(|&r| r);
             let valid_amount = amount_buf.parse::<f64>().ok().filter(|&v| v > 0.0).is_some();
             let can_send = any_resource && valid_amount;
-            let hint = if *amount_mode {
-                Line::from(vec![
-                    Span::styled("[Tab]", Style::default().fg(p.accent)),
-                    Span::raw(" resources  "),
-                    Span::styled("[Enter]", if can_send { Style::default().fg(p.good).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.dim) }),
-                    Span::raw(" send  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])
+            let mine_key = if can_send {
+                FooterKey::commit("[Enter]", "MINE")
             } else {
-                Line::from(vec![
-                    Span::styled("[1-4]", Style::default().fg(p.accent)),
-                    Span::raw(" toggle  "),
-                    Span::styled("[Tab]", Style::default().fg(p.accent)),
-                    Span::raw(" amount  "),
-                    Span::styled("[Enter]", if can_send { Style::default().fg(p.good).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.dim) }),
-                    Span::raw(" send  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])
+                FooterKey { key: "[Enter]", label: "MINE", tone: KeyTone::Disabled }
             };
-            frame.render_widget(Paragraph::new(hint), rows[1]);
+            let keys = if *amount_mode {
+                vec![FooterKey::nav("[Tab]", "resources"), mine_key, FooterKey::nav("[Esc]", "cancel")]
+            } else {
+                vec![
+                    FooterKey::nav("[1-4]", "toggle"),
+                    FooterKey::nav("[Tab]", "amount"),
+                    mine_key,
+                    FooterKey::nav("[Esc]", "cancel"),
+                ]
+            };
+            render_footer(frame, rows[1], p, &keys);
         }
 
         MineInput::Inactive => {}

--- a/src/ui/overlays/missions.rs
+++ b/src/ui/overlays/missions.rs
@@ -10,7 +10,7 @@ use ratatui::{
 use crate::api::types::{Mission, MissionStatus, MissionStepStatus};
 use crate::app::{AppState, MissionsInput};
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 
 fn mission_status_style(s: &MissionStatus, p: Palette) -> (&'static str, Style) {
     match s {
@@ -102,17 +102,11 @@ pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &App
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
 
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[↑↓]", Style::default().fg(p.accent)),
-            Span::raw(" select  "),
-            Span::styled("[a]", Style::default().fg(p.warn)),
-            Span::raw(" abandon  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" close"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::nav("[↑↓]", "select"),
+        FooterKey::nav("[a]", "abandon"),
+        FooterKey::nav("[Esc]", "close"),
+    ]);
 
     if let MissionsInput::ConfirmAbandon { ref mission_title, ref error, .. } = state.missions_input {
         render_abandon_confirm(frame, area, mission_title, error.as_deref(), p);
@@ -147,13 +141,8 @@ fn render_abandon_confirm(frame: &mut Frame, area: Rect, title: &str, error: Opt
         )));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.warn).add_modifier(Modifier::BOLD)),
-            Span::raw(" abandon  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" keep"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::danger("[Enter]", "ABANDON"),
+        FooterKey::nav("[Esc]", "keep"),
+    ]);
 }

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -173,6 +173,62 @@ pub(crate) fn centered_rect(width: u16, height: u16, r: Rect) -> Rect {
     Rect::new(x, y, width.min(r.width), height.min(r.height))
 }
 
+/// Semantic weight of a footer key, driving its colour and emphasis.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeyTone {
+    /// Navigation / intermediate step (no game effect). Accent, not bold.
+    Nav,
+    /// Terminal commit with a game effect (POST/PATCH). Good + bold.
+    Commit,
+    /// Terminal commit that is destructive or irreversible. Crit + bold.
+    Danger,
+    /// A commit key that is currently unavailable (form invalid). Dim.
+    Disabled,
+}
+
+/// One `[key] label` entry in a modal footer.
+pub(crate) struct FooterKey<'a> {
+    pub key: &'a str,
+    pub label: &'a str,
+    pub tone: KeyTone,
+}
+
+impl<'a> FooterKey<'a> {
+    pub fn nav(key: &'a str, label: &'a str) -> Self {
+        Self { key, label, tone: KeyTone::Nav }
+    }
+    pub fn commit(key: &'a str, label: &'a str) -> Self {
+        Self { key, label, tone: KeyTone::Commit }
+    }
+    pub fn danger(key: &'a str, label: &'a str) -> Self {
+        Self { key, label, tone: KeyTone::Danger }
+    }
+}
+
+/// Render the unified modal footer into `area` (expected to be a single row).
+///
+/// Each key is drawn as a bracketed, coloured `[key]` followed by its raw
+/// label, entries separated by two spaces. This is the single source of truth
+/// for every modal's bottom hint line; `[Esc]` should always come last as a
+/// `Nav` key.
+pub(crate) fn render_footer(frame: &mut Frame, area: Rect, p: Palette, keys: &[FooterKey]) {
+    let mut spans: Vec<Span> = Vec::with_capacity(keys.len() * 2);
+    for (i, fk) in keys.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw("  "));
+        }
+        let key_style = match fk.tone {
+            KeyTone::Nav => Style::default().fg(p.accent),
+            KeyTone::Commit => Style::default().fg(p.good).add_modifier(Modifier::BOLD),
+            KeyTone::Danger => Style::default().fg(p.crit).add_modifier(Modifier::BOLD),
+            KeyTone::Disabled => Style::default().fg(p.dim),
+        };
+        spans.push(Span::styled(fk.key.to_owned(), key_style));
+        spans.push(Span::raw(format!(" {}", fk.label)));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn render_pick_list(
     frame: &mut Frame,
@@ -225,16 +281,15 @@ pub(crate) fn render_pick_list(
         lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
-            Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(format!(" {action}  ")),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
+    render_footer(
+        frame,
         rows[1],
+        p,
+        &[
+            FooterKey::nav("[↑/↓]", "select"),
+            FooterKey::commit("[Enter]", action),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
     );
 }
 

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -8,7 +8,7 @@ use ratatui::{
     Frame,
 };
 
-use super::{centered_rect, render_pick_list};
+use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
     match &state.salvage {
@@ -48,15 +48,10 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-                    Span::raw(" SALVAGE  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[
+                FooterKey::commit("[Enter]", "SALVAGE"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         SalvageInput::Inactive => {}
@@ -99,15 +94,10 @@ pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &A
         lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter/y]", Style::default().fg(p.crit).add_modifier(Modifier::BOLD)),
-            Span::raw(" DROP  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::danger("[Enter/y]", "DROP"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }
 
 pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -154,15 +144,13 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.warn).add_modifier(Modifier::BOLD)),
-            Span::raw(if remote { " ABANDON  " } else { " RECALL  " }),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    // Abandon (remote) is irreversible → Danger; a normal recall is a Commit.
+    let recall_key = if remote {
+        FooterKey::danger("[Enter]", "ABANDON")
+    } else {
+        FooterKey::commit("[Enter]", "RECALL")
+    };
+    render_footer(frame, rows[1], p, &[recall_key, FooterKey::nav("[Esc]", "cancel")]);
 }
 
 pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -199,15 +187,10 @@ pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" REFUEL  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::commit("[Enter]", "REFUEL"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }
 
 pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -251,15 +234,10 @@ pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &A
         lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.accent).add_modifier(Modifier::BOLD)),
-            Span::raw(" turn on  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::commit("[Enter]", "TURN ON"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }
 
 pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -310,15 +288,10 @@ pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state:
         )));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.crit).add_modifier(Modifier::BOLD)),
-            Span::raw(" REASSIGN  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::danger("[Enter]", "REASSIGN"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }
 
 pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -357,15 +330,10 @@ pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: 
     }
 
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" rename  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::commit("[Enter]", "RENAME"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }
 
 pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -416,15 +384,10 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-                    Span::raw(" DEPLOY  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[
+                FooterKey::commit("[Enter]", "DEPLOY"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         DeployInput::Inactive => {}
@@ -438,7 +401,7 @@ pub(crate) fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppS
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     render_pick_list(frame, area, p, &format!(" INSPECT — {manny_name} "), 52, height,
-        Some("Select asteroid to inspect:"), &names, selection, error.as_deref(), "inspect");
+        Some("Select asteroid to inspect:"), &names, selection, error.as_deref(), "INSPECT");
 }
 
 pub(crate) fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -448,7 +411,7 @@ pub(crate) fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppS
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     render_pick_list(frame, area, p, &format!(" RECOVER — {manny_name} "), 52, height,
-        Some("Select container to recover:"), &names, selection, error.as_deref(), "recover");
+        Some("Select container to recover:"), &names, selection, error.as_deref(), "RECOVER");
 }
 
 pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -473,7 +436,7 @@ pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             let height = (asteroids.len() as u16 + 8).min(18);
             let prompt = format!("Attach to asteroid  (manny: {manny_name})");
             render_pick_list(frame, area, p, &format!(" DETACH — hide {container_name} "), 52, height,
-                Some(&prompt), &names, *selection, error.as_deref(), "hide here");
+                Some(&prompt), &names, *selection, error.as_deref(), "HIDE HERE");
         }
 
         DetachInput::Inactive => {}

--- a/src/ui/overlays/remote_mine.rs
+++ b/src/ui/overlays/remote_mine.rs
@@ -1,14 +1,14 @@
 use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
 use crate::app::{AppState, RemoteMineInput, RESOURCE_LABELS};
-use super::{centered_rect, render_pick_list};
+use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
@@ -23,17 +23,19 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
                 .border_style(Style::default().fg(p.accent));
             let inner = block.inner(popup);
             frame.render_widget(block, popup);
+
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(inner);
             frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled(
-                        format!("scanning sector ({x},{y},{z}) via SCUT… "),
-                        Style::default().fg(p.text),
-                    ),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                inner,
+                Paragraph::new(Line::from(Span::styled(
+                    format!("scanning sector ({x},{y},{z}) via SCUT…"),
+                    Style::default().fg(p.text),
+                ))),
+                rows[0],
             );
+            render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc]", "cancel")]);
         }
 
         RemoteMineInput::PickAsteroid { manny_name, candidates, selection, .. } => {
@@ -84,19 +86,12 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
                 lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[1-4]", Style::default().fg(p.accent)),
-                    Span::raw(" res  "),
-                    Span::styled("[Tab]", Style::default().fg(p.accent)),
-                    Span::raw(" amount  "),
-                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-                    Span::raw(" container →  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[
+                FooterKey::nav("[1-4]", "res"),
+                FooterKey::nav("[Tab]", "amount"),
+                FooterKey::nav("[Enter]", "container →"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         RemoteMineInput::PickContainer { containers, selection, .. } => {
@@ -104,7 +99,7 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
             let height = (containers.len() as u16 + 6).min(16);
             render_pick_list(
                 frame, area, palette(state.color_mode), " REMOTE MINE — store in ", 52, height,
-                Some("Detached container (required):"), &names, *selection, None, "mine",
+                Some("Detached container (required):"), &names, *selection, None, "MINE",
             );
         }
 

--- a/src/ui/overlays/repair.rs
+++ b/src/ui/overlays/repair.rs
@@ -1,14 +1,14 @@
 use crate::app::{AppState, RepairInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
 use crate::ui::theme::{format_duration, palette};
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey, KeyTone};
 pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
     let RepairInput::Typing { ref manny_name, ref buf, ref error, .. } = state.repair else { return };
@@ -114,21 +114,11 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
     // Hint bar
     let can_send = parsed.is_some() && !insufficient;
-    let hint = if can_send {
-        Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" send  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])
+    let repair_key = if can_send {
+        FooterKey::commit("[Enter]", "REPAIR")
     } else {
-        Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.dim)),
-            Span::raw(" send  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])
+        FooterKey { key: "[Enter]", label: "REPAIR", tone: KeyTone::Disabled }
     };
-    frame.render_widget(Paragraph::new(hint), hint_area);
+    render_footer(frame, hint_area, p, &[repair_key, FooterKey::nav("[Esc]", "cancel")]);
 }
 

--- a/src/ui/overlays/scanner.rs
+++ b/src/ui/overlays/scanner.rs
@@ -2,13 +2,13 @@ use crate::ui::theme::{palette, Palette};
 use crate::app::{AppState, ScanMode};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 
 /// Coordinate-entry and neighbor-scan prompts for the Scanner pane. Both modes
 /// are handled by the shared scan-input router in `input/mod.rs`; this only
@@ -53,15 +53,10 @@ fn render_coord_input(frame: &mut Frame, area: Rect, buf: &str, p: Palette) {
         ])),
         rows[1],
     );
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" observe  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[2],
-    );
+    render_footer(frame, rows[2], p, &[
+        FooterKey::commit("[Enter]", "OBSERVE"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }
 
 fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -96,13 +91,8 @@ fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
         ]),
         rows[0],
     );
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[x] [y] [z]", Style::default().fg(p.accent).add_modifier(Modifier::BOLD)),
-            Span::raw(" scan  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" cancel"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::nav("[x] [y] [z]", "scan"),
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
 }

--- a/src/ui/overlays/scut_network.rs
+++ b/src/ui/overlays/scut_network.rs
@@ -10,7 +10,7 @@ use ratatui::{
 use crate::api::types::{ProbeSector, ScutRelayStatus};
 use crate::app::{AppState, ScutNetworkInput};
 
-use super::{centered_rect, render_pick_list};
+use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 fn rel(sector: &ProbeSector) -> String {
     match sector.relative.as_ref() {
@@ -33,7 +33,7 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
                 &items,
                 *selection,
                 None,
-                "inspect",
+                "INSPECT",
             );
         }
         ScutNetworkInput::Viewing { error } => {
@@ -102,13 +102,7 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
                 lines.push(Line::from(Span::styled("loading…", Style::default().fg(p.dim))));
             }
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" close"),
-                ])),
-                rows[1],
-            );
+            render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc]", "close")]);
         }
         ScutNetworkInput::Inactive => {}
     }

--- a/src/ui/overlays/storage_move.rs
+++ b/src/ui/overlays/storage_move.rs
@@ -8,7 +8,7 @@ use ratatui::{
     Frame,
 };
 
-use super::{centered_rect, render_pick_list};
+use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 fn framed(p: Palette, title: &str, area: Rect, width: u16, height: u16, frame: &mut Frame) -> [Rect; 2] {
     let popup = centered_rect(width, height, area);
@@ -79,7 +79,12 @@ pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: 
                 error_line(p, error),
             ];
             frame.render_widget(Paragraph::new(lines), body);
-            frame.render_widget(form_footer(p), footer);
+            render_footer(frame, footer, p, &[
+                FooterKey::nav("[↑/↓]", "field"),
+                FooterKey::nav("[←/→]", "change"),
+                FooterKey::commit("[Enter]", "MOVE"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
         StorageMoveInput::ConfigureItem {
             containers, items, to_sel, item_cursor, field, error, ..
@@ -120,7 +125,13 @@ pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: 
                 ls.select(Some((*item_cursor).min(items.len() - 1)));
             }
             frame.render_stateful_widget(list, rows[1], &mut ls);
-            frame.render_widget(item_footer(p), footer);
+            render_footer(frame, footer, p, &[
+                FooterKey::nav("[Tab]", "pane"),
+                FooterKey::nav("[Space]", "toggle"),
+                FooterKey::nav("[←/→]", "dest"),
+                FooterKey::commit("[Enter]", "MOVE"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
     }
 }
@@ -132,30 +143,3 @@ fn error_line(p: Palette, error: &Option<String>) -> Line<'static> {
     }
 }
 
-fn form_footer(p: Palette) -> Paragraph<'static> {
-    Paragraph::new(Line::from(vec![
-        Span::styled("[↑/↓]", Style::default().fg(p.accent)),
-        Span::raw(" field  "),
-        Span::styled("[←/→]", Style::default().fg(p.accent)),
-        Span::raw(" change  "),
-        Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-        Span::raw(" move  "),
-        Span::styled("[Esc]", Style::default().fg(p.accent)),
-        Span::raw(" cancel"),
-    ]))
-}
-
-fn item_footer(p: Palette) -> Paragraph<'static> {
-    Paragraph::new(Line::from(vec![
-        Span::styled("[Tab]", Style::default().fg(p.accent)),
-        Span::raw(" pane  "),
-        Span::styled("[Space]", Style::default().fg(p.accent)),
-        Span::raw(" toggle  "),
-        Span::styled("[←/→]", Style::default().fg(p.accent)),
-        Span::raw(" dest  "),
-        Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-        Span::raw(" move  "),
-        Span::styled("[Esc]", Style::default().fg(p.accent)),
-        Span::raw(" cancel"),
-    ]))
-}

--- a/src/ui/overlays/travel.rs
+++ b/src/ui/overlays/travel.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use crate::ui::theme::{format_duration, palette};
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
     let popup = centered_rect(46, 11, area);
@@ -84,15 +84,10 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             }
 
             frame.render_widget(Paragraph::new(lines), body);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.accent)),
-                    Span::raw(" preview  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])),
-                hint_area,
-            );
+            render_footer(frame, hint_area, p, &[
+                FooterKey::nav("[Enter]", "preview"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
         }
 
         TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error } => {
@@ -141,20 +136,14 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
             frame.render_widget(Paragraph::new(lines), body);
 
-            let hint = if error.is_some() {
-                Line::from(vec![
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])
+            if error.is_some() {
+                render_footer(frame, hint_area, p, &[FooterKey::nav("[Esc]", "cancel")]);
             } else {
-                Line::from(vec![
-                    Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-                    Span::raw(" GO  "),
-                    Span::styled("[Esc]", Style::default().fg(p.accent)),
-                    Span::raw(" cancel"),
-                ])
-            };
-            frame.render_widget(Paragraph::new(hint), hint_area);
+                render_footer(frame, hint_area, p, &[
+                    FooterKey::commit("[Enter]", "GO"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ]);
+            }
         }
     }
 }

--- a/src/ui/overlays/waypoints.rs
+++ b/src/ui/overlays/waypoints.rs
@@ -4,11 +4,11 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState},
     Frame,
 };
 
-use super::centered_rect;
+use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
     let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
@@ -56,16 +56,10 @@ pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &Ap
     list_state.select(Some(selection));
     frame.render_stateful_widget(list, rows[0], &mut list_state);
 
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("[↑/↓]", Style::default().fg(p.accent)),
-            Span::raw(" select  "),
-            Span::styled("[Enter]", Style::default().fg(p.good).add_modifier(Modifier::BOLD)),
-            Span::raw(" travel  "),
-            Span::styled("[Esc]", Style::default().fg(p.accent)),
-            Span::raw(" close"),
-        ])),
-        rows[1],
-    );
+    render_footer(frame, rows[1], p, &[
+        FooterKey::nav("[↑/↓]", "select"),
+        FooterKey::commit("[Enter]", "TRAVEL"),
+        FooterKey::nav("[Esc]", "close"),
+    ]);
 }
 


### PR DESCRIPTION
## Summary

Unifies the footer/hint line across every modal overlay. Previously each wizard hand-rolled its own footer paragraph, and the contextual menu popup had none at all — leading to inconsistent key legends and casing.

## Changes

- **New shared helpers** in `overlays/mod.rs`: `render_footer` + `FooterKey`/`KeyTone`. `render_pick_list` is rewritten on top of them, making the footer a single source of truth.
- **Contextual menu popup** (`cockpit_v2/menu.rs`) gains the previously-missing footer line (`[↑/↓] move · [Enter] select · [Esc] close`).
- **`remote_mine` `Loading` branch** gets a proper dedicated footer row instead of an inline `[Esc]` appended to the body.
- **Consistent key semantics** across all 20 overlays:
  - `Commit` (green + bold, UPPERCASE verb) — non-destructive API actions (`MINE`, `CRAFT`, `REPAIR`, `MOVE`, `RENAME`, `SEND`, `ACK`, `OBSERVE`, `TRAVEL`, `GO`…)
  - `Danger` (red + bold, UPPERCASE verb) — destructive/irreversible (`EJECT`, `JETTISON`, `DROP`, `ABANDON`, `REASSIGN`)
  - `Nav` (accent, no bold, lowercase) — navigation / intermediate steps
  - `[Esc]` always last.

Semantic colours degrade gracefully: on the monochrome themes (`mono-green`/`mono-amber`) the distinction carries through casing + bold; on `phosphor-semantic`/`modern-16` the green/red is visible.

## Notes

- Modals with semantic border colours (crit/warn/good) keep them — the migration only swaps the footer rendering, not the frame.
- Net −106 lines across 21 files.

## Test

- `cargo build`, `cargo clippy` (no issues), `cargo test` (189 passed).
- Manual TUI check confirmed by @MagiCrazy.