### PR TITLE
fix(tui): restore terminal on panic via panic hook

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use crossterm::{
+    cursor::Show,
     event::{DisableMouseCapture, EnableMouseCapture, EventStream},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -28,6 +29,14 @@ use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
 use neumann_cockpit::ui;
 
+/// Best-effort restoration of the terminal to its cooked state. Writes the
+/// leave sequences straight to `stdout` so it can run from a panic hook, where
+/// the `Terminal` value is out of reach.
+fn restore_terminal() -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture, Show)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cfg = config::Config::load()?;
@@ -38,18 +47,23 @@ async fn main() -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+
+    // A panic anywhere in the ~16k lines of render/input unwinds past the
+    // teardown below, leaving the shell in raw mode with mouse capture on and
+    // the panic message hidden in the alternate screen. Restore the terminal
+    // first, then let the original hook print the report to the real screen.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = restore_terminal();
+        original_hook(info);
+    }));
+
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
     let result = run(&client, &mut terminal, hints, color_mode).await;
 
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
+    restore_terminal()?;
 
     result
 }


### PR DESCRIPTION
## Summary

Addresses the **HIGH · S** finding from the v63.1.0 project review: *"Pas de panic hook — un panic laisse le terminal en raw mode"*.

Previously the terminal restoration (`disable_raw_mode`, `LeaveAlternateScreen`, `DisableMouseCapture`) only ran when `run()` returned normally. A panic anywhere in the ~16k lines of render/input unwound past the teardown, leaving the shell in raw mode with mouse capture on and the panic message hidden inside the alternate screen — the classic ratatui failure mode.

## Changes

- New `restore_terminal()` helper writing the leave sequences straight to `io::stdout()` (so it works from a panic hook, where the `Terminal` value is out of reach). It also shows the cursor.
- A `std::panic::set_hook` that chains the original hook: restore the terminal first, then let the default hook print the panic report to the real screen.
- The normal teardown reuses the same helper (DRY).

Follows the restoration pattern recommended by the ratatui docs.

## Test

- `cargo build`, `cargo clippy` (no issues), `cargo test` (189 passed).
- Panic path verified by inspection (chained hook + best-effort restore); can be exercised manually with a temporary `panic!()` in `run()`.