### PR TITLE
fix(api): harden HTTP client — timeouts + richer user-agent

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -6,6 +6,7 @@ use super::types::{
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct ApiClient {
@@ -16,8 +17,15 @@ pub struct ApiClient {
 
 impl ApiClient {
     pub fn new(base_url: String, api_key: String) -> Result<Self> {
+        // reqwest has no default timeout: a half-open connection (suspend/resume,
+        // wifi dropping mid-request) would otherwise hang a fetch task forever —
+        // no ApiMessage ever arrives, `loading` stays true, and all three refresh
+        // paths are gated on `!loading`. Bound both the connect and the overall
+        // request so a stuck fetch always fails and frees the refresh loop.
         let client = Client::builder()
             .user_agent("neumann-cockpit/0.1")
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
             .build()
             .context("Failed to build HTTP client")?;
         let base_url = Url::parse(&base_url).context("Invalid base_url in config")?;

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -17,13 +17,22 @@ pub struct ApiClient {
 
 impl ApiClient {
     pub fn new(base_url: String, api_key: String) -> Result<Self> {
+        // Identify the client to the game server: app version + platform.
+        // e.g. "neumann-cockpit/63.1.0 (linux; x86_64)".
+        let user_agent = format!(
+            "neumann-cockpit/{} ({}; {})",
+            env!("CARGO_PKG_VERSION"),
+            std::env::consts::OS,
+            std::env::consts::ARCH,
+        );
+
         // reqwest has no default timeout: a half-open connection (suspend/resume,
         // wifi dropping mid-request) would otherwise hang a fetch task forever —
         // no ApiMessage ever arrives, `loading` stays true, and all three refresh
         // paths are gated on `!loading`. Bound both the connect and the overall
         // request so a stuck fetch always fails and frees the refresh loop.
         let client = Client::builder()
-            .user_agent("neumann-cockpit/0.1")
+            .user_agent(user_agent)
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(30))
             .build()


### PR DESCRIPTION
## Summary

Two improvements to the `ApiClient` builder (`client.rs`).

### 1. HTTP timeouts (HIGH · S from the v63.1.0 review)

`reqwest` has no default timeout and the builder only set the user agent. A half-open connection (laptop suspend/resume, wifi dropping mid-request) left a fetch task hung forever: no `ApiMessage` arrived, `loading` stayed `true`, and **all three refresh paths (F5, periodic, deadline) are gated on `!loading`** — the spinner froze with no obvious recovery.

- `connect_timeout(10s)` — cap the TCP/TLS handshake.
- `timeout(30s)` — overall request deadline.

### 2. Richer user-agent

The user-agent was the hardcoded, stale literal `neumann-cockpit/0.1`. Now built from `env!("CARGO_PKG_VERSION")` + target OS + arch:

```
neumann-cockpit/63.1.1 (linux; x86_64)
```

So the game server sees the real client, version and platform. Zero new dependencies.

## Follow-up (not in this PR)

Defense-in-depth watchdog that releases `loading` independently of the request outcome — left out to keep scope tight.

## Test

- `cargo build`, `cargo clippy` (no issues), `cargo test` (189 passed).