### PR TITLE
fix(refresh): back off periodic auto-refresh on consecutive failures

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -48,6 +48,13 @@ pub struct AppState {
     pub probe: Option<Probe>,
     pub mannies: Option<Vec<Manny>>,
     pub last_update: Option<DateTime<Local>>,
+    /// When the last automatic (periodic) refresh was *fired*, as opposed to
+    /// `last_update` (last *successful* sync). Lets the periodic refresh throttle
+    /// by elapsed-since-attempt instead of firing every tick while the last sync
+    /// stays stale during an outage.
+    pub last_attempt: Option<DateTime<Local>>,
+    /// Consecutive failed periodic refreshes, driving exponential backoff.
+    pub consecutive_failures: u32,
     pub movement_arrival: Option<DateTime<Utc>>,
     pub error: Option<String>,
     pub loading: bool,
@@ -145,6 +152,8 @@ impl AppState {
             .filter(|&a| a > Utc::now());
         self.probe = Some(probe);
         self.last_update = Some(Local::now());
+        // A successful probe sync clears the refresh backoff.
+        self.consecutive_failures = 0;
         self.error = None;
         self.clamp_inventory_selection();
     }
@@ -297,11 +306,42 @@ impl AppState {
         self.last_update.map(|t| (Local::now() - t).num_seconds().max(0))
     }
 
-    /// Whether a periodic auto-refresh is due: idle and ≥60 s since the last
-    /// sync. Requires a prior successful sync, so a failed initial fetch does
-    /// not spin-retry every tick.
+    /// Interval the periodic refresh must respect: the normal 60 s cadence when
+    /// healthy, otherwise exponential backoff (5→10→20→40→60 s) so a network
+    /// outage does not trigger a request storm (7 spawns per tick).
+    pub fn refresh_backoff_secs(&self) -> i64 {
+        match self.consecutive_failures {
+            0 => 60,
+            n => (5_i64 << (n - 1).min(4)).min(60),
+        }
+    }
+
+    /// Record that an automatic refresh was just fired.
+    pub fn note_refresh_attempt(&mut self) {
+        self.last_attempt = Some(Local::now());
+    }
+
+    /// Record a failed refresh (fatal probe error), growing the backoff.
+    pub fn note_refresh_failure(&mut self) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+    }
+
+    /// Whether a periodic auto-refresh is due. Requires a prior successful sync
+    /// (so a failed initial fetch does not spin-retry), the data to be stale
+    /// (≥60 s), and — crucially — the backoff-adjusted interval to have elapsed
+    /// since the last *attempt*, so consecutive failures back off instead of
+    /// firing every 1 s tick while `last_update` stays stale.
     pub fn periodic_refresh_due(&self) -> bool {
-        !self.loading && matches!(self.seconds_since_sync(), Some(s) if s >= 60)
+        if self.loading || self.last_update.is_none() {
+            return false;
+        }
+        if !matches!(self.seconds_since_sync(), Some(s) if s >= 60) {
+            return false;
+        }
+        match self.last_attempt {
+            None => true,
+            Some(t) => (Local::now() - t).num_seconds().max(0) >= self.refresh_backoff_secs(),
+        }
     }
 
     pub fn next_refresh_instant(&self) -> Instant {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1421,6 +1421,38 @@ fn periodic_refresh_not_due_when_recent_or_loading() {
     assert!(!state.periodic_refresh_due(), "a fetch already in flight");
 }
 
+#[test]
+fn refresh_backoff_grows_then_caps_at_60() {
+    let mut state = AppState::default();
+    assert_eq!(state.refresh_backoff_secs(), 60, "healthy cadence is 60s");
+    for (failures, expected) in [(1, 5), (2, 10), (3, 20), (4, 40), (5, 60), (6, 60), (99, 60)] {
+        state.consecutive_failures = failures;
+        assert_eq!(state.refresh_backoff_secs(), expected, "after {failures} failures");
+    }
+}
+
+#[test]
+fn periodic_refresh_backs_off_after_failure() {
+    let mut state = AppState::default();
+    // Stale data (never re-synced), one recent failed attempt.
+    state.last_update = Some(chrono::Local::now() - chrono::Duration::seconds(300));
+    state.consecutive_failures = 1; // backoff = 5s
+    state.last_attempt = Some(chrono::Local::now() - chrono::Duration::seconds(2));
+    assert!(!state.periodic_refresh_due(), "2s < 5s backoff → not due yet");
+    state.last_attempt = Some(chrono::Local::now() - chrono::Duration::seconds(6));
+    assert!(state.periodic_refresh_due(), "6s ≥ 5s backoff → due");
+}
+
+#[test]
+fn successful_probe_sync_clears_backoff() {
+    let mut state = AppState::default();
+    state.consecutive_failures = 4;
+    state.note_refresh_failure();
+    assert_eq!(state.consecutive_failures, 5);
+    state.update_probe(make_probe(1.0, 0.0, 0.0, 0.0));
+    assert_eq!(state.consecutive_failures, 0, "a successful sync resets the backoff");
+}
+
 // ── manny task progress interpolation ─────────────────────────────────────
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,7 @@ async fn run(
                 // only fire the periodic refresh when it is due.
                 if !state.booting && state.periodic_refresh_due() {
                     fetch_all(client.clone(), tx.clone());
+                    state.note_refresh_attempt();
                     state.loading = true;
                 }
             }
@@ -344,7 +345,10 @@ async fn run(
                     ApiMessage::RenameMannyError(e) => state.set_rename_manny_error(e),
                     ApiMessage::VersionFetched(v) => state.api_version = Some(v),
                     ApiMessage::VisitedSectorsFetched(v) => state.visited_sectors = v,
-                    ApiMessage::Error(e) => state.set_error(e),
+                    ApiMessage::Error(e) => {
+                        state.note_refresh_failure();
+                        state.set_error(e);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Addresses the **MED · S** finding from the v63.1.0 project review: *"Coupure réseau = tempête de retry, 7 requêtes/s sans backoff"*.

`periodic_refresh_due()` was gated only on `seconds_since_sync` (last **successful** sync). During an outage `last_update` never advances, so the ≥60s condition stays permanently true and every 1s `ui_tick` refired `fetch_all` — a **7-request/second storm** with a matching churn of error toasts.

## Change

Throttle the periodic refresh on the last **attempt** with exponential backoff:

- healthy cadence: **60s** (unchanged)
- after consecutive fatal probe errors: **5 → 10 → 20 → 40 → 60s** (capped)

New state: `last_attempt` (set when a periodic fetch fires) and `consecutive_failures`. A successful probe sync (`update_probe`) clears the backoff; a fatal `ApiMessage::Error` grows it.

This complements PR #121: the HTTP timeout bounds **hung** connections; the backoff bounds **fast** failures (connection refused) that clear `loading` instantly and would otherwise refire every tick.

## Tests

3 new unit tests (backoff mapping, backoff gating after a failure, reset on success). `cargo build` + `clippy` clean, `cargo test` **192 passed**.