### PR TITLE
fix(errors): surface swallowed fetch errors instead of silent no-ops

### DIFF
--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -95,9 +95,11 @@ pub fn fetch_send_message(
 
 pub fn fetch_mark_message_read(id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        if let Ok(m) = client.mark_message_read(id).await {
-            let _ = tx.send(ApiMessage::MessageMarkedRead(m)).await;
-        }
+        let msg = match client.mark_message_read(id).await {
+            Ok(m) => ApiMessage::MessageMarkedRead(m),
+            Err(e) => ApiMessage::ActionError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
     });
 }
 
@@ -129,17 +131,21 @@ pub fn fetch_damage_warnings(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
 
 pub fn fetch_ack_alert(id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        if let Ok(a) = client.ack_alert(id).await {
-            let _ = tx.send(ApiMessage::AlertAcknowledged(a)).await;
-        }
+        let msg = match client.ack_alert(id).await {
+            Ok(a) => ApiMessage::AlertAcknowledged(a),
+            Err(e) => ApiMessage::ActionError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
     });
 }
 
 pub fn fetch_ack_damage_warning(id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        if let Ok(w) = client.ack_damage_warning(id).await {
-            let _ = tx.send(ApiMessage::DamageWarningAcknowledged(w)).await;
-        }
+        let msg = match client.ack_damage_warning(id).await {
+            Ok(w) => ApiMessage::DamageWarningAcknowledged(w),
+            Err(e) => ApiMessage::ActionError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
     });
 }
 
@@ -185,9 +191,11 @@ pub fn fetch_storage_containers(client: ApiClient, tx: mpsc::Sender<ApiMessage>)
 
 pub fn fetch_storage_container_detail(id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        if let Ok((c, inv)) = client.get_storage_container(&id).await {
-            let _ = tx.send(ApiMessage::StorageContainerDetailFetched(c, inv)).await;
-        }
+        let msg = match client.get_storage_container(&id).await {
+            Ok((c, inv)) => ApiMessage::StorageContainerDetailFetched(c, inv),
+            Err(e) => ApiMessage::StorageContainerDetailError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
     });
 }
 

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -44,6 +44,7 @@ pub enum ApiMessage {
     AlertAcknowledged(ProbeAlert),
     StorageContainersFetched(Vec<StorageContainer>),
     StorageContainerDetailFetched(StorageContainer, ContainerInventory),
+    StorageContainerDetailError(String),
     RenameContainerDone(StorageContainer, ProbeInventory),
     RenameContainerError(String),
     UpdateContainerRulesDone(StorageContainer, ProbeInventory),
@@ -70,5 +71,10 @@ pub enum ApiMessage {
     MessageMarkedRead(ProbeMessage),
     DropStorageContainerStarted(Manny),
     DropStorageContainerError(String),
+    /// A direct user action (ack alert / damage warning, mark message read) that
+    /// failed — surfaced in the status bar so the key does not feel dead.
+    /// Distinct from `Error`, which is the fatal-probe channel that drives
+    /// refresh backoff.
+    ActionError(String),
     Error(String),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -84,6 +84,9 @@ pub struct AppState {
     /// Storage containers fetched on demand when the containers overlay opens.
     pub storage_containers: Vec<StorageContainer>,
     pub storage_container_detail: Option<(StorageContainer, ContainerInventory)>,
+    /// Error from the last container-detail fetch, shown in the drill-in instead
+    /// of a "fetching…" line that would otherwise hang forever.
+    pub storage_container_detail_error: Option<String>,
     pub rename_container: RenameContainerInput,
     pub container_rules: ContainerRulesInput,
     pub storage_move: StorageMoveInput,

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -110,6 +110,7 @@ fn drill_in(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessa
             state.pane_nav[Pane::Storage.index()].drill.last().cloned()
         {
             state.storage_container_detail = None;
+            state.storage_container_detail_error = None;
             fetch_storage_container_detail(id, client.clone(), tx.clone());
         }
     }
@@ -119,6 +120,7 @@ fn drill_in(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessa
 fn drill_out(state: &mut AppState) {
     if state.active_pane == Pane::Storage {
         state.storage_container_detail = None;
+        state.storage_container_detail_error = None;
     }
     state.pane_drill_out();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,12 @@ async fn run(
                         });
                     }
                     ApiMessage::ScanError(e) => {
-                        if state.scan_batch.is_some() {
+                        if matches!(state.remote_mine, RemoteMineInput::Loading { .. }) {
+                            // The remote-mine sector fetch failed — don't leave the
+                            // wizard hung on "fetching…". Abort and surface why.
+                            state.remote_mine = RemoteMineInput::Inactive;
+                            state.set_error(e);
+                        } else if state.scan_batch.is_some() {
                             state.batch_tick();
                         } else {
                             state.set_scan_error(e);
@@ -299,6 +304,11 @@ async fn run(
                     ApiMessage::StorageContainersFetched(c) => state.storage_containers = c,
                     ApiMessage::StorageContainerDetailFetched(c, inv) => {
                         state.storage_container_detail = Some((c, inv));
+                        state.storage_container_detail_error = None;
+                    }
+                    ApiMessage::StorageContainerDetailError(e) => {
+                        state.storage_container_detail = None;
+                        state.storage_container_detail_error = Some(e);
                     }
                     ApiMessage::RenameContainerDone(c, inv) => {
                         state.apply_container_update(c, inv);
@@ -359,6 +369,7 @@ async fn run(
                     ApiMessage::RenameMannyError(e) => state.set_rename_manny_error(e),
                     ApiMessage::VersionFetched(v) => state.api_version = Some(v),
                     ApiMessage::VisitedSectorsFetched(v) => state.visited_sectors = v,
+                    ApiMessage::ActionError(e) => state.set_error(e),
                     ApiMessage::Error(e) => {
                         state.note_refresh_failure();
                         state.set_error(e);

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -500,7 +500,11 @@ fn render_container_contents(
 
     match state.storage_container_detail.as_ref().filter(|(c, _)| c.id == id) {
         None => {
-            lines.push(Line::styled("fetching contents…", dim));
+            if let Some(err) = &state.storage_container_detail_error {
+                lines.push(Line::styled(format!("✗ {err}"), Style::default().fg(p.crit)));
+            } else {
+                lines.push(Line::styled("fetching contents…", dim));
+            }
         }
         Some((c, inv)) => {
             let ratio = if c.capacity > 0.0 {


### PR DESCRIPTION
## Summary

Addresses the **MED · S** finding from the v63.1.0 project review: *"~15 fetches avalent leurs erreurs — dont des actions utilisateur directes et 2 états UI bloqués"*.

Several spawners discarded errors with `if let Ok(...)`, so on failure the key felt dead or a view hung forever. Fixed the user-facing ones:

- **ack-alert / ack-damage-warning / mark-message-read** — now report failures via a new `ApiMessage::ActionError` → status bar. Deliberately kept separate from `ApiMessage::Error` (the fatal-probe channel) so a failed user action does **not** trigger the refresh backoff.
- **Storage drill-in (container detail)** — a failed detail fetch now sets `storage_container_detail_error`, shown in the pane, instead of leaving `fetching contents…` on screen forever. Cleared when a new drill-in starts, on success, and on drill-out.
- **Remote-mine `Loading`** — a failed sector fetch (`ScanError`) now aborts the wizard and surfaces the reason, instead of hanging on the fetching state until a guessed `Esc`.

Background/cosmetic fetches (version, recipes, mannies/sector/alerts refresh) intentionally stay silent — they retry on the next cycle.

## Test

- `cargo build`, `cargo clippy` (no issues), `cargo test` (189 passed).