### PR TITLE
refactor(overlays): drive overlay rendering from a single registry

### DIFF
--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -45,14 +45,7 @@ pub(crate) use storage_move::render_storage_move_overlay;
 pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
 
-use crate::app::{
-    AlertsInput, AppState, AtomicPrinterCraftInput, ContainerRulesInput,
-    CraftInput, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput,
-    GotoVisitedInput, InspectInput, JettisonInput, MineInput,
-    MessagesInput, MindSnapshotInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput,
-    RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput,
-    ScanMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput, WaypointsInput,
-};
+use crate::app::{AppState, GotoVisitedInput, ScanMode};
 use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -62,102 +55,59 @@ use ratatui::{
     Frame,
 };
 
+/// The wizard overlays, in z-order (back to front). Every one self-guards —
+/// its render fn early-returns when its `*Input` field is `Inactive` — so they
+/// can be painted unconditionally. Only one wizard is active at a time (the
+/// input router routes keys to a single wizard and launch sites are mutually
+/// exclusive), so the relative order only matters as documentation. Adding a
+/// wizard overlay means adding one line here — the single source of truth for
+/// the render side, replacing the hand-synchronized `if !matches!` ladder.
+const WIZARD_OVERLAYS: &[fn(&mut Frame, Rect, &AppState)] = &[
+    render_alerts_overlay,
+    render_travel_overlay,
+    render_repair_overlay,
+    render_mine_overlay,
+    render_remote_mine_overlay,
+    render_jettison_overlay,
+    render_craft_overlay,
+    render_atomic_printer_craft_overlay,
+    render_salvage_overlay,
+    render_recall_overlay,
+    render_refuel_overlay,
+    render_mind_snapshot_overlay,
+    render_missions_overlay,
+    render_messages_overlay,
+    render_scut_relay_overlay,
+    render_scut_network_overlay,
+    render_drop_cargo_overlay,
+    render_deploy_overlay,
+    render_rename_manny_overlay,
+    render_inspect_overlay,
+    render_recover_overlay,
+    render_detach_overlay,
+    render_drop_container_overlay,
+    render_object_action_overlay,
+    render_waypoints_overlay,
+    render_rename_container_overlay,
+    render_container_rules_overlay,
+    render_storage_move_overlay,
+];
+
 /// Render whichever wizard overlays are active, on top of the cockpit grid.
 pub(crate) fn render_active_overlays(frame: &mut Frame, area: Rect, state: &AppState) {
-    // Informational overlays first (lowest in the stack); action wizards on top.
-    if !matches!(state.alerts_input, AlertsInput::Inactive) {
-        render_alerts_overlay(frame, area, state);
+    for render in WIZARD_OVERLAYS {
+        render(frame, area, state);
     }
-    if !matches!(state.travel, TravelInput::Inactive) {
-        render_travel_overlay(frame, area, state);
-    }
-    if !matches!(state.repair, RepairInput::Inactive) {
-        render_repair_overlay(frame, area, state);
-    }
-    if !matches!(state.mine, MineInput::Inactive) {
-        render_mine_overlay(frame, area, state);
-    }
-    if !matches!(state.remote_mine, RemoteMineInput::Inactive) {
-        render_remote_mine_overlay(frame, area, state);
-    }
+    // Modals that don't follow the `*Input::Inactive` pattern (bool flags or a
+    // distinct enum) stay explicit. `help` is topmost, so it renders last.
     if state.map.open {
         render_map_overlay(frame, area, state);
     }
     if matches!(state.goto_visited, GotoVisitedInput::Picking { .. }) {
         render_goto_visited_overlay(frame, area, state);
     }
-    if !matches!(state.jettison, JettisonInput::Inactive) {
-        render_jettison_overlay(frame, area, state);
-    }
-    if !matches!(state.craft, CraftInput::Inactive) {
-        render_craft_overlay(frame, area, state);
-    }
-    if !matches!(state.atomic_printer_craft, AtomicPrinterCraftInput::Inactive) {
-        render_atomic_printer_craft_overlay(frame, area, state);
-    }
-    if !matches!(state.salvage, SalvageInput::Inactive) {
-        render_salvage_overlay(frame, area, state);
-    }
-    if !matches!(state.recall, RecallInput::Inactive) {
-        render_recall_overlay(frame, area, state);
-    }
-    if !matches!(state.refuel, RefuelInput::Inactive) {
-        render_refuel_overlay(frame, area, state);
-    }
-    if !matches!(state.mind_snapshot, MindSnapshotInput::Inactive) {
-        render_mind_snapshot_overlay(frame, area, state);
-    }
-    if !matches!(state.missions_input, MissionsInput::Inactive) {
-        render_missions_overlay(frame, area, state);
-    }
-    if !matches!(state.messages_input, MessagesInput::Inactive) {
-        render_messages_overlay(frame, area, state);
-    }
-    if !matches!(state.scut_relay, ScutRelayInput::Inactive) {
-        render_scut_relay_overlay(frame, area, state);
-    }
-    if !matches!(state.scut_network, ScutNetworkInput::Inactive) {
-        render_scut_network_overlay(frame, area, state);
-    }
-    if !matches!(state.drop_cargo, DropCargoInput::Inactive) {
-        render_drop_cargo_overlay(frame, area, state);
-    }
-    if !matches!(state.deploy, DeployInput::Inactive) {
-        render_deploy_overlay(frame, area, state);
-    }
-    if !matches!(state.rename_manny, RenameMannyInput::Inactive) {
-        render_rename_manny_overlay(frame, area, state);
-    }
-    if !matches!(state.inspect, InspectInput::Inactive) {
-        render_inspect_overlay(frame, area, state);
-    }
-    if !matches!(state.recover, RecoverInput::Inactive) {
-        render_recover_overlay(frame, area, state);
-    }
-    if !matches!(state.detach, DetachInput::Inactive) {
-        render_detach_overlay(frame, area, state);
-    }
-    if !matches!(state.drop_container, DropStorageContainerInput::Inactive) {
-        render_drop_container_overlay(frame, area, state);
-    }
-    if !matches!(state.object_action, ObjectActionInput::Inactive) {
-        render_object_action_overlay(frame, area, state);
-    }
-    if !matches!(state.waypoints, WaypointsInput::Inactive) {
-        render_waypoints_overlay(frame, area, state);
-    }
     if state.inventory_detail_open {
         render_inventory_detail_overlay(frame, area, state);
-    }
-    // Container action wizards + read-only detail sit above the list.
-    if !matches!(state.rename_container, RenameContainerInput::Inactive) {
-        render_rename_container_overlay(frame, area, state);
-    }
-    if !matches!(state.container_rules, ContainerRulesInput::Inactive) {
-        render_container_rules_overlay(frame, area, state);
-    }
-    if !matches!(state.storage_move, StorageMoveInput::Inactive) {
-        render_storage_move_overlay(frame, area, state);
     }
     if !matches!(state.scan_mode, ScanMode::Current) {
         render_scan_input_overlay(frame, area, state);


### PR DESCRIPTION
## Summary

**Phase 1** of the wizard-dispatch consolidation (HIGH·L review finding: *"le pattern *Input a dépassé ses limites — 4 sites de dispatch synchronisés à la main"*).

`render_active_overlays` was **30 hand-maintained** `if !matches!(state.x, XInput::Inactive) { render_x(...) }` blocks — a list kept in sync by hand, and redundant with each render fn's own `Inactive` early-return.

## Change

- Uniform overlays now live in a single ordered `WIZARD_OVERLAYS: &[fn(&mut Frame, Rect, &AppState)]` slice, painted unconditionally (each render fn self-guards). **Adding an overlay = one line.**
- The 5 modals that don't follow the `*Input::Inactive` pattern (map, goto-visited, inventory detail, scan input, help) stay explicit, with `help` rendered last (topmost).

Net −50 lines. Behavior-preserving: overlays are mutually exclusive (verified — the input router routes to a single wizard and launch sites don't overlap), so z-order is unchanged in practice.

Follows PR #126 (characterization tests) and precedes Phase 2 (the input-side registry).

## Test

`cargo build` + `clippy` clean, `cargo test` 192 passed.