### PR TITLE
fix(tui): stop capturing the mouse

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use crossterm::{
     cursor::Show,
-    event::{DisableMouseCapture, EnableMouseCapture, EventStream},
+    event::EventStream,
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -34,7 +34,7 @@ use neumann_cockpit::ui;
 /// the `Terminal` value is out of reach.
 fn restore_terminal() -> io::Result<()> {
     disable_raw_mode()?;
-    execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture, Show)
+    execute!(io::stdout(), LeaveAlternateScreen, Show)
 }
 
 #[tokio::main]
@@ -46,12 +46,14 @@ async fn main() -> Result<()> {
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    // No mouse capture: the cockpit handles no mouse events, and capturing would
+    // steal the terminal's native selection/copy and scroll-wheel.
+    execute!(stdout, EnterAlternateScreen)?;
 
     // A panic anywhere in the ~16k lines of render/input unwinds past the
-    // teardown below, leaving the shell in raw mode with mouse capture on and
-    // the panic message hidden in the alternate screen. Restore the terminal
-    // first, then let the original hook print the report to the real screen.
+    // teardown below, leaving the shell in raw mode and the panic message hidden
+    // in the alternate screen. Restore the terminal first, then let the original
+    // hook print the report to the real screen.
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = restore_terminal();


### PR DESCRIPTION
## Summary

Addresses the **MED·S** UX finding from the v63.1.0 review: *"Mouse capture activé, aucun événement souris géré"*.

`EnableMouseCapture` stole the terminal's native text selection/copy (forcing the user to hold Shift) and hijacked the scroll wheel — a daily irritation for zero benefit, since the cockpit handles no mouse events.

## Change

Drop the `Enable`/`DisableMouseCapture` pair (setup + `restore_terminal`) and the now-unused imports. Keyboard-only input is unaffected — crossterm only emits mouse events while capture is enabled, so the existing `let Event::Key(k) = event else { return }` path is unchanged.

## Test

`cargo build` + `clippy` clean, `cargo test` 201 passed.