### PR TITLE
fix(input): make cockpit keys work with CapsLock

### DIFF
--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -30,6 +30,15 @@ pub fn handle_cockpit_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
+    // Cockpit keys (ertdfgcvb, jkhl, z, q, …) are all lowercase, but CapsLock —
+    // or Shift — sends uppercase letters, and no cockpit binding uses those.
+    // Normalize so the grid stays navigable regardless of CapsLock. Text entry
+    // is handled by the wizard/command layers before this, so it is unaffected.
+    let code = match code {
+        KeyCode::Char(c) => KeyCode::Char(c.to_ascii_lowercase()),
+        other => other,
+    };
+
     // A context menu, when open, captures all input.
     if matches!(state.mode, InputMode::Menu(_)) {
         handle_menu_key(code, state, client, tx);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -250,6 +250,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cockpit_pane_key_works_with_capslock() {
+        // CapsLock (or Shift) sends an uppercase letter; cockpit keys must still work.
+        let mut state = AppState::default();
+        press(&mut state, KeyCode::Char('E'));
+        assert_eq!(state.active_pane, Pane::Scanner, "uppercase 'E' routes like 'e'");
+    }
+
+    #[tokio::test]
     async fn open_wizard_captures_keys_before_cockpit() {
         let mut state = AppState::default();
         state.travel = TravelInput::Typing(String::new());


### PR DESCRIPTION
## Summary

Addresses the **LOW·S** UX finding from the v63.1.0 review: *"CapsLock tue silencieusement toutes les lettres"*.

`Pane::from_key` and every `KeyCode::Char` match are lowercase-only, so with CapsLock on (or Shift held) the cockpit keys `ertdfgcvb`, `jkhl`, `z`, `q` silently died — no binding uses the uppercase forms, so they fell through to the no-op arm.

## Change

Normalize `Char` codes to lowercase at the top of `handle_cockpit_event` (before the context-menu dispatch too). Non-letter keys and non-`Char` codes are untouched; text entry is handled by the wizard/command layers *before* the cockpit layer, so it is unaffected.

## Test

New characterization test: uppercase `'E'` routes like `'e'` (switches pane). `cargo test` 202 passed, `clippy` clean.