### PR TITLE
feat(store): persist scan history in local SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +263,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +412,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -402,6 +435,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -721,6 +763,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +845,7 @@ dependencies = [
  "pretty_assertions",
  "ratatui",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "tokio",
@@ -859,6 +913,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1087,6 +1147,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1633,6 +1707,18 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ directories = "5"
 futures     = "0.3"
 reqwest     = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 ratatui     = "0.29"
+rusqlite    = { version = "0.32", features = ["bundled"] }
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 tokio       = { version = "1", features = ["full"] }

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -1,6 +1,5 @@
 use crate::api::types::{ScutRelayStatus, SectorObjectType, SectorObservation};
 use chrono::Utc;
-use std::path::Path;
 use super::*;
 
 /// Cyclic filter applied to the scan history list ([f] in the scanner).
@@ -432,12 +431,5 @@ impl AppState {
             }
         }
         None
-    }
-
-    pub fn load_scan_history(&mut self, path: &Path) {
-        let Ok(data) = std::fs::read(path) else { return };
-        if let Ok(history) = serde_json::from_slice::<Vec<SectorObservation>>(&data) {
-            self.scan_history = history;
-        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,23 @@ pub fn history_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("scan_history.json"))
 }
 
+/// Path to the local SQLite database (scan history today; action audit later).
+///
+/// This is mutable state, not configuration, so it lives in the XDG state dir
+/// (`~/.local/state/…`) rather than `~/.config`. State dir is Linux-only in the
+/// spec, so fall back to the data dir elsewhere. The legacy `scan_history.json`
+/// stays under `config_dir` (see `history_path`) purely as a one-time import
+/// source.
+pub fn db_path() -> PathBuf {
+    ProjectDirs::from("net", "neumann", "neumann-cockpit")
+        .map(|d| {
+            d.state_dir()
+                .unwrap_or_else(|| d.data_local_dir())
+                .join("cockpit.db")
+        })
+        .unwrap_or_else(|| PathBuf::from("cockpit.db"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod api;
 pub mod app;
 pub mod config;
 pub mod input;
+pub mod store;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use neumann_cockpit::app::{
 };
 use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
+use neumann_cockpit::store;
 use neumann_cockpit::ui;
 
 /// Best-effort restoration of the terminal to its cooked state. Writes the
@@ -83,8 +84,17 @@ async fn run(
         booting: true,
         ..Default::default()
     };
-    let scan_history_path = config::history_path();
-    state.load_scan_history(&scan_history_path);
+    // Local SQLite store: load the scan history and get a writer handle. On any
+    // DB error we start with an empty history (like the old corrupt-JSON path)
+    // and simply don't persist.
+    let persist_tx = match store::open(&config::db_path()) {
+        Ok(conn) => {
+            store::import_legacy_json(&conn, &config::history_path());
+            state.scan_history = store::load_observations(&conn);
+            Some(store::spawn_writer(conn))
+        }
+        Err(_) => None,
+    };
     let mut events = EventStream::new();
 
     // Short-lived tick that drives the boot assembly; runs only while booting.
@@ -141,13 +151,11 @@ async fn run(
                         state.update_sector(sector);
                         state.remote_mine_sector_loaded(sx, sy, sz);
                         state.batch_tick();
-                        let history = state.scan_history.clone();
-                        let path = scan_history_path.clone();
-                        tokio::spawn(async move {
-                            if let Ok(json) = serde_json::to_string(&history) {
-                                let _ = tokio::fs::write(path, json).await;
-                            }
-                        });
+                        // Persist just the observation that changed (upsert by
+                        // coordinates), via the single writer thread.
+                        if let (Some(tx), Some(obs)) = (&persist_tx, state.scan_history.first()) {
+                            let _ = tx.send(store::PersistMsg::UpsertObservation(obs.clone()));
+                        }
                     }
                     ApiMessage::ScanError(e) => {
                         if matches!(state.remote_mine, RemoteMineInput::Loading { .. }) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,8 @@ async fn run(
     // DB error we start with an empty history (like the old corrupt-JSON path)
     // and simply don't persist.
     let persist_tx = match store::open(&config::db_path()) {
-        Ok(conn) => {
-            store::import_legacy_json(&conn, &config::history_path());
+        Ok(mut conn) => {
+            let _ = store::migrate_legacy_json(&mut conn, &config::history_path());
             state.scan_history = store::load_observations(&conn);
             Some(store::spawn_writer(conn))
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,7 +4,14 @@
 //! non-atomic whole-file JSON write (`scan_history.json`). A single writer
 //! thread owns the connection, so writes are serialized and atomic by
 //! construction — matching the app's single-owner, message-passing design.
-//! The schema leaves room for an action-audit table later.
+//!
+//! Schema shape: the stable top-level fields of an observation are promoted to
+//! typed columns (queryable/indexable), and the **full API payload** is kept
+//! verbatim in `data` as JSON. This keeps the row faithful to what the API
+//! returns and forward-compatible with API drift (new fields ride along in the
+//! payload, exactly like the serde `Unknown` fallbacks elsewhere) while still
+//! giving clean columns to query and sort on. Room is left for an
+//! `action_audit` table later.
 
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -12,6 +19,26 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use rusqlite::Connection;
 
 use crate::api::types::SectorObservation;
+
+/// Table + index DDL, shared by `open` and the tests.
+const SCHEMA: &str = "
+CREATE TABLE IF NOT EXISTS sector_observations (
+    x                 INTEGER NOT NULL,
+    y                 INTEGER NOT NULL,
+    z                 INTEGER NOT NULL,
+    distance          INTEGER,
+    knowledge_level   TEXT,
+    confidence        REAL,
+    navigational_risk TEXT,
+    message           TEXT,
+    object_count      INTEGER,
+    scanned_at        TEXT,
+    data              TEXT NOT NULL,
+    PRIMARY KEY (x, y, z)
+);
+CREATE INDEX IF NOT EXISTS idx_sector_scanned_at
+    ON sector_observations (scanned_at);
+";
 
 /// Messages accepted by the persistence writer thread.
 pub enum PersistMsg {
@@ -27,17 +54,7 @@ pub fn open(path: &Path) -> rusqlite::Result<Connection> {
     let conn = Connection::open(path)?;
     // WAL keeps the single-writer / startup-reader pair snappy and durable.
     conn.pragma_update(None, "journal_mode", "WAL")?;
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS sector_observations (
-            x           INTEGER NOT NULL,
-            y           INTEGER NOT NULL,
-            z           INTEGER NOT NULL,
-            scanned_at  TEXT,
-            data        TEXT NOT NULL,
-            PRIMARY KEY (x, y, z)
-        )",
-        [],
-    )?;
+    conn.execute_batch(SCHEMA)?;
     Ok(conn)
 }
 
@@ -49,23 +66,45 @@ fn coords(obs: &SectorObservation) -> (i64, i64, i64) {
     )
 }
 
+/// Serialize a simple serde enum to its string form (e.g. `KnowledgeLevel` →
+/// `"detailed"`), for storing in a text column.
+fn enum_text<T: serde::Serialize>(v: &T) -> Option<String> {
+    serde_json::to_value(v).ok().and_then(|j| j.as_str().map(str::to_string))
+}
+
 /// Insert or replace the observation for its sector (keyed by coordinates,
-/// mirroring the in-memory dedupe in `AppState::update_sector`).
+/// mirroring the in-memory dedupe in `AppState::update_sector`). Promotes the
+/// stable fields to columns and stores the full API payload in `data`.
 pub fn upsert_observation(conn: &Connection, obs: &SectorObservation) -> rusqlite::Result<()> {
     let (x, y, z) = coords(obs);
-    let scanned_at = obs.scanned_at.map(|t| t.to_rfc3339());
     let data = serde_json::to_string(obs).unwrap_or_default();
     conn.execute(
-        "INSERT OR REPLACE INTO sector_observations (x, y, z, scanned_at, data)
-         VALUES (?1, ?2, ?3, ?4, ?5)",
-        rusqlite::params![x, y, z, scanned_at, data],
+        "INSERT OR REPLACE INTO sector_observations
+            (x, y, z, distance, knowledge_level, confidence,
+             navigational_risk, message, object_count, scanned_at, data)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        rusqlite::params![
+            x,
+            y,
+            z,
+            obs.distance,
+            enum_text(&obs.knowledge_level),
+            obs.confidence,
+            &obs.navigational_risk,
+            &obs.message,
+            obs.objects.as_ref().map(|o| o.len() as i64),
+            obs.scanned_at.map(|t| t.to_rfc3339()),
+            data,
+        ],
     )?;
     Ok(())
 }
 
 /// Load all observations, most-recently-scanned first — matching the in-memory
-/// `scan_history` ordering (newest at index 0). Best-effort: any error yields
-/// an empty history, like the old corrupt-JSON path.
+/// `scan_history` ordering (newest at index 0). The full observation is
+/// reconstructed from the `data` payload; the columns are for querying only.
+/// Best-effort: any error yields an empty history, like the old corrupt-JSON
+/// path.
 pub fn load_observations(conn: &Connection) -> Vec<SectorObservation> {
     let Ok(mut stmt) =
         conn.prepare("SELECT data FROM sector_observations ORDER BY scanned_at DESC")
@@ -80,20 +119,36 @@ pub fn load_observations(conn: &Connection) -> Vec<SectorObservation> {
         .collect()
 }
 
-/// One-time import of the legacy `scan_history.json`, only while the table is
-/// still empty — so DB-native data is never clobbered.
-pub fn import_legacy_json(conn: &Connection, json_path: &Path) {
+/// One-time migration of the legacy `scan_history.json`: while the table is
+/// still empty, import every observation, then delete the JSON so it stops
+/// lingering. The import runs in a transaction and the file is removed **only
+/// after a fully successful commit** — a missing/corrupt file or a write error
+/// leaves the JSON untouched (data-safe, retried next launch). A non-empty
+/// table means we already migrated, so we never re-import or touch the file.
+///
+/// TEMPORARY: legacy migration, scheduled for removal — see issue #134.
+/// The `legacy_migration_removal_reminder` test fails the build after
+/// 2027-01-01 so this can't be forgotten.
+pub fn migrate_legacy_json(conn: &mut Connection, json_path: &Path) -> rusqlite::Result<()> {
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
         .unwrap_or(0);
     if count > 0 {
-        return;
+        return Ok(());
     }
-    let Ok(data) = std::fs::read(json_path) else { return };
-    let Ok(history) = serde_json::from_slice::<Vec<SectorObservation>>(&data) else { return };
+    let Ok(data) = std::fs::read(json_path) else { return Ok(()) };
+    let Ok(history) = serde_json::from_slice::<Vec<SectorObservation>>(&data) else {
+        return Ok(());
+    };
+    let tx = conn.transaction()?;
     for obs in &history {
-        let _ = upsert_observation(conn, obs);
+        upsert_observation(&tx, obs)?;
     }
+    tx.commit()?;
+    // Import committed — retire the legacy file. Failure to remove is harmless
+    // (next launch sees a non-empty table and skips).
+    let _ = std::fs::remove_file(json_path);
+    Ok(())
 }
 
 /// Spawn the writer thread, taking ownership of the connection, and return the
@@ -130,12 +185,7 @@ mod tests {
 
     fn mem() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
-        conn.execute(
-            "CREATE TABLE sector_observations (x INTEGER, y INTEGER, z INTEGER,
-             scanned_at TEXT, data TEXT NOT NULL, PRIMARY KEY (x, y, z))",
-            [],
-        )
-        .unwrap();
+        conn.execute_batch(SCHEMA).unwrap();
         conn
     }
 
@@ -152,6 +202,22 @@ mod tests {
     }
 
     #[test]
+    fn promoted_columns_are_populated() {
+        let conn = mem();
+        upsert_observation(&conn, &obs(1.0, 2.0, 3.0)).unwrap();
+        let (dist, level, conf): (i64, String, f64) = conn
+            .query_row(
+                "SELECT distance, knowledge_level, confidence FROM sector_observations",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(dist, 1);
+        assert_eq!(level, "detailed", "enum stored as clean text, not JSON");
+        assert!((conf - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
     fn load_orders_newest_first() {
         let conn = mem();
         let mut a = obs(1.0, 1.0, 1.0);
@@ -163,5 +229,49 @@ mod tests {
         let loaded = load_observations(&conn);
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded[0].relative_coordinates.x as i64, 2, "newest first");
+    }
+
+    #[test]
+    fn migrate_imports_then_deletes_json() {
+        let mut conn = mem();
+        let path = std::env::temp_dir().join("nc_migrate_import_test.json");
+        let history = vec![obs(1.0, 1.0, 1.0), obs(2.0, 2.0, 2.0)];
+        std::fs::write(&path, serde_json::to_vec(&history).unwrap()).unwrap();
+        migrate_legacy_json(&mut conn, &path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "all observations imported");
+        assert!(!path.exists(), "JSON deleted after a successful import");
+    }
+
+    #[test]
+    fn migrate_skips_and_keeps_json_when_table_not_empty() {
+        let mut conn = mem();
+        upsert_observation(&conn, &obs(9.0, 9.0, 9.0)).unwrap();
+        let path = std::env::temp_dir().join("nc_migrate_skip_test.json");
+        std::fs::write(&path, serde_json::to_vec(&vec![obs(1.0, 1.0, 1.0)]).unwrap()).unwrap();
+        migrate_legacy_json(&mut conn, &path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "did not import into an already-populated table");
+        assert!(path.exists(), "JSON left in place when not migrating");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn legacy_migration_removal_reminder() {
+        // The scan_history.json migration is one-time (issue #134). Once every
+        // local install has migrated, delete `migrate_legacy_json`, its call in
+        // main.rs, and this test. This assertion fails the build after the
+        // horizon so the cleanup can't be forgotten.
+        let today = chrono::Utc::now().date_naive();
+        let horizon = chrono::NaiveDate::from_ymd_opt(2027, 1, 1).unwrap();
+        assert!(
+            today < horizon,
+            "Legacy JSON migration has expired — remove store::migrate_legacy_json \
+             and this test (see issue #134)."
+        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,167 @@
+//! Local SQLite persistence.
+//!
+//! Scope today: the sector scan history, keyed by coordinates, migrated off the
+//! non-atomic whole-file JSON write (`scan_history.json`). A single writer
+//! thread owns the connection, so writes are serialized and atomic by
+//! construction — matching the app's single-owner, message-passing design.
+//! The schema leaves room for an action-audit table later.
+
+use std::path::Path;
+use std::sync::mpsc::{self, Receiver, Sender};
+
+use rusqlite::Connection;
+
+use crate::api::types::SectorObservation;
+
+/// Messages accepted by the persistence writer thread.
+pub enum PersistMsg {
+    /// Upsert the latest observation for a sector (keyed by coordinates).
+    UpsertObservation(SectorObservation),
+}
+
+/// Open (creating if needed) the cockpit database and ensure the schema.
+pub fn open(path: &Path) -> rusqlite::Result<Connection> {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let conn = Connection::open(path)?;
+    // WAL keeps the single-writer / startup-reader pair snappy and durable.
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sector_observations (
+            x           INTEGER NOT NULL,
+            y           INTEGER NOT NULL,
+            z           INTEGER NOT NULL,
+            scanned_at  TEXT,
+            data        TEXT NOT NULL,
+            PRIMARY KEY (x, y, z)
+        )",
+        [],
+    )?;
+    Ok(conn)
+}
+
+fn coords(obs: &SectorObservation) -> (i64, i64, i64) {
+    (
+        obs.relative_coordinates.x as i64,
+        obs.relative_coordinates.y as i64,
+        obs.relative_coordinates.z as i64,
+    )
+}
+
+/// Insert or replace the observation for its sector (keyed by coordinates,
+/// mirroring the in-memory dedupe in `AppState::update_sector`).
+pub fn upsert_observation(conn: &Connection, obs: &SectorObservation) -> rusqlite::Result<()> {
+    let (x, y, z) = coords(obs);
+    let scanned_at = obs.scanned_at.map(|t| t.to_rfc3339());
+    let data = serde_json::to_string(obs).unwrap_or_default();
+    conn.execute(
+        "INSERT OR REPLACE INTO sector_observations (x, y, z, scanned_at, data)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![x, y, z, scanned_at, data],
+    )?;
+    Ok(())
+}
+
+/// Load all observations, most-recently-scanned first — matching the in-memory
+/// `scan_history` ordering (newest at index 0). Best-effort: any error yields
+/// an empty history, like the old corrupt-JSON path.
+pub fn load_observations(conn: &Connection) -> Vec<SectorObservation> {
+    let Ok(mut stmt) =
+        conn.prepare("SELECT data FROM sector_observations ORDER BY scanned_at DESC")
+    else {
+        return Vec::new();
+    };
+    let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(0)) else {
+        return Vec::new();
+    };
+    rows.filter_map(Result::ok)
+        .filter_map(|json| serde_json::from_str::<SectorObservation>(&json).ok())
+        .collect()
+}
+
+/// One-time import of the legacy `scan_history.json`, only while the table is
+/// still empty — so DB-native data is never clobbered.
+pub fn import_legacy_json(conn: &Connection, json_path: &Path) {
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
+        .unwrap_or(0);
+    if count > 0 {
+        return;
+    }
+    let Ok(data) = std::fs::read(json_path) else { return };
+    let Ok(history) = serde_json::from_slice::<Vec<SectorObservation>>(&data) else { return };
+    for obs in &history {
+        let _ = upsert_observation(conn, obs);
+    }
+}
+
+/// Spawn the writer thread, taking ownership of the connection, and return the
+/// channel to send persistence messages on. `rusqlite` is synchronous, so the
+/// writes run off the tokio runtime on this dedicated thread. Write errors are
+/// best-effort (dropped) until the tracing work lands.
+pub fn spawn_writer(conn: Connection) -> Sender<PersistMsg> {
+    let (tx, rx): (Sender<PersistMsg>, Receiver<PersistMsg>) = mpsc::channel();
+    std::thread::spawn(move || {
+        for msg in rx {
+            match msg {
+                PersistMsg::UpsertObservation(obs) => {
+                    let _ = upsert_observation(&conn, &obs);
+                }
+            }
+        }
+    });
+    tx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs(x: f64, y: f64, z: f64) -> SectorObservation {
+        serde_json::from_str(&format!(
+            r#"{{"relativeCoordinates":{{"x":{x},"y":{y},"z":{z}}},"distance":1,
+                "knowledgeLevel":"detailed","confidence":1.0,
+                "scan":{{"currentSectorResidenceSeconds":60,
+                        "requiredResidenceSeconds":60,"scanQuality":1.0}}}}"#
+        ))
+        .unwrap()
+    }
+
+    fn mem() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE sector_observations (x INTEGER, y INTEGER, z INTEGER,
+             scanned_at TEXT, data TEXT NOT NULL, PRIMARY KEY (x, y, z))",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn upsert_is_keyed_by_coordinates() {
+        let conn = mem();
+        upsert_observation(&conn, &obs(1.0, 2.0, 3.0)).unwrap();
+        upsert_observation(&conn, &obs(1.0, 2.0, 3.0)).unwrap();
+        upsert_observation(&conn, &obs(4.0, 5.0, 6.0)).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "same coords replace, not append");
+    }
+
+    #[test]
+    fn load_orders_newest_first() {
+        let conn = mem();
+        let mut a = obs(1.0, 1.0, 1.0);
+        a.scanned_at = Some("2026-07-03T10:00:00+00:00".parse().unwrap());
+        let mut b = obs(2.0, 2.0, 2.0);
+        b.scanned_at = Some("2026-07-03T12:00:00+00:00".parse().unwrap());
+        upsert_observation(&conn, &a).unwrap();
+        upsert_observation(&conn, &b).unwrap();
+        let loaded = load_observations(&conn);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].relative_coordinates.x as i64, 2, "newest first");
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the non-atomic `scan_history.json` whole-file write with a local **SQLite** database — closing the last **palier-1** safety item from the v63.1.0 review, and laying the groundwork for the action-audit + logs work.

The old path spawned a detached `tokio::fs::write` of the *entire* history on every `SectorUpdated`, so a batch scan raced N truncate-then-write and a torn file silently lost all accumulated history.

## Change

- New `store` module (SQLite via `rusqlite`, `bundled`), single **writer thread** owning the connection (`rusqlite` is sync → off the tokio runtime), fed by an `mpsc` channel. Writes are serialized and atomic by construction.
- **Schema — hybrid**: the stable observation fields (`distance`, `knowledge_level`, `confidence`, `navigational_risk`, `message`, `object_count`, `scanned_at`) are promoted to typed, indexable columns; the **full API payload** is kept verbatim in `data` (JSON). Faithful to what the API returns and forward-compatible with API drift (new fields ride along in the payload, like the serde `Unknown` fallbacks), while giving clean columns to query/sort on.
- `SectorUpdated` persists just the one changed observation (upsert keyed by coordinates, mirroring `update_sector`'s dedupe).
- **Legacy migration**: `migrate_legacy_json` imports the old `scan_history.json` in a transaction and **deletes it only after a fully successful commit** (a missing/corrupt file or a write error leaves it untouched; retried next launch). Runs only while the table is empty.
- DB lives in the **XDG state dir** (`~/.local/state/neumann-cockpit/cockpit.db`), not `~/.config` — it's mutable state, not configuration. The legacy JSON under `config_dir` is read once as the import source.
- The migration is marked temporary (issue #134) with an **expiry test** that fails the build after 2027-01-01 so the cleanup can't be forgotten.
- Dropped the now-dead `AppState::load_scan_history`.

## Notes

- `rusqlite` `bundled` compiles SQLite from source — first CI build is slower; no runtime C dependency.
- Inspectable out-of-app with `sqlite3` — handy for the upcoming audit trail.

## Test

Unit tests: keyed upsert replaces (not appends), promoted columns populated with clean text, newest-first load, migrate imports+deletes JSON, migrate skips+keeps JSON on a non-empty table, plus the expiry reminder. `cargo build` + `clippy` clean, `cargo test` 177 lib tests pass.