### PR TITLE
fix(cockpit): render the command-line caret at the cursor

### DIFF
--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -193,11 +193,24 @@ fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette, vi
     render_status_line(frame, bar, state, p, visible);
     if let Some(second_area) = second {
         let line = if let Some(cmd) = command {
-            // `:verb args` with a caret; accent to signal text-entry mode.
-            Line::from(vec![
-                Span::styled(format!(" :{}", cmd.input), Style::default().fg(p.accent)),
-                Span::styled("█", Style::default().fg(p.accent)),
-            ])
+            // `:verb args` with the caret at cmd.cursor (accent = text-entry
+            // mode). The caret is a REVERSED cell over the character it sits on,
+            // or a block when it's past the end — so mid-line edits are visible.
+            let chars: Vec<char> = cmd.input.chars().collect();
+            let cur = cmd.cursor.min(chars.len());
+            let accent = Style::default().fg(p.accent);
+            let before: String = chars[..cur].iter().collect();
+            let mut spans = vec![Span::styled(format!(" :{before}"), accent)];
+            if cur < chars.len() {
+                spans.push(Span::styled(
+                    chars[cur].to_string(),
+                    accent.add_modifier(Modifier::REVERSED),
+                ));
+                spans.push(Span::styled(chars[cur + 1..].iter().collect::<String>(), accent));
+            } else {
+                spans.push(Span::styled("█", accent));
+            }
+            Line::from(spans)
         } else {
             Line::from(Span::styled(format!(" {}", state.pane_hints()), Style::default().fg(p.dim)))
         };


### PR DESCRIPTION
## Summary

Addresses a **MED·S** UX finding from the v63.1.0 review: *"Caret de la ligne de commande rendu au mauvais endroit"* (palier 2).

The `:` command line already handled `Left`/`Right` and mid-line insertion via `cmd.cursor`, but the render always drew the block caret at the *end* of the string — so any mid-line correction happened blind.

## Change

Render the input split at `cmd.cursor`: the text before the cursor, then a **REVERSED cell** over the character the caret sits on (or a block `█` when the caret is past the end), then the rest. Handles multi-byte input via char indexing.

No state change — `command.rs` cursor logic was already correct; this only makes it visible.

## Test

`cargo build` + `clippy` clean. Visual-only change (the cursor state machine is unchanged); verified by build.