### PR TITLE
feat(cockpit): 1-9 accelerators in the contextual menu

### DIFF
--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -185,6 +185,20 @@ fn handle_menu_key(
                 fire_menu_action(action, state, client, tx);
             }
         }
+        // 1-9 accelerators: fire the nth enabled item directly (one keystroke
+        // instead of walking there with j/k). Disabled/out-of-range digits noop.
+        KeyCode::Char(c @ '1'..='9') => {
+            let idx = c as usize - '1' as usize;
+            let action = if let InputMode::Menu(m) = &state.mode {
+                m.items.get(idx).filter(|i| i.enabled).map(|i| i.action)
+            } else {
+                None
+            };
+            if let Some(action) = action {
+                state.mode = InputMode::Normal;
+                fire_menu_action(action, state, client, tx);
+            }
+        }
         _ => {}
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -258,6 +258,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn menu_digit_accelerator_fires_nth_item() {
+        use crate::app::{ContextMenu, InputMode, MenuAction, MenuItem};
+        let mut state = AppState::default();
+        state.mode = InputMode::Menu(ContextMenu {
+            title: "TEST".into(),
+            items: vec![MenuItem {
+                action: MenuAction::Travel,
+                label: "Travel…".into(),
+                enabled: true,
+                disabled_reason: None,
+            }],
+            cursor: 0,
+        });
+        press(&mut state, KeyCode::Char('1'));
+        assert!(matches!(state.mode, InputMode::Normal), "digit fired and closed the menu");
+        assert!(!matches!(state.travel, TravelInput::Inactive), "the item's wizard launched");
+    }
+
+    #[tokio::test]
     async fn open_wizard_captures_keys_before_cockpit() {
         let mut state = AppState::default();
         state.travel = TravelInput::Typing(String::new());

--- a/src/ui/cockpit_v2/menu.rs
+++ b/src/ui/cockpit_v2/menu.rs
@@ -20,7 +20,8 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
         .items
         .iter()
         .map(|i| {
-            i.label.chars().count()
+            // 3 = the " N " accelerator gutter rendered before every label.
+            3 + i.label.chars().count()
                 + i.disabled_reason.as_ref().map_or(0, |r| r.chars().count() + 3)
         })
         .max()
@@ -28,7 +29,7 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
         .max(menu.title.chars().count())
         // Keep the popup wide enough for the footer hint line.
         .max(FOOTER_WIDTH);
-    let w = (widest as u16 + 4).clamp(18, 48);
+    let w = (widest as u16 + 4).clamp(18, 56);
     // items + footer + two border rows
     let h = menu.items.len() as u16 + 3;
     let rect = centered_rect(w, h, area);
@@ -50,10 +51,13 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
         .iter()
         .enumerate()
         .map(|(i, item)| {
+            // The first nine items get a 1-9 accelerator (see handle_menu_key);
+            // later items align under a two-space gutter and stay j/k-only.
+            let acc = if i < 9 { format!(" {} ", i + 1) } else { "   ".to_string() };
             if !item.enabled {
                 let reason = item.disabled_reason.as_deref().unwrap_or("unavailable");
                 return Line::from(vec![
-                    Span::styled(format!(" {}", item.label), Style::default().fg(p.dim)),
+                    Span::styled(format!("{acc}{}", item.label), Style::default().fg(p.dim)),
                     Span::styled(format!(" ({reason})"), Style::default().fg(p.dim)),
                 ]);
             }
@@ -62,7 +66,10 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
             } else {
                 Style::default().fg(p.text)
             };
-            Line::from(Span::styled(format!(" {}", item.label), style))
+            Line::from(vec![
+                Span::styled(acc, Style::default().fg(p.dim)),
+                Span::styled(item.label.clone(), style),
+            ])
         })
         .collect();
 
@@ -77,12 +84,13 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
         p,
         &[
             FooterKey::nav("[↑/↓]", "move"),
+            FooterKey::nav("[1-9]", "pick"),
             FooterKey::nav("[Enter]", "select"),
             FooterKey::nav("[Esc]", "close"),
         ],
     );
 }
 
-/// Character width of the footer hint line (`[↑/↓] move  [Enter] select  [Esc]
-/// close`), used to size the popup.
-const FOOTER_WIDTH: usize = 39;
+/// Character width of the footer hint line (`[↑/↓] move  [1-9] pick  [Enter]
+/// select  [Esc] close`), used to size the popup.
+const FOOTER_WIDTH: usize = 51;


### PR DESCRIPTION
## Summary

Addresses a **MED·S** UX finding from the v63.1.0 review: *"Menus contextuels sans accélérateurs"* (palier 2). The Mannies menu has 12 entries navigable only with `j`/`k` — reaching a low item costs up to 11 × `j` + `Enter`.

## Change

- Number the first nine menu items with a dim ` N ` accelerator gutter.
- In `handle_menu_key`, a digit `1`-`9` fires the nth **enabled** item directly (disabled or out-of-range digits noop). Same launch path as `Enter`.
- Footer now advertises `[1-9] pick`; popup width accounts for the gutter and the wider footer.
- j/k navigation and `Enter` unchanged; items 10+ stay j/k-only under an aligned gutter.

## Test

New characterization test: with a menu open, `1` fires the first item's action and closes the menu. `cargo test` 178 passed, `clippy` clean.