### PR TITLE
fix(theme): make urgency signals stand out in the mono palettes

### DIFF
--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -250,42 +250,45 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
     }
     // An error takes over the line until dismissed; otherwise a success toast.
     if let Some(err) = &state.error {
-        left.push(Span::styled(format!("  ✗ {err}"), Style::default().fg(p.crit)));
+        left.push(Span::styled(format!("  ✗ {err}"), p.crit_style()));
     } else if let Some(toast) = state.active_toast() {
         left.push(Span::styled(format!("  ✓ {toast}"), Style::default().fg(p.good)));
     }
 
-    let mut meta = Vec::new();
+    let mut meta: Vec<(String, Style)> = Vec::new();
+    let dim = Style::default().fg(p.dim);
+    let accent = Style::default().fg(p.accent);
     // Sync status: spinner while a refresh is in flight, else the age since the
     // last successful sync (ticks live via the 1 s UI tick).
     if state.loading {
-        meta.push(("⟳ sync".to_string(), p.accent));
+        meta.push(("⟳ sync".to_string(), accent));
     } else if let Some(age) = state.seconds_since_sync() {
         let label = if age < 60 { format!("⟳ {age}s") } else { format!("⟳ {}m", age / 60) };
-        meta.push((label, p.dim));
+        meta.push((label, dim));
     }
     if !state.scut_coverage().is_empty() {
-        meta.push(("≣ SCUT".to_string(), p.accent));
+        meta.push(("≣ SCUT".to_string(), accent));
     }
     let unread = state.unread_alert_count();
     if unread > 0 {
-        meta.push((format!("! {unread}"), p.crit));
+        // Urgency signal: crit_style survives the mono palettes (bold+REVERSED).
+        meta.push((format!("! {unread}"), p.crit_style()));
     }
     if let Some(v) = state.api_version {
-        meta.push((format!("API v{v}"), p.dim));
+        meta.push((format!("API v{v}"), dim));
     }
     // Live wall clock — ticks every second via the 1 s UI tick. (Sync recency
     // lives in the ⟳ indicator above, so this is a real clock, not last-sync.)
-    meta.push((chrono::Local::now().format("%H:%M:%S").to_string(), p.dim));
+    meta.push((chrono::Local::now().format("%H:%M:%S").to_string(), dim));
     let meta_len: usize = meta.iter().map(|(s, _)| s.chars().count() + 3).sum();
     let meta_spans: Vec<Span> = meta
         .iter()
         .enumerate()
-        .flat_map(|(i, (s, c))| {
+        .flat_map(|(i, (s, st))| {
             let sep = if i == 0 { "" } else { " · " };
             [
                 Span::styled(sep, Style::default().fg(p.dim)),
-                Span::styled(s.clone(), Style::default().fg(*c)),
+                Span::styled(s.clone(), *st),
             ]
         })
         .collect();

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -60,16 +60,13 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
 
     // ── Badges ──
     if state.probe_terminal_alert().is_some() {
-        lines.push(Line::styled(
-            "⚠ RECOVER — Enter",
-            Style::default().fg(p.crit).add_modifier(Modifier::BOLD),
-        ));
+        lines.push(Line::styled("⚠ RECOVER — Enter", p.crit_style()));
     }
     let unread = state.unread_alert_count();
     if unread > 0 {
         lines.push(Line::from(vec![
             label("alerts"),
-            Span::styled(format!("{unread} unread"), Style::default().fg(p.crit)),
+            Span::styled(format!("{unread} unread"), p.crit_style()),
         ]));
     }
     if !state.scut_coverage().is_empty() {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -73,6 +73,21 @@ pub(crate) fn palette(mode: ColorMode) -> Palette {
     }
 }
 
+impl Palette {
+    /// Style for at-a-glance urgency signals (the `! n` badge, the `✗` status
+    /// line, the RECOVER banner). In the mono palettes `crit == accent`, so
+    /// colour alone can't convey urgency — fall back to bold + REVERSED, which
+    /// reads regardless of hue. Semantic palettes keep the red, bold.
+    pub(crate) fn crit_style(&self) -> Style {
+        let base = Style::default().fg(self.crit).add_modifier(Modifier::BOLD);
+        if self.crit == self.accent {
+            base.add_modifier(Modifier::REVERSED)
+        } else {
+            base
+        }
+    }
+}
+
 /// Palette-aware pane frame with retro double-line borders. Active panes get
 /// the accent colour and a bold title; inactive ones the dim accent.
 pub(crate) fn pane_block(title: &str, active: bool, p: Palette) -> Block<'_> {
@@ -300,5 +315,29 @@ pub fn format_duration(secs: i64) -> String {
         format!("{}m {:02}s", m, s)
     } else {
         format!("{}s", s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::ColorMode;
+
+    #[test]
+    fn crit_style_reverses_only_in_mono() {
+        // Mono palettes: crit == accent, so urgency needs REVERSED to read.
+        for mode in [ColorMode::MonoGreen, ColorMode::MonoAmber] {
+            assert!(
+                palette(mode).crit_style().add_modifier.contains(Modifier::REVERSED),
+                "{mode:?} crit_style must reverse"
+            );
+        }
+        // Semantic palettes keep the distinct red — no reverse needed.
+        for mode in [ColorMode::PhosphorSemantic, ColorMode::Modern16] {
+            assert!(
+                !palette(mode).crit_style().add_modifier.contains(Modifier::REVERSED),
+                "{mode:?} crit_style must not reverse"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Addresses a **MED·S** UX finding from the v63.1.0 review: *"En mono, crit ≡ accent : les signaux d'urgence disparaissent"* (palier 2).

In `mono-green`/`mono-amber`, `crit == accent`, so the always-visible urgency signals — the `! n` alerts badge, the status-bar `✗` error, the `⚠ RECOVER` banner and the `n unread` line — rendered identically to a normal accent highlight. Nothing flagged as urgent.

## Change

- New `Palette::crit_style()`: **bold + REVERSED** when `crit == accent` (the mono case), plain bold `crit` otherwise. The fg/bg inversion reads as urgent regardless of hue, so mono keeps its single-phosphor look while urgency still pops.
- Applied to the always-visible signals: status-bar error and `! n` badge (`cockpit_v2`), the RECOVER banner and unread-alerts line (`probe` panel). The status-bar meta now carries a `Style` per item instead of a bare colour.
- Semantic palettes (`phosphor-semantic`, `modern-16`) are unchanged — they already have a distinct red.

## Scope note

Gauges `< 25 %` are the one urgency signal left: criticality there is decided by the caller's `fill` colour, which is ambiguous under mono, so a proper fix needs a per-gauge critical flag/glyph — deferred to its own change.

## Test

`crit_style_reverses_only_in_mono` covers all four palettes. `cargo test` 178 passed, `clippy` clean.