### PR TITLE
feat(boot): auto-continue after the self-check + boot config key

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -7,3 +7,6 @@ api_key  = "vng_your_api_key_here"
 #theme = "mono-green"
 # Show the contextual hints line at the bottom (F1 toggles at runtime).
 #hints = true
+# Play the boot self-check animation on startup. Set false to drop straight
+# into the live cockpit (handy over tmux/ssh or on relaunch).
+#boot = true

--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -16,8 +16,12 @@ pub const BOOT_CHARS_PER_FRAME: usize = 3;
 /// the eight subsystems come online, centre-out, at the fast cadence.
 const PROBE_LEAD: u64 = 12;
 /// Frame by which the whole self-check has typed out. Past this the boot is
-/// "complete" and waits on a keypress to continue.
+/// "complete" and shows the "any key to continue" prompt.
 const BOOT_SEQUENCE_END: u64 = 34;
+/// Frame at which the boot auto-continues on its own (~2 s after the self-check
+/// finishes, at the 90 ms boot tick), so a relaunch under tmux/ssh never sits
+/// on the prompt forever. A keypress still continues immediately.
+const BOOT_AUTO_CONTINUE: u64 = BOOT_SEQUENCE_END + 22;
 
 /// The eight non-probe panes in centre-out order: axial neighbours, then
 /// corners.
@@ -43,10 +47,14 @@ fn boot_reveal_frame(pane: Pane) -> u64 {
 }
 
 impl AppState {
-    /// Advance the boot animation one frame. The boot never ends on its own —
-    /// it plays the self-check, then waits for a keypress (see `skip_boot`).
+    /// Advance the boot animation one frame. It plays the self-check, shows the
+    /// "any key to continue" prompt, then auto-continues a couple seconds later
+    /// (a keypress via `skip_boot` continues immediately).
     pub fn boot_tick(&mut self) {
         self.boot_frame = self.boot_frame.saturating_add(1);
+        if self.boot_frame >= BOOT_AUTO_CONTINUE {
+            self.booting = false;
+        }
     }
 
     /// Leave the boot screen — either skipping the animation or continuing
@@ -165,18 +173,20 @@ mod tests {
     }
 
     #[test]
-    fn boot_completes_after_the_sequence_then_waits() {
+    fn boot_completes_then_auto_continues() {
         let mut s = AppState { booting: true, ..Default::default() };
         assert!(!s.boot_complete());
         for _ in 0..BOOT_SEQUENCE_END {
             s.boot_tick();
         }
         assert!(s.boot_complete());
-        // Ticking never ends the boot on its own — it waits for a key.
-        for _ in 0..50 {
+        // Just-completed: still holds on the "any key to continue" prompt.
+        assert!(s.booting, "holds on the prompt right after the self-check");
+        // ...then auto-continues on its own so a relaunch is never stuck.
+        for _ in 0..(BOOT_AUTO_CONTINUE - BOOT_SEQUENCE_END + 1) {
             s.boot_tick();
         }
-        assert!(s.booting, "boot waits for a keypress");
+        assert!(!s.booting, "auto-continues shortly after completion");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,10 @@ pub struct Config {
     /// Show the contextual hints line in the cockpit interface (F1 toggles).
     #[serde(default = "default_true")]
     pub hints: bool,
+    /// Play the boot self-check animation on startup. Set `false` to drop
+    /// straight into the live cockpit (handy over tmux/ssh or on relaunch).
+    #[serde(default = "default_true")]
+    pub boot: bool,
 }
 
 fn default_true() -> bool {
@@ -87,6 +91,7 @@ mod tests {
             api_key: "x".into(),
             theme: theme.map(String::from),
             hints: true,
+            boot: true,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ fn restore_terminal() -> io::Result<()> {
 async fn main() -> Result<()> {
     let cfg = config::Config::load()?;
     let hints = cfg.hints;
+    let boot = cfg.boot;
     let color_mode = cfg.color_mode();
     let client = ApiClient::new(cfg.base_url, cfg.api_key)?;
 
@@ -64,7 +65,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run(&client, &mut terminal, hints, color_mode).await;
+    let result = run(&client, &mut terminal, hints, boot, color_mode).await;
 
     restore_terminal()?;
 
@@ -75,13 +76,14 @@ async fn run(
     client: &ApiClient,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     hints: bool,
+    boot: bool,
     color_mode: ColorMode,
 ) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<ApiMessage>(32);
     let mut state = AppState {
         hints_visible: hints,
         color_mode,
-        booting: true,
+        booting: boot,
         ..Default::default()
     };
     // Local SQLite store: load the scan history and get a writer handle. On any


### PR DESCRIPTION
## Summary

Addresses a **MED·S** UX finding from the v63.1.0 review: *"L'écran de boot ne continue jamais seul et ne se désactive pas"* (palier 2).

Relaunched under tmux/ssh, the cockpit sat on `ANY KEY TO CONTINUE` with no live data (fuel, alerts, ETA) until a keypress.

## Change

- **Auto-continue**: the boot now drops into the live cockpit on its own ~2 s after the self-check finishes (`BOOT_AUTO_CONTINUE = BOOT_SEQUENCE_END + 22` frames at the 90 ms tick). A keypress still continues immediately.
- **`boot` config key** (default `true`): set `boot = false` to skip the animation entirely and start in the live cockpit. Documented in `config.example.toml`.

## Test

Updated `boot_completes_then_auto_continues`: holds on the prompt right after completion, then auto-continues. `cargo test` 177 passed, `clippy` clean.