### PR TITLE
feat(cockpit): paging + jump on pane lists, and l-open hints

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -5,6 +5,12 @@
 //! that `AppState` carries, so most of it is not read yet.
 #![allow(dead_code)]
 
+/// Rows moved by one PageUp/PageDown in a pane list.
+const PANE_PAGE: usize = 10;
+/// Safety cap on the step-until-stable jump to top/bottom (guards against a
+/// hypothetical wrapping cursor looping forever).
+const PANE_JUMP_CAP: usize = 4096;
+
 /// The nine panes of the Cockpit v2 grid, laid out to match the
 /// `e r t / d f g / c v b` navigation square (identical on AZERTY and
 /// QWERTY). `Probe` is the centre — the `f` home key with the tactile bump.
@@ -212,6 +218,57 @@ impl super::AppState {
         }
     }
 
+    /// The active pane's current cursor position, whichever backing field it
+    /// uses — so paging/jumping can detect when it has reached a bound.
+    fn pane_cursor_pos(&self) -> usize {
+        match self.active_pane {
+            Pane::Inventory => self.inventory_selection,
+            Pane::Scanner => self.scan_history_idx,
+            Pane::Mannies => self.mannies_selection,
+            pane => self.pane_nav[pane.index()].cursor,
+        }
+    }
+
+    /// Move the cursor a page (10 rows) down/up, reusing the per-pane routing.
+    /// Useful on lists that grow over a session (scan history, messages).
+    pub fn pane_cursor_page_down(&mut self) {
+        for _ in 0..PANE_PAGE {
+            self.pane_cursor_down();
+        }
+    }
+
+    pub fn pane_cursor_page_up(&mut self) {
+        for _ in 0..PANE_PAGE {
+            self.pane_cursor_up();
+        }
+    }
+
+    /// Jump to the first/last row: step until the cursor stops moving (capped so
+    /// a wrapping cursor can never loop forever).
+    pub fn pane_cursor_top(&mut self) {
+        let mut last = self.pane_cursor_pos();
+        for _ in 0..PANE_JUMP_CAP {
+            self.pane_cursor_up();
+            let now = self.pane_cursor_pos();
+            if now == last {
+                break;
+            }
+            last = now;
+        }
+    }
+
+    pub fn pane_cursor_bottom(&mut self) {
+        let mut last = self.pane_cursor_pos();
+        for _ in 0..PANE_JUMP_CAP {
+            self.pane_cursor_down();
+            let now = self.pane_cursor_pos();
+            if now == last {
+                break;
+            }
+            last = now;
+        }
+    }
+
     /// Toggle full-screen zoom of the active pane.
     pub fn toggle_zoom(&mut self) {
         self.zoomed = !self.zoomed;
@@ -277,7 +334,7 @@ impl super::AppState {
         if !matches!(pane, Pane::Probe | Pane::Map) {
             parts.push("jk move");
         }
-        if !drilled && matches!(pane, Pane::Missions | Pane::Comms) {
+        if !drilled && matches!(pane, Pane::Missions | Pane::Comms | Pane::Storage | Pane::Mannies) {
             parts.push("l open");
         }
         // Panes that expose actions on Enter (menu or reused overlay). Probe

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1688,3 +1688,16 @@ fn run_command_unknown_sets_toast() {
     assert!(!state.run_command("frobnicate"));
     assert!(state.active_toast().is_some());
 }
+
+#[test]
+fn pane_paging_terminates_on_empty_panes() {
+    // The top/bottom jump steps until the cursor stops moving; on an empty pane
+    // it must terminate immediately (no infinite loop) and leave the cursor put.
+    let mut state = AppState::default();
+    state.active_pane = Pane::Missions;
+    state.pane_cursor_page_down();
+    state.pane_cursor_bottom();
+    state.pane_cursor_top();
+    state.pane_cursor_page_up();
+    assert_eq!(state.pane_nav[Pane::Missions.index()].cursor, 0);
+}

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -53,6 +53,12 @@ pub fn handle_cockpit_event(
         }
         KeyCode::Down | KeyCode::Char('j') => state.pane_cursor_down(),
         KeyCode::Up | KeyCode::Char('k') => state.pane_cursor_up(),
+        // Paging + jump to ends, for lists that grow over a session (scan
+        // history, messages). `g`/`G` are pane keys, so use PageUp/Down/Home/End.
+        KeyCode::PageDown => state.pane_cursor_page_down(),
+        KeyCode::PageUp => state.pane_cursor_page_up(),
+        KeyCode::Home => state.pane_cursor_top(),
+        KeyCode::End => state.pane_cursor_bottom(),
         KeyCode::Right | KeyCode::Char('l') => drill_in(state, client, tx),
         KeyCode::Left | KeyCode::Char('h') => {
             drill_out(state);


### PR DESCRIPTION
## Summary

Addresses a **LOW·S** UX finding from the v63.1.0 review: *"Hints incomplets et navigation single-step sur listes non bornées"* (palier 2).

Two parts:

1. **Paging + jump** — lists that grow over a session (scan history, messages) were single-step (`j`/`k`) only. Added `PageDown`/`PageUp` (10 rows) and `Home`/`End` (jump to first/last), routed through the existing per-pane cursor movement so every pane benefits. `g`/`G` are pane-selector keys (and CapsLock-folded), so paging uses `PageUp`/`Down` + `Home`/`End`. The jump steps until the cursor stops moving, capped at 4096 so a wrapping cursor can't loop forever.

2. **`l open` hint** — the drill hint was only shown for Missions/Comms, but Storage and Mannies drill in too (container contents, manny detail). Now advertised there as well.

## Test

`pane_paging_terminates_on_empty_panes` guards termination/no-panic on empty panes. `cargo test` 177 passed, `clippy` clean.