### PR TITLE
chore(cargo): add crate metadata and MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "neumann-cockpit"
 version = "63.2.0"
 edition = "2021"
 license  = "GPL-3.0-only"
+description = "A keyboard-first terminal cockpit for the Von Neumann probe game."
+repository = "https://github.com/MagiCrazy/neumann-cockpit"
+# Minimum supported Rust: uses u64::is_multiple_of (stable since 1.87).
+rust-version = "1.87"
 
 [dependencies]
 anyhow      = "1"


### PR DESCRIPTION
## Summary

Palier-3 (process) item from the v63.1.0 review: *"Pas de MSRV ni métadonnées de crate"*.

Adds `description`, `repository`, and `rust-version = "1.87"` (the crate uses `u64::is_multiple_of`, stable since 1.87) to `[package]`. The crate had no metadata and CI/`.mise.toml` floated on `stable` with no declared floor.

## Test

`cargo build` clean.