### PR TITLE
chore(renovate): don't automerge ratatui/crossterm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,12 @@
       "matchUpdateTypes": ["patch", "minor"]
     },
     {
+      "description": "ratatui/crossterm are pre-1.0: a minor is breaking by convention, and the TUI has no rendering coverage to catch a behavioural regression. Review these by hand.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["ratatui", "crossterm"],
+      "automerge": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
       "automerge": true,


### PR DESCRIPTION
## Summary

Palier-3 (process) item from the v63.1.0 review: *"Renovate automerge les minors 0.x de ratatui/crossterm"*.

Both crates are pre-1.0, where a minor bump is breaking by convention, and the TUI has no rendering coverage to catch a behavioural regression. A new packageRule excludes `ratatui` and `crossterm` from the cargo automerge (overriding the earlier `automerge: true`), so their updates are reviewed by hand. Everything else keeps automerging patch/minor.

JSON validated with `jq`.