### PR TITLE
ci: drop redundant cargo check, build with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,13 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Check
-        run: cargo check
-
+      # `cargo check` is subsumed by clippy, which type-checks too — dropped.
+      # `--locked` proves CI builds against the committed Cargo.lock.
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --locked -- -D warnings
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
 
       - name: Build release
-        run: cargo build --release
+        run: cargo build --release --locked


### PR DESCRIPTION
## Summary

Palier-3 (process) item from the v63.1.0 review: *"CI : une étape redondante… envisager aussi --locked"*.

- **Drop `cargo check`** — clippy type-checks, so the separate step was pure duplication.
- **Add `--locked`** to clippy/test/build — CI now proves it builds against the committed `Cargo.lock` and fails loudly if the lock drifts from `Cargo.toml`.
- **Keep `build --release`** — it's a cheap release-only safety net; not removed.

Verified `cargo build --locked` passes (lock in sync).