### PR TITLE
ci(release): bundle config.example.toml in each archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,10 @@ jobs:
         run: |
           BIN=neumann-cockpit
           ARCHIVE="${BIN}-${{ matrix.platform }}.tar.gz"
-          tar czf "$ARCHIVE" -C "target/${{ matrix.target }}/release" "$BIN"
+          # Bundle the example config next to the binary to ease first-run setup.
+          tar czf "$ARCHIVE" \
+            -C "target/${{ matrix.target }}/release" "$BIN" \
+            -C "$GITHUB_WORKSPACE" config.example.toml
           if command -v sha256sum >/dev/null; then
             sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
           else
@@ -67,7 +70,7 @@ jobs:
         run: |
           $BIN = "neumann-cockpit"
           $ARCHIVE = "${BIN}-${{ matrix.platform }}.zip"
-          Compress-Archive -Path "target\${{ matrix.target }}\release\${BIN}.exe" -DestinationPath $ARCHIVE
+          Compress-Archive -Path "target\${{ matrix.target }}\release\${BIN}.exe", "config.example.toml" -DestinationPath $ARCHIVE
           $hash = (Get-FileHash -Algorithm SHA256 $ARCHIVE).Hash.ToLower()
           "$hash  $ARCHIVE" | Out-File -FilePath "${ARCHIVE}.sha256" -Encoding ascii
           "ARCHIVE=${ARCHIVE}" | Out-File -FilePath $env:GITHUB_ENV -Append


### PR DESCRIPTION
## Summary

Ship `config.example.toml` next to the binary in every release archive, so binary users have the config template on hand for first-run setup without cloning the repo.

- **Unix**: `tar` with a second `-C "$GITHUB_WORKSPACE"` to add the example config alongside the binary.
- **Windows**: `Compress-Archive` with both paths.

Follows #150 (checksums) — the archives now contain the binary + example config, each with its `.sha256`.

## Note

Can't exercise the release workflow from a PR; verified by inspection.