### PR TITLE
refactor(app): remove dead Panel/focused machinery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Single `tokio::select!` loop over three sources:
 
 The timer deadline is set to `movement.arrival_at` (ISO 8601) converted to a `tokio::time::Instant`. When no movement is in progress the deadline is 24 h away — no polling.
 
-A fourth `select!` branch is a **short-lived ~90 ms boot tick**, guarded by `state.booting`: it only runs during the startup boot sequence (see UI › Boot), then stops. Steady state stays fully event-driven — no tick.
+Two more `select!` branches are timers: a **short-lived ~90 ms boot tick** (guarded by `state.booting`, runs only during the startup boot sequence — see UI › Boot — then stops) and a **steady-state 1 s `ui_tick`** that redraws so time-derived values (progress bars, ETAs, sync age) advance and fires the periodic auto-refresh when one is due.
 
 `fetch_all()` spawns **seven** independent `tokio::spawn` tasks: probe, mannies, sector, visited sectors, alerts, damage warnings, and missions. All but probe are non-fatal.
 
@@ -56,7 +56,7 @@ All other API calls (move, repair, mine, craft, storage container CRUD, storage 
 `AppState` is the single source of truth passed to the renderer. Split by domain: `mod.rs` (struct `AppState`, core impl — updates, toasts, refresh deadline — and `pub use` re-exports keeping `crate::app::*` paths stable), `grid.rs` (`Pane` — the 9 cockpit panes — + `PaneNav` per-pane cursor/drill state + grid navigation helpers), `mode.rs` (`InputMode`, `ContextMenu`, `MenuAction`, `MenuItem`), `boot.rs` (startup self-check schedule), `color.rs` (`ColorMode`), `inputs.rs` (all wizard input enums + constants), `scan.rs`, `travel.rs`, `inventory.rs`, `mannies.rs`, `containers.rs` (storage-container/move helpers), `map.rs`, `waypoints.rs`, `message.rs` (`ApiMessage`), `tests.rs` (unit tests). Key design choices:
 
 - **Cockpit v2 state**: `active_pane: Pane`, `zoomed: bool`, `mode: InputMode` (`Normal` / `Menu` / `Command`), `pane_nav: [PaneNav; 9]` (cursor + drill-in stack per pane), `hints_visible`, `color_mode`, and `booting` / `boot_frame` for the startup sequence. `build_context_menu()` produces the `Enter` menu for the active pane; menu items map to `MenuAction`s that launch the existing wizards.
-- The legacy `Panel` enum + `focused` field remain, still used by the four reused panel renderers to mark the active pane; the classic single-key action handlers are gone.
+- The four reused panel renderers (Probe/Inventory/Scanner/Mannies) take an `active: bool` to mark the active pane; the old `Panel` enum + `focused` state and the classic single-key action handlers are gone.
 
 - Each interactive action (travel, repair, mine, craft, jettison, salvage, recall, rename, deploy, inspect, recover, detach, atomic printer craft, object actions, waypoints, alerts, storage containers + rename + routing rules, storage moves, drop cargo) has its own input state enum (`TravelInput`, `RepairInput`, `ObjectActionInput`, `AlertsInput`, `ContainersInput`, `ContainerRulesInput`, `StorageMoveInput`, etc.) with variants for each wizard step. All start as `Inactive`.
 - `update_probe()` extracts `movement_arrival` from the response and stores it separately so the event loop can compute the next deadline without re-reading the full probe struct.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35,14 +35,6 @@ use crate::api::types::{
 use chrono::{DateTime, Local, Utc};
 use tokio::time::Instant;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Panel {
-    Probe,
-    Inventory,
-    Mannies,
-    Scanner,
-}
-
 #[derive(Default)]
 pub struct AppState {
     pub probe: Option<Probe>,
@@ -59,7 +51,6 @@ pub struct AppState {
     pub error: Option<String>,
     pub loading: bool,
     pub quit: bool,
-    pub focused: Option<Panel>,
     pub mannies_selection: usize,
     pub inventory_selection: usize,
     pub scan_history: Vec<SectorObservation>,
@@ -265,38 +256,6 @@ impl AppState {
 
     pub fn set_quit(&mut self) {
         self.quit = true;
-    }
-
-    /// Toggle focus on a panel; pressing the same shortcut again unfocuses.
-    pub fn toggle_focus(&mut self, panel: Panel) {
-        if self.focused == Some(panel) {
-            self.focused = None;
-        } else {
-            self.focused = Some(panel);
-        }
-    }
-
-    /// Visual order for Tab cycling: top-left → top-right → bottom-left → bottom-right.
-    const PANEL_ORDER: [Panel; 4] = [Panel::Probe, Panel::Inventory, Panel::Scanner, Panel::Mannies];
-
-    pub fn focus_next_panel(&mut self) {
-        self.focused = Some(match self.focused {
-            None => Self::PANEL_ORDER[0],
-            Some(p) => {
-                let i = Self::PANEL_ORDER.iter().position(|&x| x == p).unwrap_or(0);
-                Self::PANEL_ORDER[(i + 1) % Self::PANEL_ORDER.len()]
-            }
-        });
-    }
-
-    pub fn focus_prev_panel(&mut self) {
-        self.focused = Some(match self.focused {
-            None => Self::PANEL_ORDER[Self::PANEL_ORDER.len() - 1],
-            Some(p) => {
-                let i = Self::PANEL_ORDER.iter().position(|&x| x == p).unwrap_or(0);
-                Self::PANEL_ORDER[(i + Self::PANEL_ORDER.len() - 1) % Self::PANEL_ORDER.len()]
-            }
-        });
     }
 
     pub fn probe_sector_coords(&self) -> Option<(i32, i32, i32)> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -468,55 +468,6 @@ fn probe_at(x: f64, y: f64, z: f64) -> Probe {
     make_probe(7.0, x, y, z)
 }
 
-// ── toggle_focus ──────────────────────────────────────────────────────────
-
-#[test]
-fn toggle_focus_sets_panel() {
-    let mut state = AppState::default();
-    state.toggle_focus(Panel::Probe);
-    assert_eq!(state.focused, Some(Panel::Probe));
-}
-
-#[test]
-fn toggle_focus_same_panel_clears() {
-    let mut state = AppState::default();
-    state.toggle_focus(Panel::Scanner);
-    state.toggle_focus(Panel::Scanner);
-    assert_eq!(state.focused, None);
-}
-
-#[test]
-fn toggle_focus_different_panel_switches() {
-    let mut state = AppState::default();
-    state.toggle_focus(Panel::Probe);
-    state.toggle_focus(Panel::Mannies);
-    assert_eq!(state.focused, Some(Panel::Mannies));
-}
-
-#[test]
-fn focus_next_panel_cycles_in_visual_order() {
-    let mut state = AppState::default();
-    state.focus_next_panel();
-    assert_eq!(state.focused, Some(Panel::Probe));
-    state.focus_next_panel();
-    assert_eq!(state.focused, Some(Panel::Inventory));
-    state.focus_next_panel();
-    assert_eq!(state.focused, Some(Panel::Scanner));
-    state.focus_next_panel();
-    assert_eq!(state.focused, Some(Panel::Mannies));
-    state.focus_next_panel();
-    assert_eq!(state.focused, Some(Panel::Probe));
-}
-
-#[test]
-fn focus_prev_panel_cycles_backwards() {
-    let mut state = AppState::default();
-    state.focus_prev_panel();
-    assert_eq!(state.focused, Some(Panel::Mannies));
-    state.focus_prev_panel();
-    assert_eq!(state.focused, Some(Panel::Scanner));
-}
-
 // ── manny_next / manny_prev ───────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Palier-4 queue item from the v63.1.0 review: *"Machinerie legacy Panel/focused morte mais invisible au lint"*.

`Panel`, `AppState::focused`, `toggle_focus`, `focus_next_panel`/`focus_prev_panel` and `PANEL_ORDER` were unreferenced anywhere outside their own tests — leftovers from the pre-cockpit-v2 UI, kept alive only because the enum was `pub` (so `dead_code` never fired). Removed them and their tests (−92 lines).

The panel renderers' `focused`/`active` **bool** parameter is unrelated (it marks the active pane) and is untouched.

Also fixes two stale `CLAUDE.md` claims the review flagged:
- steady state *does* tick — the 1 s `ui_tick` (redraw + periodic refresh) was undocumented and wrongly called "no tick";
- `Panel`/`focused` are described as gone, not "still used".

## Test

`cargo build` + `clippy` clean, `cargo test` 177 passed.