### PR TITLE
refactor(input): dedupe pick-list navigation with list_move

### DIFF
--- a/src/input/geometry.rs
+++ b/src/input/geometry.rs
@@ -43,6 +43,19 @@ pub(super) fn list_nav(code: KeyCode, sel: usize, count: usize) -> Option<usize>
         _ => None,
     }
 }
+
+/// Apply a pick-list nav key to `selection` in place. Returns `true` when the
+/// key was a navigation key (`j`/`k`/arrows) — so a handler can consume it and
+/// stop before its Esc/Enter arms, without re-matching the state to write back.
+pub(super) fn list_move(code: KeyCode, selection: &mut usize, count: usize) -> bool {
+    match list_nav(code, *selection, count) {
+        Some(n) => {
+            *selection = n;
+            true
+        }
+        None => false,
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -325,4 +325,23 @@ mod tests {
         press(&mut state, KeyCode::Esc);
         assert!(matches!(state.alerts_input, AlertsInput::Inactive), "Esc closes the alerts overlay");
     }
+
+    #[tokio::test]
+    async fn pick_list_j_moves_selection_and_esc_closes() {
+        use crate::app::SalvageInput;
+        let mut state = AppState::default();
+        state.salvage = SalvageInput::PickTarget {
+            manny_id: "m1".into(),
+            manny_name: "M".into(),
+            candidates: vec![("a".into(), "A".into()), ("b".into(), "B".into())],
+            selection: 0,
+        };
+        press(&mut state, KeyCode::Char('j'));
+        match &state.salvage {
+            SalvageInput::PickTarget { selection, .. } => assert_eq!(*selection, 1, "j moves the cursor"),
+            _ => panic!("should still be picking"),
+        }
+        press(&mut state, KeyCode::Esc);
+        assert!(matches!(state.salvage, SalvageInput::Inactive), "Esc closes the picker");
+    }
 }

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -12,52 +12,44 @@ use crate::app::{
     InspectInput, MindSnapshotInput, RecallInput, RefuelInput,
     RecoverInput, RenameMannyInput, SalvageInput, DETACH_MODES,
 };
-use super::geometry::list_nav;
+use super::geometry::list_move;
 pub(super) fn handle_salvage_event(
     code: KeyCode,
     state: &mut AppState,
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
+    if let SalvageInput::PickTarget { selection, candidates, .. } = &mut state.salvage {
+        if list_move(code, selection, candidates.len()) {
+            return;
+        }
+    }
     match &state.salvage {
-        SalvageInput::PickTarget { selection, candidates, .. } => {
-            let sel = *selection;
-            let count = candidates.len();
-            match code {
-                KeyCode::Esc => state.salvage = SalvageInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let SalvageInput::PickTarget { ref mut selection, .. } = state.salvage {
-                            *selection = new_sel;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (manny_id, manny_name, object_id, object_name) = {
-                        let SalvageInput::PickTarget { ref manny_id, ref manny_name, ref candidates, selection } = state.salvage else { return };
-                        let (id, name) = candidates[selection].clone();
-                        (manny_id.clone(), manny_name.clone(), id, name)
-                    };
-                    state.salvage = SalvageInput::Confirm {
-                        manny_id, manny_name, object_id, object_name, error: None,
-                    };
-                }
-                _ => {}
+        SalvageInput::PickTarget { .. } => match code {
+            KeyCode::Esc => state.salvage = SalvageInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, manny_name, object_id, object_name) = {
+                    let SalvageInput::PickTarget { ref manny_id, ref manny_name, ref candidates, selection } = state.salvage else { return };
+                    let (id, name) = candidates[selection].clone();
+                    (manny_id.clone(), manny_name.clone(), id, name)
+                };
+                state.salvage = SalvageInput::Confirm {
+                    manny_id, manny_name, object_id, object_name, error: None,
+                };
             }
-        }
-        SalvageInput::Confirm { .. } => {
-            match code {
-                KeyCode::Esc => state.salvage = SalvageInput::Inactive,
-                KeyCode::Enter => {
-                    let (manny_id, object_id) = {
-                        let SalvageInput::Confirm { ref manny_id, ref object_id, .. } = state.salvage else { return };
-                        (manny_id.clone(), object_id.clone())
-                    };
-                    fetch_salvage(manny_id, object_id, client.clone(), tx.clone());
-                }
-                _ => {}
+            _ => {}
+        },
+        SalvageInput::Confirm { .. } => match code {
+            KeyCode::Esc => state.salvage = SalvageInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, object_id) = {
+                    let SalvageInput::Confirm { ref manny_id, ref object_id, .. } = state.salvage else { return };
+                    (manny_id.clone(), object_id.clone())
+                };
+                fetch_salvage(manny_id, object_id, client.clone(), tx.clone());
             }
-        }
+            _ => {}
+        },
         SalvageInput::Inactive => {}
     }
 }
@@ -121,67 +113,56 @@ pub(super) fn handle_drop_container_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.drop_container {
+    match &mut state.drop_container {
         DropStorageContainerInput::PickContainer { selection, containers, .. } => {
-            let (sel, count) = (*selection, containers.len());
-            match code {
-                KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(ns) = list_nav(code, sel, count) {
-                        if let DropStorageContainerInput::PickContainer { selection, .. } =
-                            &mut state.drop_container
-                        {
-                            *selection = ns;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (manny_id, manny_name, container_id, container_name) = {
-                        let DropStorageContainerInput::PickContainer {
-                            manny_id, manny_name, containers, selection,
-                        } = &state.drop_container else { return };
-                        let (id, name) = containers[*selection].clone();
-                        (manny_id.clone(), manny_name.clone(), id, name)
-                    };
-                    let planets = state.collect_planet_candidates();
-                    if planets.is_empty() {
-                        state.drop_container = DropStorageContainerInput::Inactive;
-                        state.error = Some("no planet in current sector — scan first".into());
-                        return;
-                    }
-                    state.drop_container = DropStorageContainerInput::PickPlanet {
-                        manny_id, manny_name, container_id, container_name,
-                        planets, selection: 0, error: None,
-                    };
-                }
-                _ => {}
+            if list_move(code, selection, containers.len()) {
+                return;
             }
         }
         DropStorageContainerInput::PickPlanet { selection, planets, .. } => {
-            let (sel, count) = (*selection, planets.len());
-            match code {
-                KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(ns) = list_nav(code, sel, count) {
-                        if let DropStorageContainerInput::PickPlanet { selection, .. } =
-                            &mut state.drop_container
-                        {
-                            *selection = ns;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (manny_id, container_id, planet_id) = {
-                        let DropStorageContainerInput::PickPlanet {
-                            manny_id, container_id, planets, selection, ..
-                        } = &state.drop_container else { return };
-                        (manny_id.clone(), container_id.clone(), planets[*selection].0.clone())
-                    };
-                    fetch_drop_storage_container(manny_id, container_id, planet_id, client.clone(), tx.clone());
-                }
-                _ => {}
+            if list_move(code, selection, planets.len()) {
+                return;
             }
         }
+        DropStorageContainerInput::Inactive => {}
+    }
+    match &state.drop_container {
+        DropStorageContainerInput::PickContainer { .. } => match code {
+            KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, manny_name, container_id, container_name) = {
+                    let DropStorageContainerInput::PickContainer {
+                        manny_id, manny_name, containers, selection,
+                    } = &state.drop_container else { return };
+                    let (id, name) = containers[*selection].clone();
+                    (manny_id.clone(), manny_name.clone(), id, name)
+                };
+                let planets = state.collect_planet_candidates();
+                if planets.is_empty() {
+                    state.drop_container = DropStorageContainerInput::Inactive;
+                    state.error = Some("no planet in current sector — scan first".into());
+                    return;
+                }
+                state.drop_container = DropStorageContainerInput::PickPlanet {
+                    manny_id, manny_name, container_id, container_name,
+                    planets, selection: 0, error: None,
+                };
+            }
+            _ => {}
+        },
+        DropStorageContainerInput::PickPlanet { .. } => match code {
+            KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, container_id, planet_id) = {
+                    let DropStorageContainerInput::PickPlanet {
+                        manny_id, container_id, planets, selection, ..
+                    } = &state.drop_container else { return };
+                    (manny_id.clone(), container_id.clone(), planets[*selection].0.clone())
+                };
+                fetch_drop_storage_container(manny_id, container_id, planet_id, client.clone(), tx.clone());
+            }
+            _ => {}
+        },
         DropStorageContainerInput::Inactive => {}
     }
 }
@@ -211,83 +192,68 @@ pub(super) fn handle_deploy_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.deploy {
+    match &mut state.deploy {
         DeployInput::PickManny { selection, mannies } => {
-            let sel = *selection;
-            let count = mannies.len();
-            match code {
-                KeyCode::Esc => state.deploy = DeployInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let DeployInput::PickManny { ref mut selection, .. } = state.deploy {
-                            *selection = new_sel;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let manny_id = {
-                        let DeployInput::PickManny { ref mannies, selection } = state.deploy else { return };
-                        mannies[selection].0.clone()
-                    };
-                    let candidates = state.collect_deploy_candidates();
-                    if candidates.is_empty() {
-                        state.deploy = DeployInput::Inactive;
-                        state.error = Some("no targets in current sector".into());
-                    } else if candidates.len() == 1 {
-                        let (object_id, object_name) = candidates.into_iter().next().unwrap();
-                        state.deploy = DeployInput::EnterName { manny_id, object_id, object_name, name_buf: String::new(), error: None };
-                    } else {
-                        state.deploy = DeployInput::PickObject { manny_id, candidates, selection: 0 };
-                    }
-                }
-                _ => {}
+            if list_move(code, selection, mannies.len()) {
+                return;
             }
         }
         DeployInput::PickObject { selection, candidates, .. } => {
-            let sel = *selection;
-            let count = candidates.len();
-            match code {
-                KeyCode::Esc => state.deploy = DeployInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let DeployInput::PickObject { ref mut selection, .. } = state.deploy {
-                            *selection = new_sel;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (manny_id, object_id, object_name) = {
-                        let DeployInput::PickObject { ref manny_id, ref candidates, selection } = state.deploy else { return };
-                        let (id, name) = candidates[selection].clone();
-                        (manny_id.clone(), id, name)
-                    };
-                    state.deploy = DeployInput::EnterName {
-                        manny_id,
-                        object_id,
-                        object_name,
-                        name_buf: String::new(),
-                        error: None,
-                    };
-                }
-                _ => {}
+            if list_move(code, selection, candidates.len()) {
+                return;
             }
         }
-        DeployInput::EnterName { .. } => {
-            match code {
-                KeyCode::Esc => state.deploy = DeployInput::Inactive,
-                KeyCode::Backspace => state.deploy_backspace(),
-                KeyCode::Char(c) => state.deploy_type_char(c),
-                KeyCode::Enter => {
-                    let (manny_id, object_id, name) = {
-                        let DeployInput::EnterName { ref manny_id, ref object_id, ref name_buf, .. } = state.deploy else { return };
-                        if name_buf.is_empty() { return }
-                        (manny_id.clone(), object_id.clone(), name_buf.clone())
-                    };
-                    fetch_deploy(manny_id, object_id, name, client.clone(), tx.clone());
+        _ => {}
+    }
+    match &state.deploy {
+        DeployInput::PickManny { .. } => match code {
+            KeyCode::Esc => state.deploy = DeployInput::Inactive,
+            KeyCode::Enter => {
+                let manny_id = {
+                    let DeployInput::PickManny { ref mannies, selection } = state.deploy else { return };
+                    mannies[selection].0.clone()
+                };
+                let candidates = state.collect_deploy_candidates();
+                if candidates.is_empty() {
+                    state.deploy = DeployInput::Inactive;
+                    state.error = Some("no targets in current sector".into());
+                } else if candidates.len() == 1 {
+                    let (object_id, object_name) = candidates.into_iter().next().unwrap();
+                    state.deploy = DeployInput::EnterName { manny_id, object_id, object_name, name_buf: String::new(), error: None };
+                } else {
+                    state.deploy = DeployInput::PickObject { manny_id, candidates, selection: 0 };
                 }
-                _ => {}
             }
-        }
+            _ => {}
+        },
+        DeployInput::PickObject { .. } => match code {
+            KeyCode::Esc => state.deploy = DeployInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, object_id, object_name) = {
+                    let DeployInput::PickObject { ref manny_id, ref candidates, selection } = state.deploy else { return };
+                    let (id, name) = candidates[selection].clone();
+                    (manny_id.clone(), id, name)
+                };
+                state.deploy = DeployInput::EnterName {
+                    manny_id, object_id, object_name, name_buf: String::new(), error: None,
+                };
+            }
+            _ => {}
+        },
+        DeployInput::EnterName { .. } => match code {
+            KeyCode::Esc => state.deploy = DeployInput::Inactive,
+            KeyCode::Backspace => state.deploy_backspace(),
+            KeyCode::Char(c) => state.deploy_type_char(c),
+            KeyCode::Enter => {
+                let (manny_id, object_id, name) = {
+                    let DeployInput::EnterName { ref manny_id, ref object_id, ref name_buf, .. } = state.deploy else { return };
+                    if name_buf.is_empty() { return }
+                    (manny_id.clone(), object_id.clone(), name_buf.clone())
+                };
+                fetch_deploy(manny_id, object_id, name, client.clone(), tx.clone());
+            }
+            _ => {}
+        },
         DeployInput::Inactive => {}
     }
 }
@@ -320,18 +286,13 @@ pub(super) fn handle_inspect_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let &InspectInput::PickAsteroid { selection, ref candidates, .. } = &state.inspect else { return };
-    let sel = selection;
-    let count = candidates.len();
+    if let InspectInput::PickAsteroid { selection, candidates, .. } = &mut state.inspect {
+        if list_move(code, selection, candidates.len()) {
+            return;
+        }
+    }
     match code {
         KeyCode::Esc => state.inspect = InspectInput::Inactive,
-        KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-            if let Some(new_sel) = list_nav(code, sel, count) {
-                if let InspectInput::PickAsteroid { ref mut selection, .. } = state.inspect {
-                    *selection = new_sel;
-                }
-            }
-        }
         KeyCode::Enter => {
             let (manny_id, object_id) = {
                 let InspectInput::PickAsteroid { ref manny_id, ref candidates, selection, .. } = state.inspect else { return };
@@ -349,18 +310,13 @@ pub(super) fn handle_recover_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let &RecoverInput::PickContainer { selection, ref candidates, .. } = &state.recover else { return };
-    let sel = selection;
-    let count = candidates.len();
+    if let RecoverInput::PickContainer { selection, candidates, .. } = &mut state.recover {
+        if list_move(code, selection, candidates.len()) {
+            return;
+        }
+    }
     match code {
         KeyCode::Esc => state.recover = RecoverInput::Inactive,
-        KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-            if let Some(new_sel) = list_nav(code, sel, count) {
-                if let RecoverInput::PickContainer { ref mut selection, .. } = state.recover {
-                    *selection = new_sel;
-                }
-            }
-        }
         KeyCode::Enter => {
             let (manny_id, object_id) = {
                 let RecoverInput::PickContainer { ref manny_id, ref candidates, selection, .. } = state.recover else { return };
@@ -378,84 +334,69 @@ pub(super) fn handle_detach_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.detach {
+    match &mut state.detach {
         DetachInput::PickContainer { selection, containers, .. } => {
-            let sel = *selection;
-            let count = containers.len();
-            match code {
-                KeyCode::Esc => state.detach = DetachInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let DetachInput::PickContainer { ref mut selection, .. } = state.detach {
-                            *selection = new_sel;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (manny_id, manny_name, container_id, container_name) = {
-                        let DetachInput::PickContainer { ref manny_id, ref manny_name, ref containers, selection } = state.detach else { return };
-                        let (id, name) = containers[selection].clone();
-                        (manny_id.clone(), manny_name.clone(), id, name)
-                    };
-                    state.detach = DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection: 0, error: None };
-                }
-                _ => {}
+            if list_move(code, selection, containers.len()) {
+                return;
             }
         }
         DetachInput::PickMode { selection, .. } => {
-            let sel = *selection;
-            let count = DETACH_MODES.len();
-            match code {
-                KeyCode::Esc => state.detach = DetachInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let DetachInput::PickMode { ref mut selection, .. } = state.detach {
-                            *selection = new_sel;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (manny_id, manny_name, container_id, container_name, sel) = {
-                        let DetachInput::PickMode { ref manny_id, ref manny_name, ref container_id, ref container_name, selection, .. } = state.detach else { return };
-                        (manny_id.clone(), manny_name.clone(), container_id.clone(), container_name.clone(), selection)
-                    };
-                    let mode = DETACH_MODES[sel].0;
-                    if mode == "hidden_on_asteroid" {
-                        let asteroids = state.collect_asteroid_candidates();
-                        if asteroids.is_empty() {
-                            state.set_detach_error("no asteroids in current sector — scan first".into());
-                        } else {
-                            state.detach = DetachInput::PickAsteroid { manny_id, manny_name, container_id, container_name, asteroids, selection: 0, error: None };
-                        }
-                    } else {
-                        fetch_detach(manny_id, container_id, "drifting".into(), None, client.clone(), tx.clone());
-                    }
-                }
-                _ => {}
+            if list_move(code, selection, DETACH_MODES.len()) {
+                return;
             }
         }
         DetachInput::PickAsteroid { selection, asteroids, .. } => {
-            let sel = *selection;
-            let count = asteroids.len();
-            match code {
-                KeyCode::Esc => state.detach = DetachInput::Inactive,
-                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                    if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let DetachInput::PickAsteroid { ref mut selection, .. } = state.detach {
-                            *selection = new_sel;
-                        }
-                    }
-                }
-                KeyCode::Enter => {
-                    let (manny_id, container_id, object_id) = {
-                        let DetachInput::PickAsteroid { ref manny_id, ref container_id, ref asteroids, selection, .. } = state.detach else { return };
-                        (manny_id.clone(), container_id.clone(), asteroids[selection].0.clone())
-                    };
-                    fetch_detach(manny_id, container_id, "hidden_on_asteroid".into(), Some(object_id), client.clone(), tx.clone());
-                }
-                _ => {}
+            if list_move(code, selection, asteroids.len()) {
+                return;
             }
         }
+        DetachInput::Inactive => {}
+    }
+    match &state.detach {
+        DetachInput::PickContainer { .. } => match code {
+            KeyCode::Esc => state.detach = DetachInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, manny_name, container_id, container_name) = {
+                    let DetachInput::PickContainer { ref manny_id, ref manny_name, ref containers, selection } = state.detach else { return };
+                    let (id, name) = containers[selection].clone();
+                    (manny_id.clone(), manny_name.clone(), id, name)
+                };
+                state.detach = DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection: 0, error: None };
+            }
+            _ => {}
+        },
+        DetachInput::PickMode { .. } => match code {
+            KeyCode::Esc => state.detach = DetachInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, manny_name, container_id, container_name, sel) = {
+                    let DetachInput::PickMode { ref manny_id, ref manny_name, ref container_id, ref container_name, selection, .. } = state.detach else { return };
+                    (manny_id.clone(), manny_name.clone(), container_id.clone(), container_name.clone(), selection)
+                };
+                let mode = DETACH_MODES[sel].0;
+                if mode == "hidden_on_asteroid" {
+                    let asteroids = state.collect_asteroid_candidates();
+                    if asteroids.is_empty() {
+                        state.set_detach_error("no asteroids in current sector — scan first".into());
+                    } else {
+                        state.detach = DetachInput::PickAsteroid { manny_id, manny_name, container_id, container_name, asteroids, selection: 0, error: None };
+                    }
+                } else {
+                    fetch_detach(manny_id, container_id, "drifting".into(), None, client.clone(), tx.clone());
+                }
+            }
+            _ => {}
+        },
+        DetachInput::PickAsteroid { .. } => match code {
+            KeyCode::Esc => state.detach = DetachInput::Inactive,
+            KeyCode::Enter => {
+                let (manny_id, container_id, object_id) = {
+                    let DetachInput::PickAsteroid { ref manny_id, ref container_id, ref asteroids, selection, .. } = state.detach else { return };
+                    (manny_id.clone(), container_id.clone(), asteroids[selection].0.clone())
+                };
+                fetch_detach(manny_id, container_id, "hidden_on_asteroid".into(), Some(object_id), client.clone(), tx.clone());
+            }
+            _ => {}
+        },
         DetachInput::Inactive => {}
     }
 }


### PR DESCRIPTION
## Summary

Palier-4 queue item from the v63.1.0 review: *"Handlers de pick-list copiés-collés … le rendu a déjà son helper partagé (render_pick_list) ; l'input mérite son symétrique."*

The six pick-list handlers (`salvage`, `deploy`, `inspect`, `recover`, `detach`, `drop_container`) each repeated the same Esc/j/k/Enter machine, with a *destructure → `list_nav` → re-match* dance just to write the moved `selection` back into the enum variant.

## Change

- New `geometry::list_move(code, &mut selection, count) -> bool` — the input-side symmetric of `render_pick_list`: applies a nav key in place, returns whether it consumed one.
- Each handler now does a **tight `&mut` nav pass at the top** (per pick-list variant) that consumes `j`/`k`/arrows and returns; the `Esc`/`Enter` arms then read immutably. No more double-destructure.

Behavior-preserving (bounded to `pickers.rs`). Net −27 lines and much less boilerplate.

## Test

New characterization test (`j` moves the selection, `Esc` closes) via the real `handle_event`. `cargo test` 178 passed, `clippy` clean.