### PR TITLE
feat(boot): in-TUI preflight with first-run API-key onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,21 @@ hints    = true           # show the contextual hints line (optional)
 
 Unknown keys are ignored, so legacy configs (`ui`, `phosphor`, `animations`, `theme = "retro"`) still load.
 
-Copy `config.example.toml` to that path and fill in the API key (generated once via the web UI).
+Copy `config.example.toml` to that path and fill in the API key (generated once via the web UI). **First run needs no manual file**: if the config is missing or has no real key, the boot preflight prompts for an API key and writes `config.toml` for you (see Boot preflight).
 
-Scan history is persisted across runs to `~/.config/neumann-cockpit/scan_history.json`.
+Scan history is persisted across runs in a local SQLite database (`cockpit.db`, under the XDG state dir); the legacy `scan_history.json` is migrated into it once, then removed (`src/store.rs`, issue #134).
 
 ## Architecture
+
+### Boot preflight (`src/preflight.rs` + `src/ui/preflight.rs`)
+
+`main()` enters the alternate screen **before** any fallible startup, then runs `preflight::run()`, which draws the boot grid with the real check-list **inside the centre Probe pane** (the eight surrounding subsystems stay dark until the link comes up) and returns a `preflight::Ready` (config, `ApiClient`, DB connection, scan history, api_version, link_ok) or `Outcome::Quit`. This is the Windows first-run fix: `Config::load()` used to error out before the terminal existed, so a double-clicked binary flashed a console and vanished — now every failure has an in-TUI outcome. Steps:
+
+- **CONFIG** — `Config::load_status()` returns `Ready` / `NeedsKey` / `Invalid` (a lenient parse so a keyless file doesn't error). On `NeedsKey`/`Invalid`, an onboarding prompt in the Probe pane collects an API key and `config::write_config()` writes `config.toml` (base URL defaulted to `DEFAULT_BASE_URL`); Esc/Ctrl-C quits cleanly.
+- **ARCHIVE** — `store::open` + `migrate_legacy_json` (reports `MigrationOutcome`: imported N / already migrated / none) + `load_observations`.
+- **REMOTE LINK** — `get_api_version()` under an 8 s timeout, retried interactively: a bad key or outage shows in the Probe pane with actions — `[R]` retry · `[K]` re-enter key (re-runs onboarding) · `[Enter]` continue offline. Continuing enters **degraded mode** (an error toast; `F5` retries), per the API-KO decision.
+
+Once the link is up (or the pilot continues offline), it hands off to `run()`, which builds `AppState`, spawns the persistence writer from the preflight's connection, and plays the cosmetic boot animation that lights the eight subsystems centre-out (see UI › Boot).
 
 ### Event loop (`src/main.rs`)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,14 @@ use directories::ProjectDirs;
 use serde::Deserialize;
 use std::path::PathBuf;
 
+/// The production probe server, pre-filled when onboarding writes a fresh config
+/// so the pilot only ever has to paste an API key.
+pub const DEFAULT_BASE_URL: &str = "https://neumann-probe.net";
+
+/// The placeholder key shipped in `config.example.toml`; treated as "no key yet"
+/// so a copied-but-unedited example still triggers onboarding.
+const PLACEHOLDER_KEY: &str = "vng_your_api_key_here";
+
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub base_url: String,
@@ -37,19 +45,79 @@ impl Config {
     }
 }
 
+/// A lenient view of `config.toml` where every key is optional, so a file that
+/// exists but lacks an API key parses cleanly (and drives onboarding) instead of
+/// erroring out. Unknown keys are ignored, matching the tolerant load contract.
+#[derive(Debug, Default, Deserialize)]
+struct RawConfig {
+    base_url: Option<String>,
+    api_key: Option<String>,
+    theme: Option<String>,
+    hints: Option<bool>,
+    boot: Option<bool>,
+}
+
+/// The outcome of inspecting the on-disk config at boot.
+pub enum ConfigStatus {
+    /// A usable config with a real API key.
+    Ready(Config),
+    /// No file, or the file has no usable key yet — onboarding should collect one.
+    NeedsKey,
+    /// The file exists but is not valid TOML — surfaced so the pilot can fix it.
+    Invalid(String),
+}
+
 impl Config {
-    pub fn load() -> Result<Self> {
-        let path = config_path();
-        let content = std::fs::read_to_string(&path).with_context(|| {
-            format!(
-                "Config not found: {}\n\nCreate it:\n  mkdir -p {}\n  cp config.example.toml {}",
-                path.display(),
-                path.parent().unwrap_or(&path).display(),
-                path.display()
-            )
-        })?;
-        toml::from_str(&content).context("Invalid config.toml")
+    /// Inspect `config.toml` without failing on a missing/keyless file. This is
+    /// the boot entry point: it never returns an error the caller must print to
+    /// a vanishing console — every case maps to an in-TUI outcome.
+    pub fn load_status() -> ConfigStatus {
+        load_status_at(&config_path())
     }
+}
+
+/// Path-injectable core of `Config::load_status`, so tests never touch the real
+/// user config.
+fn load_status_at(path: &std::path::Path) -> ConfigStatus {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return ConfigStatus::NeedsKey,
+    };
+    let raw: RawConfig = match toml::from_str(&content) {
+        Ok(r) => r,
+        Err(e) => return ConfigStatus::Invalid(e.to_string()),
+    };
+    let key = raw.api_key.unwrap_or_default();
+    if key.trim().is_empty() || key == PLACEHOLDER_KEY {
+        return ConfigStatus::NeedsKey;
+    }
+    ConfigStatus::Ready(Config {
+        base_url: raw.base_url.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+        api_key: key,
+        theme: raw.theme,
+        hints: raw.hints.unwrap_or(true),
+        boot: raw.boot.unwrap_or(true),
+    })
+}
+
+/// Write a minimal `config.toml` (base URL + API key), creating the config
+/// directory if needed. Returns the path written, for the boot log.
+pub fn write_config(base_url: &str, api_key: &str) -> Result<PathBuf> {
+    write_config_at(&config_path(), base_url, api_key)?;
+    Ok(config_path())
+}
+
+/// Path-injectable core of `write_config`.
+fn write_config_at(path: &std::path::Path, base_url: &str, api_key: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating config dir {}", parent.display()))?;
+    }
+    // `{:?}` emits a double-quoted, backslash-escaped string — valid TOML basic
+    // string syntax, and API keys / URLs never contain anything exotic.
+    let body = format!("base_url = {base_url:?}\napi_key  = {api_key:?}\n");
+    std::fs::write(path, body).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
 }
 
 pub fn config_path() -> PathBuf {
@@ -115,5 +183,52 @@ mod tests {
         let m = m.cycle().cycle();
         assert_eq!(m, ColorMode::Modern16);
         assert_eq!(m.cycle(), ColorMode::MonoGreen);
+    }
+
+    fn tmp(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("nc_cfg_test_{name}.toml"))
+    }
+
+    #[test]
+    fn write_then_load_round_trips_with_default_base_url() {
+        let path = tmp("roundtrip");
+        let _ = std::fs::remove_file(&path);
+        write_config_at(&path, DEFAULT_BASE_URL, "vng_realkey123").unwrap();
+        match load_status_at(&path) {
+            ConfigStatus::Ready(c) => {
+                assert_eq!(c.api_key, "vng_realkey123");
+                assert_eq!(c.base_url, DEFAULT_BASE_URL);
+                assert!(c.hints && c.boot, "defaults applied");
+            }
+            _ => panic!("a freshly written key must load as Ready"),
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_file_needs_key() {
+        let path = tmp("missing");
+        let _ = std::fs::remove_file(&path);
+        assert!(matches!(load_status_at(&path), ConfigStatus::NeedsKey));
+    }
+
+    #[test]
+    fn placeholder_and_empty_key_need_key() {
+        let path = tmp("placeholder");
+        std::fs::write(&path, format!("api_key = {PLACEHOLDER_KEY:?}\n")).unwrap();
+        assert!(matches!(load_status_at(&path), ConfigStatus::NeedsKey), "example key is not real");
+        std::fs::write(&path, "api_key = \"\"\n").unwrap();
+        assert!(matches!(load_status_at(&path), ConfigStatus::NeedsKey), "empty key");
+        std::fs::write(&path, "base_url = \"https://x\"\n").unwrap();
+        assert!(matches!(load_status_at(&path), ConfigStatus::NeedsKey), "no key at all");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn malformed_toml_is_invalid() {
+        let path = tmp("malformed");
+        std::fs::write(&path, "this is = = not toml\n").unwrap();
+        assert!(matches!(load_status_at(&path), ConfigStatus::Invalid(_)));
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod api;
 pub mod app;
 pub mod config;
 pub mod input;
+pub mod preflight;
 pub mod store;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 use tokio::sync::mpsc;
 
-use neumann_cockpit::api::client::ApiClient;
 use neumann_cockpit::api::tasks::{
     fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies, fetch_messages,
     fetch_missions, fetch_sent_messages,
@@ -25,8 +24,8 @@ use neumann_cockpit::app::{
     RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScutNetworkInput,
     ScutRelayInput, StorageMoveInput,
 };
-use neumann_cockpit::config;
 use neumann_cockpit::input::handle_event;
+use neumann_cockpit::preflight;
 use neumann_cockpit::store;
 use neumann_cockpit::ui;
 
@@ -40,12 +39,11 @@ fn restore_terminal() -> io::Result<()> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cfg = config::Config::load()?;
-    let hints = cfg.hints;
-    let boot = cfg.boot;
-    let color_mode = cfg.color_mode();
-    let client = ApiClient::new(cfg.base_url, cfg.api_key)?;
-
+    // Enter the alternate screen FIRST — before any fallible startup. A missing
+    // or keyless config used to error out of `main` before the terminal was set
+    // up, which on a double-clicked Windows binary flashed a console and
+    // vanished. Now the preflight screen is up first and every failure (and the
+    // first-run key onboarding) has an in-TUI outcome.
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     // No mouse capture: the cockpit handles no mouse events, and capturing would
@@ -65,7 +63,21 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run(&client, &mut terminal, hints, boot, color_mode).await;
+    // Preflight: config check + first-run onboarding, local archive migration,
+    // and the remote link check — all drawn in-screen.
+    let ready = match preflight::run(&mut terminal, ColorMode::default()).await {
+        Ok(preflight::Outcome::Ready(r)) => *r,
+        Ok(preflight::Outcome::Quit) => {
+            restore_terminal()?;
+            return Ok(());
+        }
+        Err(e) => {
+            restore_terminal()?;
+            return Err(e);
+        }
+    };
+
+    let result = run(&mut terminal, ready).await;
 
     restore_terminal()?;
 
@@ -73,30 +85,27 @@ async fn main() -> Result<()> {
 }
 
 async fn run(
-    client: &ApiClient,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    hints: bool,
-    boot: bool,
-    color_mode: ColorMode,
+    ready: preflight::Ready,
 ) -> Result<()> {
+    let preflight::Ready { config, client, conn, scan_history, api_version, link_ok } = ready;
     let (tx, mut rx) = mpsc::channel::<ApiMessage>(32);
     let mut state = AppState {
-        hints_visible: hints,
-        color_mode,
-        booting: boot,
+        hints_visible: config.hints,
+        color_mode: config.color_mode(),
+        booting: config.boot,
+        scan_history,
+        api_version,
         ..Default::default()
     };
-    // Local SQLite store: load the scan history and get a writer handle. On any
-    // DB error we start with an empty history (like the old corrupt-JSON path)
-    // and simply don't persist.
-    let persist_tx = match store::open(&config::db_path()) {
-        Ok(mut conn) => {
-            let _ = store::migrate_legacy_json(&mut conn, &config::history_path());
-            state.scan_history = store::load_observations(&conn);
-            Some(store::spawn_writer(conn))
-        }
-        Err(_) => None,
-    };
+    // The remote link was already probed in the preflight; surface a down link
+    // straight away so the pilot sees why data is missing (F5 retries).
+    if !link_ok {
+        state.set_error("remote link down — press F5 to retry".into());
+    }
+    // The persistence writer takes the connection opened during preflight; on a
+    // DB error there we run without persistence (history already empty).
+    let persist_tx = conn.map(store::spawn_writer);
     let mut events = EventStream::new();
 
     // Short-lived tick that drives the boot assembly; runs only while booting.
@@ -122,7 +131,7 @@ async fn run(
 
         tokio::select! {
             Some(event) = events.next() => {
-                handle_event(event?, &mut state, client, &tx);
+                handle_event(event?, &mut state, &client, &tx);
             }
 
             _ = boot_tick.tick(), if state.booting => {

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -1,0 +1,282 @@
+//! Boot preflight: runs the real startup checks — config presence, local
+//! archive (SQLite migration), and the remote API link — inside the boot grid's
+//! centre Probe pane, and onboards a first-run API key without ever crashing to
+//! a console.
+//!
+//! The eight surrounding subsystems stay dark until the link comes up (the
+//! cosmetic boot animation in `run()` lights them centre-out afterwards). This
+//! runs before the cockpit event loop and hands `run()` a ready set of
+//! resources. The Windows first-run failure it fixes: `Config::load()` used to
+//! error out before the terminal was set up, so a double-clicked binary flashed
+//! a console and vanished. Now the screen is up first and every failure has an
+//! in-TUI outcome.
+
+use std::io;
+use std::time::Duration;
+
+use anyhow::Result;
+use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
+use futures::StreamExt;
+use ratatui::{backend::CrosstermBackend, Terminal};
+use rusqlite::Connection;
+use tokio::time::timeout;
+
+use crate::api::client::ApiClient;
+use crate::api::types::SectorObservation;
+use crate::app::ColorMode;
+use crate::config::{self, Config, ConfigStatus, DEFAULT_BASE_URL};
+use crate::store;
+
+/// How long to wait on the remote link check before declaring it down.
+const LINK_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Status of one preflight check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Status {
+    Pending,
+    Ok(String),
+    Warn(String),
+    Fail(String),
+}
+
+/// One line of the boot check-list.
+#[derive(Debug, Clone)]
+pub struct Step {
+    pub label: &'static str,
+    pub status: Status,
+}
+
+/// The ordered check-list, with the last entry being the step currently running.
+#[derive(Debug, Default)]
+pub struct BootLog {
+    pub steps: Vec<Step>,
+}
+
+impl BootLog {
+    /// Append a new step in the `Pending` state and make it current.
+    fn begin(&mut self, label: &'static str) {
+        self.steps.push(Step { label, status: Status::Pending });
+    }
+    /// Set the status of the current (last) step.
+    fn set(&mut self, status: Status) {
+        if let Some(last) = self.steps.last_mut() {
+            last.status = status;
+        }
+    }
+}
+
+/// Everything the cockpit needs, produced by a successful preflight.
+pub struct Ready {
+    pub config: Config,
+    pub client: ApiClient,
+    pub conn: Option<Connection>,
+    pub scan_history: Vec<SectorObservation>,
+    pub api_version: Option<u32>,
+    pub link_ok: bool,
+}
+
+/// The result of the preflight: either resources to run, or a clean quit
+/// (the pilot pressed Esc/Ctrl-C at the onboarding prompt).
+pub enum Outcome {
+    Ready(Box<Ready>),
+    Quit,
+}
+
+/// What the pilot chose at the "remote link down" prompt.
+enum LinkAction {
+    Retry,
+    ReenterKey,
+    Continue,
+}
+
+type Term = Terminal<CrosstermBackend<io::Stdout>>;
+
+/// Run the preflight sequence, drawing each step in the Probe pane as it
+/// completes. Returns once the link is up, or the pilot chooses to continue in
+/// degraded mode, or quits.
+pub async fn run(terminal: &mut Term, color: ColorMode) -> Result<Outcome> {
+    let mut log = BootLog::default();
+    let mut events = EventStream::new();
+
+    // ── CONFIG ──────────────────────────────────────────────────────────
+    log.begin("CONFIG");
+    redraw(terminal, &log, None, None, color)?;
+    let mut config = match Config::load_status() {
+        ConfigStatus::Ready(c) => {
+            log.set(Status::Ok("loaded".into()));
+            c
+        }
+        ConfigStatus::Invalid(msg) => {
+            log.set(Status::Warn(format!("invalid: {msg}")));
+            match onboard(terminal, &log, &mut events, color).await? {
+                Some(c) => {
+                    log.set(Status::Ok("configured".into()));
+                    c
+                }
+                None => return Ok(Outcome::Quit),
+            }
+        }
+        ConfigStatus::NeedsKey => match onboard(terminal, &log, &mut events, color).await? {
+            Some(c) => {
+                log.set(Status::Ok("configured".into()));
+                c
+            }
+            None => return Ok(Outcome::Quit),
+        },
+    };
+
+    // ── ARCHIVE (local SQLite store) ────────────────────────────────────
+    log.begin("ARCHIVE");
+    redraw(terminal, &log, None, None, color)?;
+    let (conn, scan_history) = match store::open(&config::db_path()) {
+        Ok(mut conn) => {
+            let outcome = store::migrate_legacy_json(&mut conn, &config::history_path())
+                .unwrap_or(store::MigrationOutcome::NoLegacyFile);
+            let history = store::load_observations(&conn);
+            let msg = match outcome {
+                store::MigrationOutcome::Imported(n) => {
+                    format!("{} sectors · migrated {n}", history.len())
+                }
+                _ => format!("{} sectors", history.len()),
+            };
+            log.set(Status::Ok(msg));
+            (Some(conn), history)
+        }
+        Err(e) => {
+            log.set(Status::Warn(format!("disabled: {e}")));
+            (None, Vec::new())
+        }
+    };
+
+    // ── REMOTE LINK ─────────────────────────────────────────────────────
+    // Retried interactively: a bad key or an outage is shown in the Probe pane
+    // with actions (retry / re-enter key / continue offline).
+    log.begin("REMOTE LINK");
+    let mut client = ApiClient::new(config.base_url.clone(), config.api_key.clone())?;
+    let (link_ok, api_version) = loop {
+        log.set(Status::Pending);
+        redraw(terminal, &log, None, None, color)?;
+        match timeout(LINK_TIMEOUT, client.get_api_version()).await {
+            Ok(Ok(v)) => {
+                log.set(Status::Ok(format!("online · v{v}")));
+                break (true, Some(v));
+            }
+            Ok(Err(e)) => log.set(Status::Fail(short_err(&e))),
+            Err(_) => log.set(Status::Fail("timeout".into())),
+        }
+        redraw(
+            terminal,
+            &log,
+            None,
+            Some("[R]etry   [K] re-enter key\n[Enter] continue offline"),
+            color,
+        )?;
+        match wait_action(&mut events).await {
+            LinkAction::Retry => continue,
+            LinkAction::Continue => break (false, None),
+            LinkAction::ReenterKey => match onboard(terminal, &log, &mut events, color).await? {
+                Some(c) => {
+                    config = c;
+                    client = ApiClient::new(config.base_url.clone(), config.api_key.clone())?;
+                }
+                None => return Ok(Outcome::Quit),
+            },
+        }
+    };
+
+    Ok(Outcome::Ready(Box::new(Ready {
+        config,
+        client,
+        conn,
+        scan_history,
+        api_version,
+        link_ok,
+    })))
+}
+
+/// Collect an API key from the pilot and write `config.toml`. Renders the
+/// current check-list plus the onboarding prompt in the Probe pane; does not
+/// touch step statuses (the caller owns those). Returns the ready `Config`, or
+/// `None` if they pressed Esc/Ctrl-C to quit.
+async fn onboard(
+    terminal: &mut Term,
+    log: &BootLog,
+    events: &mut EventStream,
+    color: ColorMode,
+) -> Result<Option<Config>> {
+    let mut buf = String::new();
+    let mut error: Option<String> = None;
+    loop {
+        redraw(terminal, log, Some(&buf), error.as_deref(), color)?;
+        let Some(ev) = events.next().await else { return Ok(None) };
+        let Ok(Event::Key(k)) = ev else { continue };
+        if k.kind != KeyEventKind::Press {
+            continue;
+        }
+        let ctrl = k.modifiers.contains(KeyModifiers::CONTROL);
+        match k.code {
+            KeyCode::Esc => return Ok(None),
+            KeyCode::Char('c') if ctrl => return Ok(None),
+            KeyCode::Backspace => {
+                buf.pop();
+            }
+            KeyCode::Enter => {
+                let key = buf.trim().to_string();
+                if key.is_empty() {
+                    error = Some("key can't be empty".into());
+                    continue;
+                }
+                match config::write_config(DEFAULT_BASE_URL, &key) {
+                    Ok(_) => {
+                        if let ConfigStatus::Ready(c) = Config::load_status() {
+                            return Ok(Some(c));
+                        }
+                        // We just wrote a valid key; fall back to a direct build.
+                        return Ok(Some(Config {
+                            base_url: DEFAULT_BASE_URL.into(),
+                            api_key: key,
+                            theme: None,
+                            hints: true,
+                            boot: true,
+                        }));
+                    }
+                    Err(e) => error = Some(format!("write failed: {e}")),
+                }
+            }
+            KeyCode::Char(c) => buf.push(c),
+            _ => {}
+        }
+    }
+}
+
+fn redraw(
+    terminal: &mut Term,
+    log: &BootLog,
+    entry: Option<&str>,
+    note: Option<&str>,
+    color: ColorMode,
+) -> Result<()> {
+    terminal.draw(|f| crate::ui::preflight::render(f, f.area(), &log.steps, entry, note, color))?;
+    Ok(())
+}
+
+/// Wait for the pilot's choice at the "remote link down" prompt.
+async fn wait_action(events: &mut EventStream) -> LinkAction {
+    loop {
+        match events.next().await {
+            Some(Ok(Event::Key(k))) if k.kind == KeyEventKind::Press => match k.code {
+                KeyCode::Char('r') | KeyCode::Char('R') => return LinkAction::Retry,
+                KeyCode::Char('k') | KeyCode::Char('K') => return LinkAction::ReenterKey,
+                KeyCode::Enter | KeyCode::Esc => return LinkAction::Continue,
+                _ => {}
+            },
+            Some(_) => {}
+            None => return LinkAction::Continue,
+        }
+    }
+}
+
+/// The first line of an error, for a compact status column.
+fn short_err(e: &anyhow::Error) -> String {
+    e.to_string().lines().next().unwrap_or("error").to_string()
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -46,6 +46,17 @@ pub enum PersistMsg {
     UpsertObservation(SectorObservation),
 }
 
+/// What `migrate_legacy_json` did, so the boot preflight can report it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationOutcome {
+    /// The table already had rows — no import, JSON left untouched.
+    AlreadyMigrated,
+    /// No legacy `scan_history.json` to import (fresh install or already gone).
+    NoLegacyFile,
+    /// Imported N observations from the JSON, then removed the file.
+    Imported(usize),
+}
+
 /// Open (creating if needed) the cockpit database and ensure the schema.
 pub fn open(path: &Path) -> rusqlite::Result<Connection> {
     if let Some(parent) = path.parent() {
@@ -129,16 +140,16 @@ pub fn load_observations(conn: &Connection) -> Vec<SectorObservation> {
 /// TEMPORARY: legacy migration, scheduled for removal — see issue #134.
 /// The `legacy_migration_removal_reminder` test fails the build after
 /// 2027-01-01 so this can't be forgotten.
-pub fn migrate_legacy_json(conn: &mut Connection, json_path: &Path) -> rusqlite::Result<()> {
+pub fn migrate_legacy_json(conn: &mut Connection, json_path: &Path) -> rusqlite::Result<MigrationOutcome> {
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
         .unwrap_or(0);
     if count > 0 {
-        return Ok(());
+        return Ok(MigrationOutcome::AlreadyMigrated);
     }
-    let Ok(data) = std::fs::read(json_path) else { return Ok(()) };
+    let Ok(data) = std::fs::read(json_path) else { return Ok(MigrationOutcome::NoLegacyFile) };
     let Ok(history) = serde_json::from_slice::<Vec<SectorObservation>>(&data) else {
-        return Ok(());
+        return Ok(MigrationOutcome::NoLegacyFile);
     };
     let tx = conn.transaction()?;
     for obs in &history {
@@ -148,7 +159,7 @@ pub fn migrate_legacy_json(conn: &mut Connection, json_path: &Path) -> rusqlite:
     // Import committed — retire the legacy file. Failure to remove is harmless
     // (next launch sees a non-empty table and skips).
     let _ = std::fs::remove_file(json_path);
-    Ok(())
+    Ok(MigrationOutcome::Imported(history.len()))
 }
 
 /// Spawn the writer thread, taking ownership of the connection, and return the
@@ -237,7 +248,7 @@ mod tests {
         let path = std::env::temp_dir().join("nc_migrate_import_test.json");
         let history = vec![obs(1.0, 1.0, 1.0), obs(2.0, 2.0, 2.0)];
         std::fs::write(&path, serde_json::to_vec(&history).unwrap()).unwrap();
-        migrate_legacy_json(&mut conn, &path).unwrap();
+        assert_eq!(migrate_legacy_json(&mut conn, &path).unwrap(), MigrationOutcome::Imported(2));
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
             .unwrap();
@@ -251,7 +262,7 @@ mod tests {
         upsert_observation(&conn, &obs(9.0, 9.0, 9.0)).unwrap();
         let path = std::env::temp_dir().join("nc_migrate_skip_test.json");
         std::fs::write(&path, serde_json::to_vec(&vec![obs(1.0, 1.0, 1.0)]).unwrap()).unwrap();
-        migrate_legacy_json(&mut conn, &path).unwrap();
+        assert_eq!(migrate_legacy_json(&mut conn, &path).unwrap(), MigrationOutcome::AlreadyMigrated);
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
             .unwrap();

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -7,7 +7,7 @@
 //! colours until they get cockpit-native renderers); the five promoted panes
 //! use the compact renderers in [`panes`].
 
-mod grid;
+pub(crate) mod grid;
 mod menu;
 mod panes;
 
@@ -249,8 +249,11 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
         }
     }
     // An error takes over the line until dismissed; otherwise a success toast.
+    // Keep the leading gap in a plain span — `crit_style()` is REVERSED in the
+    // mono palettes, which would otherwise highlight the spaces before the mark.
     if let Some(err) = &state.error {
-        left.push(Span::styled(format!("  ✗ {err}"), p.crit_style()));
+        left.push(Span::styled("  ", Style::default()));
+        left.push(Span::styled(format!("✗ {err}"), p.crit_style()));
     } else if let Some(toast) = state.active_toast() {
         left.push(Span::styled(format!("  ✓ {toast}"), Style::default().fg(p.good)));
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod cockpit_v2;
 pub(crate) mod overlays;
 pub(crate) mod panels;
+pub(crate) mod preflight;
 pub(crate) mod theme;
 
 use crate::app::AppState;

--- a/src/ui/preflight.rs
+++ b/src/ui/preflight.rs
@@ -1,0 +1,165 @@
+//! Boot preflight screen: the real startup checks (config → local archive →
+//! remote link) run **inside the boot grid's centre Probe pane**, while the
+//! eight surrounding subsystems stay dark until the link comes up. First-run
+//! API-key onboarding happens in the same Probe pane. Rendered entirely inside
+//! the alternate screen so a missing config never flashes a console and
+//! vanishes.
+
+use crate::app::{ColorMode, Pane};
+use crate::preflight::{Status, Step};
+use crate::ui::cockpit_v2::grid;
+use crate::ui::theme::{palette, pane_block};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+/// Draw the boot grid during preflight: the Probe pane shows the live check-list
+/// (and the onboarding prompt / link-failure actions), the eight others sit dark
+/// until preflight succeeds. `entry` is `Some(buf)` while collecting the API
+/// key; `note` is an optional action/status line shown under the check-list.
+pub(crate) fn render(
+    frame: &mut Frame,
+    area: Rect,
+    steps: &[Step],
+    entry: Option<&str>,
+    note: Option<&str>,
+    color: ColorMode,
+) {
+    let p = palette(color);
+    let dim = Style::default().fg(p.dim);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+
+    for (pane, rect) in grid::visible_panes(rows[0], Pane::Probe) {
+        let is_probe = pane == Pane::Probe;
+        let title = format!(" {} ", pane.label());
+        let block = pane_block(&title, is_probe, p);
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+
+        if !is_probe {
+            // Subsystems stay offline until the preflight clears.
+            frame.render_widget(
+                Paragraph::new(Line::styled("· · ·", dim)).alignment(Alignment::Center),
+                inner,
+            );
+            continue;
+        }
+        frame.render_widget(Paragraph::new(probe_lines(steps, entry, note, p)), inner);
+    }
+
+    // Bottom banner — GUPPI narrating the preflight.
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(" GUPPI — preflight self-check", Style::default().fg(p.accent)))),
+        rows[1],
+    );
+}
+
+/// Build the Probe pane's content: the check-list, then either the onboarding
+/// prompt or a status/action line. Kept compact so it fits the centre cell.
+fn probe_lines(
+    steps: &[Step],
+    entry: Option<&str>,
+    note: Option<&str>,
+    p: crate::ui::theme::Palette,
+) -> Vec<Line<'static>> {
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
+    let mut lines: Vec<Line> = Vec::new();
+
+    for step in steps {
+        let (mark, color, result) = match &step.status {
+            Status::Pending => ("·", p.dim, String::new()),
+            Status::Ok(m) => ("✓", p.good, m.clone()),
+            Status::Warn(m) => ("⚠", p.warn, m.clone()),
+            Status::Fail(m) => ("✗", p.crit, m.clone()),
+        };
+        let mut spans = vec![
+            Span::styled(format!("{mark} "), Style::default().fg(color)),
+            Span::styled(format!("{:<12}", step.label), text),
+        ];
+        if !result.is_empty() {
+            spans.push(Span::styled(result, Style::default().fg(color)));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    if let Some(buf) = entry {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled("⚠ NO API KEY", Style::default().fg(p.warn).add_modifier(Modifier::BOLD))));
+        lines.push(Line::from(Span::styled("get one at", dim)));
+        lines.push(Line::from(Span::styled("neumann-probe.net", Style::default().fg(p.accent))));
+        lines.push(Line::from(vec![
+            Span::styled("KEY ›", Style::default().fg(p.accent)),
+            Span::styled(buf.to_string(), text),
+            Span::styled("▌", Style::default().fg(p.accent)),
+        ]));
+    }
+
+    if let Some(note) = note {
+        lines.push(Line::default());
+        // Notes may carry several `\n`-separated lines (e.g. the link-failure
+        // actions), so they fit the narrow centre cell.
+        for part in note.split('\n') {
+            let style = if part.starts_with('✗') {
+                Style::default().fg(p.crit)
+            } else {
+                dim
+            };
+            lines.push(Line::from(Span::styled(part.to_string(), style)));
+        }
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preflight::Status;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn text(steps: &[Step], entry: Option<&str>, note: Option<&str>) -> String {
+        // Large enough for the 3×3 boot grid (Probe pane centre).
+        let mut t = Terminal::new(TestBackend::new(100, 33)).unwrap();
+        t.draw(|f| render(f, f.area(), steps, entry, note, ColorMode::default())).unwrap();
+        t.backend().buffer().content.iter().map(|c| c.symbol()).collect()
+    }
+
+    #[test]
+    fn boot_grid_shows_probe_active_and_others_dark() {
+        let steps = [Step { label: "CONFIG", status: Status::Pending }];
+        let out = text(&steps, None, None);
+        assert!(out.contains("PROBE"), "the centre Probe pane is framed");
+        assert!(out.contains("SCANNER") && out.contains("MANNIES"), "surrounding panes are drawn too");
+        assert!(out.contains("· · ·"), "the eight subsystems sit dark until preflight clears");
+        assert!(out.contains("GUPPI"), "preflight banner");
+    }
+
+    #[test]
+    fn onboarding_prompt_shows_where_to_get_the_key_and_the_buffer() {
+        let steps = [Step { label: "CONFIG", status: Status::Pending }];
+        let out = text(&steps, Some("vng_abc123"), None);
+        assert!(out.contains("NO API KEY"), "onboarding heading");
+        assert!(out.contains("neumann-probe.net"), "where to get the key");
+        assert!(out.contains("vng_abc123"), "the typed key echoes");
+    }
+
+    #[test]
+    fn link_failure_is_shown_with_actions() {
+        let steps = [
+            Step { label: "CONFIG", status: Status::Ok("loaded".into()) },
+            Step { label: "REMOTE LINK", status: Status::Fail("401 unauthorized".into()) },
+        ];
+        let out = text(&steps, None, Some("[R]etry   [K] re-enter key\n[Enter] continue offline"));
+        assert!(out.contains("REMOTE LINK") && out.contains("401 unauthorized"), "the bad-key error is visible");
+        assert!(out.contains("[R]etry") && out.contains("re-enter key") && out.contains("continue offline"), "recovery actions offered");
+    }
+}


### PR DESCRIPTION
## Problem

On first launch (missing config or absent `api_key`), `main()` called `Config::load()?` **before** entering the alternate screen: the error bubbled up, printed to stderr, and exited — so a double-clicked Windows binary flashed a console and vanished with no explanation.

## Change

Startup now enters the alternate screen **first**, then runs a **preflight rendered inside the boot grid's centre Probe pane**. The eight surrounding panes stay dark (`· · ·`) until the link is established; once it's up, the cosmetic animation lights them centre-out.

Steps (shown as a check-list in the Probe pane):
- **CONFIG** — `Config::load_status()` (`Ready`/`NeedsKey`/`Invalid`, lenient parse). Missing/keyless config → **onboarding prompt**: instructions + key entry → writes `config.toml` (base URL defaulted). Esc/Ctrl-C quits cleanly.
- **ARCHIVE** — `store::open` + `migrate_legacy_json` (now returns a `MigrationOutcome`, surfaced in the log) + `load_observations`.
- **REMOTE LINK** — `get_api_version()` under a timeout, **retried interactively**: a bad key or outage shows in the Probe pane with `[R]` retry · `[K]` re-enter key (re-runs onboarding) · `[Enter]` continue offline. Continuing enters **degraded mode** (error toast, F5 retries).

Bonus: fixed the status bar highlighting the spaces before the `✗` (`crit_style` is `REVERSED` in the mono palettes).

## Files

- `src/preflight.rs` (new) — async state machine + onboarding.
- `src/ui/preflight.rs` (new) — boot-grid render + Probe pane.
- `src/main.rs` — reordered startup (alternate screen first, `run()` takes a `preflight::Ready`).
- `src/config.rs` — `load_status()`, `write_config()`, `DEFAULT_BASE_URL` (path-injectable for tests).
- `src/store.rs` — `MigrationOutcome`.

## Tests

222 tests passing, clippy clean. Added: config write/load round-trip + NeedsKey/Invalid cases (on temp paths, never the real config), preflight grid render (Probe active / 8 dark), onboarding, and link failure with actions.