### PR TITLE
feat(cockpit): wire SCUT-network inspect and deploy-waypoint launchers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,18 +123,18 @@ The four reused panels (Probe / Inventory / Scanner / Mannies) keep their intern
 
 **Overlays** (wizards, rendered on top of the grid; launched from the contextual menu or the reused panels):
 - **Mannies pane menu** (`Enter`) — Fabricate, Mine, Repair, Salvage, Inspect, Recover/Detach container, Refill deuterium, Drop cargo, Recall/Abandon, Rename. Each launches its wizard (`*Input`). Fabricate opens the unified catalog with the selected Manny pre-chosen as builder. Remote mine (SCUT-reachable manny) fetches the manny's sector first, then picks asteroid → resources/amount → mandatory detached container. Recall on a SCUT-remote manny is labelled **abandon**.
-- **Inventory pane menu** (`Enter`) — Fabricate, Jettison, Move stock. Fabricate opens the unified catalog with no builder pre-chosen.
+- **Inventory pane menu** (`Enter`) — Fabricate, Move stock, Jettison, and **Deploy waypoint…** (only when a `waypoint_bookmark` is held; picks the installing Manny → sector target → name, firing `install-bookmark`). Fabricate opens the unified catalog with no builder pre-chosen.
 - **Missions pane** (`Enter`) — active-mission list with steps/status; abandon (confirmation).
 - **Comms pane** (`Enter`) — messaging inbox/sent (mark read, compose to a probe/planet recipient); alerts + damage-warnings live in the same pane.
 - **Storage pane** (`Enter`) — container browser with capacity bars; content view, rename, routing-rules editor (none → priority → exclusion → strict).
 - **Sector pane** (`Enter` on an object) — object-action picker (mine / inspect / salvage / recover / deploy waypoint); an inactive `scut_relay` offers **turn on relay** (needs a star + integrated_circuit) and salvage.
 - **Map pane** — compact summary; `z` opens the full isometric map (pan `hjkl`, `g` travel to the centred sector, `c` coordinate center). `Enter` menu: open map, **Travel to coordinates…**, **Jump to visited sector…** (picker over `visited_sectors`), **Waypoints…** (picker over bookmarks/stars/mineable targets). Scanner `Enter` also offers **Travel here** to the selected observation.
 - **Travel** wizard — coordinate input (absolute, or relative with a leading `+`), live parity check, fuel/ETA preview + confirmation. Launched from Map/Scanner or `:travel`.
-- **Mind-snapshot reassign** — only when the probe is dead or trapped by a black hole (`probe.alert`); reassigns the snapshot to a fresh probe (Probe pane `Enter`).
+- **Probe pane menu** (`Enter`) — **Inspect SCUT network…** (enabled when a SCUT relay covers the current sector; auto-views the sole network or picks among several via `scut-network/{id}`), plus **Reassign mind snapshot** only when the probe is dead or trapped by a black hole (`probe.alert`); reassigns the snapshot to a fresh probe.
 - **Command mode** (`:`) — `focus <pane>` · `travel <x y z|+dx dy dz>` · `goto <x y z>` · `filter <all|objects|minable|danger>` · `craft` · `refresh` · `theme <mode>` · `zoom` · `help` · `q`. `Tab` completes the verb; verbs live in `AppState::run_command` (`app/command.rs`).
 - Shared bits: `EndpointId` is an untagged int|string (probe id | planet object id). `Manny.taskVisibility` (`local` / `scut_network` / `too_far`) drives remote display (`≣ via SCUT` / `too far`).
 
-**Remaining follow-ups** (wizards that exist but still have no cockpit launcher): SCUT-network inspect and deploy-waypoint from Inventory. Everything else — Travel, the full isometric Map (`z` on the Map pane), Waypoints, mind-snapshot reassign, drop-storage-container, and command mode (`:`) — is wired.
+**All wizards are now wired to a cockpit launcher** — Travel, the full isometric Map (`z` on the Map pane), Waypoints, mind-snapshot reassign, drop-storage-container, SCUT-network inspect (Probe pane), deploy-waypoint (Inventory pane), and command mode (`:`).
 
 ## Implemented API endpoints
 

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -25,8 +25,12 @@ pub enum MenuAction {
     // Inventory pane
     Jettison,
     MoveStock,
+    /// Deploy a waypoint bookmark from inventory onto a sector object.
+    Deploy,
     // Probe pane
     MindSnapshot,
+    /// Inspect the SCUT relay network covering the current sector.
+    ScutInspect,
     // Mannies pane (extra)
     DropStorageContainer,
     // Storage pane
@@ -223,25 +227,31 @@ impl super::AppState {
     }
 
     fn probe_context_menu(&self) -> Option<ContextMenu> {
-        // The only probe action is recovery, and only for a dead/trapped probe.
-        self.probe_terminal_alert()?;
-        Some(ContextMenu {
-            title: "PROBE".into(),
-            items: vec![MenuItem {
+        let has_scut = !self.scut_coverage().is_empty();
+        let mut items = vec![MenuItem {
+            action: MenuAction::ScutInspect,
+            label: "Inspect SCUT network…".into(),
+            enabled: has_scut,
+            disabled_reason: (!has_scut).then(|| "no SCUT network here".to_string()),
+        }];
+        // Mind-snapshot recovery only applies to a dead/trapped probe.
+        if self.probe_terminal_alert().is_some() {
+            items.push(MenuItem {
                 action: MenuAction::MindSnapshot,
                 label: "Reassign mind snapshot".into(),
                 enabled: true,
                 disabled_reason: None,
-            }],
-            cursor: 0,
-        })
+            });
+        }
+        let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
+        Some(ContextMenu { title: "PROBE".into(), items, cursor })
     }
 
     fn inventory_context_menu(&self) -> ContextMenu {
         let has_row = self.selected_inventory_row().is_some();
         let has_recipes = !self.recipes.is_empty();
         let idle_manny = !self.collect_idle_onboard_mannies().is_empty();
-        let items = vec![
+        let mut items = vec![
             MenuItem {
                 action: MenuAction::Fabricate,
                 label: "Fabricate…".into(),
@@ -261,6 +271,23 @@ impl super::AppState {
                 disabled_reason: (!has_row).then(|| "no item selected".to_string()),
             },
         ];
+        // Deploy waypoint — only when a bookmark is actually held; it needs an
+        // idle Manny to install it and a target object in the current sector.
+        if self.inventory_waypoint_bookmark_id().is_some() {
+            let has_target = !self.collect_deploy_candidates().is_empty();
+            items.push(MenuItem {
+                action: MenuAction::Deploy,
+                label: "Deploy waypoint…".into(),
+                enabled: idle_manny && has_target,
+                disabled_reason: if !idle_manny {
+                    Some("no idle manny".to_string())
+                } else if !has_target {
+                    Some("no target in sector".to_string())
+                } else {
+                    None
+                },
+            });
+        }
         let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
         ContextMenu { title: "INVENTORY".into(), items, cursor }
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1352,8 +1352,22 @@ fn mannies_context_menu_reflects_manny_state() {
 #[test]
 fn context_menu_none_for_pane_without_actions() {
     let mut state = AppState::default();
-    state.active_pane = Pane::Probe;
+    // Comms uses its own rich overlay (inbox), not the contextual popup menu.
+    state.active_pane = Pane::Comms;
     assert!(state.build_context_menu().is_none());
+}
+
+#[test]
+fn probe_menu_offers_scut_inspect_disabled_without_coverage() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Probe;
+    let menu = state.build_context_menu().expect("probe menu now always present");
+    let item = menu
+        .items
+        .iter()
+        .find(|i| i.action == MenuAction::ScutInspect)
+        .expect("SCUT inspect offered");
+    assert!(!item.enabled && item.disabled_reason.is_some(), "no coverage → disabled with a reason");
 }
 
 #[test]
@@ -1364,6 +1378,28 @@ fn inventory_context_menu_present_but_disabled_when_empty() {
     assert_eq!(menu.items.len(), 3);
     // Nothing loaded → every action disabled with a reason.
     assert!(menu.items.iter().all(|i| !i.enabled && i.disabled_reason.is_some()));
+    // No bookmark held → no deploy-waypoint entry.
+    assert!(!menu.items.iter().any(|i| i.action == MenuAction::Deploy));
+}
+
+#[test]
+fn inventory_menu_offers_deploy_only_with_a_held_bookmark() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Inventory;
+    state.probe = Some(serde_json::from_str(r#"{
+        "id": 1, "name": "t", "status": "idle",
+        "fuel": {"deuterium": null}, "sensorMode": "normal",
+        "sector": null, "movement": null, "systems": null,
+        "inventory": {"capacity": 10.0, "usedCapacity": 1.0, "freeCapacity": 9.0,
+            "resourceStocks": [], "externalTanks": [], "containers": [],
+            "items": [{"id": "wp-1", "type": "waypoint_bookmark", "name": "Waypoint bookmark",
+                "containerSpace": 0.01, "currentTask": null, "taskProgressPercent": 0.0,
+                "location": {"type": "probe", "sector": null}, "cargo": null, "container": null}]}
+    }"#).unwrap());
+    let menu = state.build_context_menu().expect("inventory menu");
+    let deploy = menu.items.iter().find(|i| i.action == MenuAction::Deploy).expect("deploy offered");
+    // No idle manny / no sector target here → offered but disabled with a reason.
+    assert!(!deploy.enabled && deploy.disabled_reason.is_some());
 }
 
 // ── periodic auto-refresh gating ──────────────────────────────────────────

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -11,17 +11,18 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{
-    fetch_all, fetch_inspect, fetch_messages, fetch_recover, fetch_sector, fetch_sent_messages,
-    fetch_storage_container_detail,
+    fetch_all, fetch_inspect, fetch_messages, fetch_recover, fetch_scut_network, fetch_sector,
+    fetch_sent_messages, fetch_storage_container_detail,
 };
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
-    ApiMessage, AppState, FabricationInput, DetachInput, DropCargoInput,
+    ApiMessage, AppState, DeployInput, FabricationInput, DetachInput, DropCargoInput,
     CommandLine, DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction,
     MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
     GotoVisitedInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, ScanMode, StorageMoveInput, TravelInput, WaypointsInput,
+    RepairInput, SalvageInput, ScanMode, ScutNetworkInput, StorageMoveInput, TravelInput,
+    WaypointsInput,
 };
 
 pub fn handle_cockpit_event(
@@ -253,6 +254,32 @@ fn fire_menu_action(
                     };
                 }
                 _ => state.storage_move = StorageMoveInput::PickManny { mannies, selection: 0 },
+            }
+            return;
+        }
+        MenuAction::Deploy => {
+            // Deploy a held waypoint bookmark: pick the installing Manny, then a
+            // target object in the current sector, then a name.
+            let mannies = state.collect_idle_onboard_mannies();
+            if mannies.is_empty() {
+                state.error = Some("no idle Manny on board".into());
+            } else if state.collect_deploy_candidates().is_empty() {
+                state.error = Some("no target object in current sector — scan first".into());
+            } else {
+                state.deploy = DeployInput::PickManny { mannies, selection: 0 };
+            }
+            return;
+        }
+        MenuAction::ScutInspect => {
+            let nets = state.scut_coverage();
+            match nets.len() {
+                0 => state.error = Some("no SCUT network covers this sector".into()),
+                1 => {
+                    state.scut_network = ScutNetworkInput::Viewing { error: None };
+                    state.scut_network_view = None;
+                    fetch_scut_network(nets[0].0, client.clone(), tx.clone());
+                }
+                _ => state.scut_network = ScutNetworkInput::Picking { networks: nets, selection: 0 },
             }
             return;
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -392,4 +392,40 @@ mod tests {
             _ => panic!("stays on the recipe step with an error"),
         }
     }
+
+    #[tokio::test]
+    async fn scut_inspect_from_probe_menu_opens_picker() {
+        use crate::app::{Pane, ScutNetworkInput};
+        let mut state = AppState::default();
+        state.active_pane = Pane::Probe;
+        // Two SCUT networks cover the current sector (first scan, no probe sector).
+        state.scan_history = vec![serde_json::from_str(r#"{
+            "relativeCoordinates":{"x":0,"y":0,"z":0},"distance":0,
+            "knowledgeLevel":"detailed","confidence":1.0,
+            "scutNetworks":[{"id":1,"name":"Alpha"},{"id":2,"name":"Beta"}],
+            "scan":{"currentSectorResidenceSeconds":60,"requiredResidenceSeconds":60,"scanQuality":1.0}
+        }"#).unwrap()];
+        press(&mut state, KeyCode::Enter); // open the Probe context menu
+        press(&mut state, KeyCode::Enter); // fire the first enabled item (Inspect SCUT network…)
+        match &state.scut_network {
+            ScutNetworkInput::Picking { networks, .. } => assert_eq!(networks.len(), 2, "both networks offered"),
+            _ => panic!("two networks should open the picker"),
+        }
+    }
+
+    #[tokio::test]
+    async fn scut_inspect_single_network_goes_straight_to_view() {
+        use crate::app::{Pane, ScutNetworkInput};
+        let mut state = AppState::default();
+        state.active_pane = Pane::Probe;
+        state.scan_history = vec![serde_json::from_str(r#"{
+            "relativeCoordinates":{"x":0,"y":0,"z":0},"distance":0,
+            "knowledgeLevel":"detailed","confidence":1.0,
+            "scutNetworks":[{"id":7,"name":"Solo"}],
+            "scan":{"currentSectorResidenceSeconds":60,"requiredResidenceSeconds":60,"scanQuality":1.0}
+        }"#).unwrap()];
+        press(&mut state, KeyCode::Enter);
+        press(&mut state, KeyCode::Enter);
+        assert!(matches!(state.scut_network, ScutNetworkInput::Viewing { .. }), "a single network views directly");
+    }
 }


### PR DESCRIPTION
## Context

Two wizards were fully implemented (state enum, key handler, overlay, API endpoint) but had **no cockpit launcher** — no `MenuAction`, and their entry state was never constructed. This wires them in, closing the last "Remaining follow-ups" item.

## Changes

- **SCUT-network inspect** → Probe pane menu (`Enter` → "Inspect SCUT network…"). Enabled when a SCUT relay covers the current sector (`scut_coverage()`); a single network views directly via `scut-network/{id}`, several open a picker. The Probe menu now always returns a menu (previously only for a dead/trapped probe).
- **Deploy waypoint** → Inventory pane menu (`Enter` → "Deploy waypoint…"), shown only when a `waypoint_bookmark` is held; disabled with a reason when there's no idle Manny or no sector target. Fires the existing cascade Manny → sector object → name → `install-bookmark`. `DeployInput::PickManny` was previously unreachable dead code; it is now the launcher's first step.

## Tests

226 passing, clippy clean. Added: menu presence/enablement for both entries, and two integration tests driving the full SCUT `menu → dispatch → wizard` flow (single network → view, several → picker) so the SCUT path is covered without live coverage.