### PR TITLE
feat(mine): label asteroid picker by index and resource content

### DIFF
--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -142,8 +142,19 @@ impl AppState {
     /// carbon_compounds). Looks up a top-level object or a nested mining target
     /// by id. `None` when the object isn't in the current sector scan.
     pub fn minable_target_reserves(&self, object_id: &str) -> Option<([bool; 4], [f64; 4])> {
+        Self::reserves_in(self.current_sector()?, object_id)
+    }
+
+    /// Same lookup as [`minable_target_reserves`] but against the probe's actual
+    /// current sector rather than the displayed history entry — used by the mine
+    /// wizard, which targets the probe's sector regardless of what's on screen.
+    pub fn probe_minable_reserves(&self, object_id: &str) -> Option<([bool; 4], [f64; 4])> {
+        Self::reserves_in(self.probe_current_sector_scan()?, object_id)
+    }
+
+    fn reserves_in(sector: &SectorObservation, object_id: &str) -> Option<([bool; 4], [f64; 4])> {
         use crate::api::types::ResourceShares;
-        let objs = self.current_sector()?.objects.as_ref()?;
+        let objs = sector.objects.as_ref()?;
         let build = |types: &[String], amt: Option<&ResourceShares>| {
             let has = |t: &str| types.iter().any(|x| x == t);
             let flags = [has("deuterium"), has("metals"), has("ice"), has("carbon_compounds")];

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -9,6 +9,29 @@ use ratatui::{
 
 use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
+/// A mining-target picker row: `#n [name]  metals 1.20  ice 0.55 …`, listing
+/// each present resource (by its full label) with its remaining reserve when
+/// known.
+fn asteroid_label(state: &AppState, index: usize, id: &str, name: &str) -> String {
+    let mut label = format!("#{}", index + 1);
+    if name != "unnamed" {
+        label.push_str(&format!(" {name}"));
+    }
+    if let Some((flags, res)) = state.probe_minable_reserves(id) {
+        for (k, &res_label) in RESOURCE_LABELS.iter().enumerate() {
+            if !flags[k] {
+                continue;
+            }
+            if res[k] > 0.0 {
+                label.push_str(&format!("  {res_label} {:.2}", res[k]));
+            } else {
+                label.push_str(&format!("  {res_label}"));
+            }
+        }
+    }
+    label
+}
+
 pub(crate) fn estimate_mine_duration(target_amount: f64) -> (i64, i64) {
     const CARGO_CAP: f64 = 0.30;
     const TRAVEL_SECS: i64 = 1800; // 900s each way
@@ -30,9 +53,16 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
     let p = palette(state.color_mode);
     match &state.mine {
         MineInput::PickAsteroid { manny_name, candidates, selection, .. } => {
-            let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
+            // Asteroids are usually unnamed, so label each by index + its known
+            // resource content (like the Sector pane) instead of a bare name.
+            let labels: Vec<String> = candidates
+                .iter()
+                .enumerate()
+                .map(|(i, (id, name))| asteroid_label(state, i, id, name))
+                .collect();
+            let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" MINE — {manny_name} "), 50, height,
+            render_pick_list(frame, area, palette(state.color_mode), &format!(" MINE — {manny_name} "), 62, height,
                 Some("Select mining target:"), &names, *selection, None, "confirm");
         }
 
@@ -186,3 +216,42 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::AppState;
+
+    fn state_with_targets() -> AppState {
+        let mut state = AppState::default();
+        state.probe = Some(serde_json::from_str(r#"{
+            "id":1,"name":"t","status":"idle","fuel":{"deuterium":null},"sensorMode":"normal",
+            "sector":{"relative":{"x":2,"y":0,"z":-2}},"movement":null,"systems":null,
+            "inventory":{"capacity":10.0,"usedCapacity":1.0,"freeCapacity":9.0,"resourceStocks":[],"externalTanks":[],"containers":[],"items":[]}
+        }"#).unwrap());
+        state.scan_history = vec![serde_json::from_str(r#"{
+            "relativeCoordinates":{"x":2,"y":0,"z":-2},"distance":0,"knowledgeLevel":"detailed","confidence":1.0,
+            "objects":[{"id":"planet-1","type":"planet","name":"P1","minableTargets":[
+                {"id":"ast-1","type":"asteroid","name":null,"resourceTypes":["deuterium","metals"],"resourceAmounts":{"deuterium":0.42,"metals":1.20,"ice":0.0,"carbonCompounds":0.0}},
+                {"id":"ast-3","type":"asteroid","name":"Big Rock","resourceTypes":["metals"],"resourceAmounts":null}
+            ]}],
+            "scan":{"currentSectorResidenceSeconds":60,"requiredResidenceSeconds":60,"scanQuality":1.0}
+        }"#).unwrap()];
+        state
+    }
+
+    #[test]
+    fn unnamed_asteroid_labelled_by_index_and_reserves() {
+        let state = state_with_targets();
+        let label = asteroid_label(&state, 0, "ast-1", "unnamed");
+        assert_eq!(label, "#1  deuterium 0.42  metals 1.20", "index + named per-resource reserves, no 'unnamed'");
+    }
+
+    #[test]
+    fn named_asteroid_keeps_its_name_and_lists_present_resources() {
+        let state = state_with_targets();
+        // No reserve amounts known → just the resource label.
+        let label = asteroid_label(&state, 2, "ast-3", "Big Rock");
+        assert_eq!(label, "#3 Big Rock  metals");
+    }
+}


### PR DESCRIPTION
## Problem

When ordering a Manny to mine from the Mannies pane, the asteroid picker listed every target as **"unnamed"** (asteroids rarely have a name), so there was no way to tell them apart or see what they held.

## Change

Each picker row is now labelled by **index + resource content**, mirroring the Sector pane:

```
▶ #1  deuterium 0.42  metals 1.20
  #2  ice 0.55  carbon
  #3 Big Rock  metals
```

- Uses the canonical `RESOURCE_LABELS` (deuterium / metals / ice / carbon), consistent with the mine Configure step.
- Shows the remaining reserve when the target exposes it, otherwise just the resource name.
- Keeps the asteroid's real name when it has one.
- New `AppState::probe_minable_reserves` looks up reserves in the **probe's actual sector** (not the displayed history entry), so the picker is correct even while viewing another scanned sector. `minable_target_reserves` now delegates to a shared `reserves_in` helper.

## Tests

224 passing, clippy clean. Added two `asteroid_label` tests (unnamed → index + reserves; named → name + present resources).