### PR TITLE
feat(hints): advertise the ? help key in the hints line

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -358,6 +358,7 @@ impl super::AppState {
         parts.push("z zoom");
         parts.push("ertdfgcvb pane");
         parts.push("F1 hints");
+        parts.push("? help");
         parts.join(" · ")
     }
 
@@ -493,9 +494,11 @@ mod tests {
     fn pane_hints_are_contextual() {
         let mut s = crate::app::AppState::default();
 
-        // Probe has no list → no movement hint.
+        // Probe has no list → no movement hint. Help is always advertised.
         s.active_pane = Pane::Probe;
-        assert!(!s.pane_hints().contains("jk move"));
+        let probe_h = s.pane_hints();
+        assert!(!probe_h.contains("jk move"));
+        assert!(probe_h.contains("? help"), "the help key is always shown");
 
         // Missions at root offers drill-in, not "back".
         s.active_pane = Pane::Missions;


### PR DESCRIPTION
## Change

The bottom hints line (toggled with `F1`) listed navigation keys but never showed how to open the help overlay. Append `? help` to the end so the key is discoverable without already knowing it:

```
… · z zoom · ertdfgcvb pane · F1 hints · ? help
```

Built in `AppState::pane_hints` so it shows for every pane. Test updated to assert the help key is always present.

## Tests

222 passing, clippy clean.