### PR TITLE
feat(api): catch up API v71 type drift (Lot A)

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -66,6 +66,8 @@ pub enum MannyTask {
     InstallingWaypointBookmark,
     DetachingStorageContainer,
     InspectingAsteroid,
+    InspectingSectorObject,
+    ImprovingProbe,
     Returning,
     WaitingForSpace,
     MovingStockage,
@@ -166,6 +168,7 @@ pub struct ResourceStockContainerLine {
 #[serde(rename_all = "camelCase")]
 pub struct MannyCargo {
     pub capacity: f64,
+    pub capacity_unit: Option<String>,
     pub deuterium: f64,
     pub metals: f64,
     pub ice: f64,
@@ -285,6 +288,7 @@ pub enum AlertType {
     IntelligentLife,
     SectorObjectDetected,
     AnomalyDetected,
+    MannyReport,
     #[serde(other)]
     Unknown,
 }
@@ -305,6 +309,7 @@ pub enum AlertPhase {
     DecelerationStart,
     Arrival,
     Detection,
+    MannyReport,
     #[serde(other)]
     Unknown,
 }
@@ -343,6 +348,16 @@ pub struct AlertObjectRef {
     pub resource_types: Vec<String>,
 }
 
+/// A Manny inspection report attached to a `manny_report` warning (API v70).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AlertReportRef {
+    pub title: Option<String>,
+    pub object_id: Option<String>,
+    pub object_type: Option<String>,
+    pub object_label: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AlertSector {
@@ -364,6 +379,8 @@ pub struct ProbeAlert {
     pub risk: Option<AlertRisk>,
     pub planet: Option<AlertPlanetRef>,
     pub object: Option<AlertObjectRef>,
+    /// Manny report payload (API v70 `manny_report` warnings).
+    pub report: Option<AlertReportRef>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub read_at: Option<DateTime<Utc>>,
@@ -531,8 +548,11 @@ pub struct ProbeMessage {
     pub recipient: ProbeMessageEndpoint,
     pub body: String,
     pub status: MessageStatus,
+    /// Relative sector the message was emitted from (API v71).
+    pub sector: Option<ProbeSector>,
     pub read_at: Option<String>,
     pub created_at: String,
+    pub updated_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -542,7 +562,10 @@ pub struct ProbeSentMessage {
     pub sender: ProbeMessageEndpoint,
     pub recipient: ProbeMessageEndpoint,
     pub body: String,
+    /// Relative sector the message was emitted from (API v71).
+    pub sector: Option<ProbeSector>,
     pub created_at: String,
+    pub updated_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -650,6 +673,7 @@ pub enum SectorObjectType {
     DetachedContainer,
     DeuteriumRefuelStation,
     ScutRelay,
+    DormantConstruct,
     #[serde(other)]
     Unknown,
 }
@@ -768,9 +792,17 @@ pub struct SectorObject {
     pub capacity: Option<f64>,
     pub capacity_unit: Option<String>,
     pub minable_targets: Option<Vec<MinableTarget>>,
+    /// Home planet of a deuterium refuel station (API v71).
+    pub planet_id: Option<String>,
+    pub planet_name: Option<String>,
+    /// Dormant-construct descriptors, revealed by inspection (API v64/v70).
+    pub apparent_origin: Option<String>,
+    pub activity_status: Option<String>,
+    pub known_function: Option<String>,
     // SCUT relay objects (present only when object_type == ScutRelay).
     pub status: Option<ScutRelayStatus>,
     pub coverage_radius_sectors: Option<i64>,
+    pub created_by_probe_id: Option<i64>,
     pub created_by_probe_name: Option<String>,
     pub activated_at: Option<String>,
     pub network: Option<ScutNetworkReference>,

--- a/src/ui/overlays/alerts.rs
+++ b/src/ui/overlays/alerts.rs
@@ -17,6 +17,7 @@ fn alert_type_label(t: &AlertType) -> &'static str {
         AlertType::IntelligentLife => "intelligent life",
         AlertType::SectorObjectDetected => "object detected",
         AlertType::AnomalyDetected => "anomaly detected",
+        AlertType::MannyReport => "manny report",
         AlertType::Unknown => "alert",
     }
 }
@@ -28,6 +29,7 @@ fn type_color(t: &AlertType, p: Palette) -> Color {
         AlertType::IntelligentLife => p.accent,
         AlertType::SectorObjectDetected => p.warn,
         AlertType::AnomalyDetected => p.crit,
+        AlertType::MannyReport => p.good,
         AlertType::Unknown => p.text,
     }
 }

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -66,6 +66,8 @@ pub(crate) fn manny_task_label(task: Option<&MannyTask>) -> &'static str {
         Some(MannyTask::InstallingWaypointBookmark) => "installing waypoint",
         Some(MannyTask::DetachingStorageContainer) => "detaching container",
         Some(MannyTask::InspectingAsteroid) => "inspecting",
+        Some(MannyTask::InspectingSectorObject) => "inspecting",
+        Some(MannyTask::ImprovingProbe) => "improving probe",
         Some(MannyTask::Returning) => "returning",
         Some(MannyTask::WaitingForSpace) => "waiting for space",
         Some(MannyTask::MovingStockage) => "moving cargo",

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -190,6 +190,7 @@ pub(crate) fn object_color(t: &SectorObjectType, p: Palette) -> Color {
         SectorObjectType::BlackHole => p.crit,
         SectorObjectType::Manny | SectorObjectType::DeuteriumRefuelStation => p.good,
         SectorObjectType::DetachedContainer | SectorObjectType::ScutRelay => p.accent,
+        SectorObjectType::DormantConstruct => p.warn,
         SectorObjectType::Unknown => p.dim,
     }
 }
@@ -209,6 +210,7 @@ pub(crate) fn object_type_label(t: &SectorObjectType) -> &'static str {
         SectorObjectType::DetachedContainer => "container",
         SectorObjectType::DeuteriumRefuelStation => "fuel station",
         SectorObjectType::ScutRelay => "SCUT relay",
+        SectorObjectType::DormantConstruct => "dormant construct",
         SectorObjectType::Unknown => "object",
     }
 }
@@ -226,6 +228,7 @@ pub(crate) fn object_icon(t: &SectorObjectType) -> (&'static str, Color) {
         SectorObjectType::DetachedContainer => ("□", Color::Cyan),
         SectorObjectType::DeuteriumRefuelStation => ("⛽", Color::Green),
         SectorObjectType::ScutRelay => ("≣", Color::LightBlue),
+        SectorObjectType::DormantConstruct => ("⍟", Color::Yellow),
         SectorObjectType::Unknown => ("?", Color::DarkGray),
     }
 }

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -758,3 +758,40 @@ fn mission_with_steps_deserializes() {
     assert_eq!(m.steps[0].status, MissionStepStatus::Pending);
     assert_eq!(m.steps[1].status, MissionStepStatus::Completed);
 }
+
+// ── API v71 drift: new enum variants must not fall back to Unknown ─────────────
+
+#[test]
+fn manny_task_v71_variants() {
+    let improving = MANNY_MINING_JSON.replace("\"mining\"", "\"improving_probe\"");
+    assert_eq!(deser::<Manny>(&improving).current_task, Some(MannyTask::ImprovingProbe));
+    let inspecting = MANNY_MINING_JSON.replace("\"mining\"", "\"inspecting_sector_object\"");
+    assert_eq!(
+        deser::<Manny>(&inspecting).current_task,
+        Some(MannyTask::InspectingSectorObject)
+    );
+}
+
+#[test]
+fn sector_object_dormant_construct() {
+    let o: SectorObject = deser(
+        r#"{"id":"dc-1","type":"dormant_construct","name":"Relic",
+            "apparentOrigin":"unknown","activityStatus":"dormant","knownFunction":null}"#,
+    );
+    assert_eq!(o.object_type, SectorObjectType::DormantConstruct);
+    assert_eq!(o.apparent_origin.as_deref(), Some("unknown"));
+    assert_eq!(o.activity_status.as_deref(), Some("dormant"));
+}
+
+#[test]
+fn alert_manny_report_with_payload() {
+    let a: ProbeAlert = deser(
+        r#"{"id":7,"type":"manny_report","status":"unread","message":"Report in.",
+            "phase":"manny_report","scheduledAt":null,
+            "report":{"title":"Manny report","objectId":"dc-1","objectType":"dormant_construct","objectLabel":null}}"#,
+    );
+    assert_eq!(a.alert_type, AlertType::MannyReport);
+    assert_eq!(a.phase, AlertPhase::MannyReport);
+    let report = a.report.expect("report payload");
+    assert_eq!(report.object_id.as_deref(), Some("dc-1"));
+}


### PR DESCRIPTION
## Context

First slice of the v63→v71 API catch-up: **types only, no new endpoints**. Between v63 and v71 the server added just three endpoints (probe improvements, inspect-sector-object) but also drifted existing schemas — new enum values were silently falling to `Unknown` and new fields were dropped. All changes below were **verified against the game server source** (`Von-Neumann-Game`), not just the spec.

## Changes (`src/api/types.rs` + UI match arms)

- **MannyTask**: `InspectingSectorObject`, `ImprovingProbe` — a Manny improving the probe or inspecting an object showed "Unknown". Added pane labels.
- **SectorObjectType**: `DormantConstruct` (new v64 object) — added color / label / icon in `theme.rs`.
- **AlertType** / **AlertPhase**: `MannyReport` (v70 `manny_report` warnings) — added alerts-overlay label/color.
- **ProbeAlert.report** (`AlertReportRef`): the report payload attached to `manny_report`.
- **SectorObject**: `planetId`/`planetName` (deuterium stations), `apparentOrigin`/`activityStatus`/`knownFunction` (dormant constructs), `createdByProbeId` (SCUT relays).
- **MannyCargo**: `capacityUnit`.
- **ProbeMessage** / **ProbeSentMessage**: `sector`, `updatedAt`.

Note: `manny_report` and `sector_object_detected` ride on the already-wired damage-warnings endpoint (they are warning *types*), so no new fetch is needed.

## Tests

231 passing, clippy clean. Added serde tests asserting the new MannyTask / SectorObjectType / AlertType+AlertPhase variants deserialize to their proper value instead of `Unknown`.

## Next

Lot B — probe improvements (`improve-probe` + `probe-improvements-available` + UI). Lot C — inspect-sector-object migration + dormant-construct actions.