### PR TITLE
feat(api): probe improvements (API v71 Lot B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ The four reused panels (Probe / Inventory / Scanner / Mannies) keep their intern
 - **Sector pane** (`Enter` on an object) — object-action picker (mine / inspect / salvage / recover / deploy waypoint); an inactive `scut_relay` offers **turn on relay** (needs a star + integrated_circuit) and salvage.
 - **Map pane** — compact summary; `z` opens the full isometric map (pan `hjkl`, `g` travel to the centred sector, `c` coordinate center). `Enter` menu: open map, **Travel to coordinates…**, **Jump to visited sector…** (picker over `visited_sectors`), **Waypoints…** (picker over bookmarks/stars/mineable targets). Scanner `Enter` also offers **Travel here** to the selected observation.
 - **Travel** wizard — coordinate input (absolute, or relative with a leading `+`), live parity check, fuel/ETA preview + confirmation. Launched from Map/Scanner or `:travel`.
-- **Probe pane menu** (`Enter`) — **Inspect SCUT network…** (enabled when a SCUT relay covers the current sector; auto-views the sole network or picks among several via `scut-network/{id}`), plus **Reassign mind snapshot** only when the probe is dead or trapped by a black hole (`probe.alert`); reassigns the snapshot to a fresh probe.
+- **Probe pane menu** (`Enter`) — **Inspect SCUT network…** (enabled when a SCUT relay covers the current sector; auto-views the sole network or picks among several via `scut-network/{id}`), **Improve probe…** (enabled when an unlocked, not-yet-done improvement exists; two-panel catalog → resolve the installing Manny → `improve-probe`), plus **Reassign mind snapshot** only when the probe is dead or trapped by a black hole (`probe.alert`); reassigns the snapshot to a fresh probe. Improvements are fetched in `fetch_all` (`ProbeImprovement`).
 - **Command mode** (`:`) — `focus <pane>` · `travel <x y z|+dx dy dz>` · `goto <x y z>` · `filter <all|objects|minable|danger>` · `craft` · `refresh` · `theme <mode>` · `zoom` · `help` · `q`. `Tab` completes the verb; verbs live in `AppState::run_command` (`app/command.rs`).
 - Shared bits: `EndpointId` is an untagged int|string (probe id | planet object id). `Manny.taskVisibility` (`local` / `scut_network` / `too_far`) drives remote display (`≣ via SCUT` / `too far`).
 
@@ -153,6 +153,8 @@ The four reused panels (Probe / Inventory / Scanner / Mannies) keep their intern
 | `/api/probe/mannies/{id}/repair` | POST | ✓ |
 | `/api/probe/mannies/{id}/mine` | POST | ✓ |
 | `/api/probe/mannies/{id}/craft` | POST | ✓ |
+| `/api/probe/mannies/{id}/improve-probe` | POST | ✓ |
+| `/api/probe/probe-improvements-available` | GET | ✓ |
 | `/api/probe/mannies/{id}/salvage` | POST | ✓ |
 | `/api/probe/mannies/{id}/recall` | POST | ✓ |
 | `/api/probe/mannies/{id}` | PATCH | ✓ (rename) |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,7 +1,7 @@
 use super::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, EndpointId, Manny, Mission, Pagination,
-    Probe, ProbeAlert, ProbeInventory, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork,
-    SectorObservation, StorageContainer, VisitedSector,
+    Probe, ProbeAlert, ProbeImprovement, ProbeInventory, ProbeMessage, ProbeMovement,
+    ProbeSentMessage, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
 };
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
@@ -209,6 +209,21 @@ impl ApiClient {
         struct Resp { manny: Manny }
         let path = format!("/api/probe/mannies/{manny_id}/craft");
         Ok(self.post::<Resp, _>(&path, &Body { recipe }).await?.manny)
+    }
+
+    pub async fn get_probe_improvements(&self) -> Result<Vec<ProbeImprovement>> {
+        #[derive(Deserialize)]
+        struct Resp { improvements: Vec<ProbeImprovement> }
+        Ok(self.get::<Resp>("/api/probe/probe-improvements-available").await?.improvements)
+    }
+
+    pub async fn improve_probe(&self, manny_id: &str, improvement: &str) -> Result<Manny> {
+        #[derive(Serialize)]
+        struct Body<'a> { improvement: &'a str }
+        #[derive(Deserialize)]
+        struct Resp { manny: Manny }
+        let path = format!("/api/probe/mannies/{manny_id}/improve-probe");
+        Ok(self.post::<Resp, _>(&path, &Body { improvement }).await?.manny)
     }
 
     pub async fn get_sector(&self, x: i32, y: i32, z: i32) -> Result<SectorObservation> {

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -47,10 +47,35 @@ pub fn fetch_all(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
         }
     });
 
-    // Alerts + damage warnings + missions: non-fatal, same pattern as mannies/sector.
+    // Alerts + damage warnings + missions + probe improvements: non-fatal, same
+    // pattern as mannies/sector.
     fetch_alerts(client.clone(), tx.clone());
     fetch_missions(client.clone(), tx.clone());
+    fetch_probe_improvements(client.clone(), tx.clone());
     fetch_damage_warnings(client, tx);
+}
+
+pub fn fetch_probe_improvements(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    tokio::spawn(async move {
+        if let Ok(improvements) = client.get_probe_improvements().await {
+            let _ = tx.send(ApiMessage::ProbeImprovementsFetched(improvements)).await;
+        }
+    });
+}
+
+pub fn fetch_improve_probe(
+    manny_id: String,
+    improvement: String,
+    client: ApiClient,
+    tx: mpsc::Sender<ApiMessage>,
+) {
+    tokio::spawn(async move {
+        let msg = match client.improve_probe(&manny_id, &improvement).await {
+            Ok(_) => ApiMessage::ImproveProbeStarted,
+            Err(e) => ApiMessage::ImproveProbeError(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
 }
 
 pub fn fetch_missions(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -624,6 +624,26 @@ pub struct CraftingRecipe {
     pub output: CraftingRecipeOutput,
 }
 
+// ── Probe improvements (API v67+) ──────────────────────────────────────────────
+
+/// An installable probe upgrade (e.g. `deuterium_compression`). Built by an idle
+/// onboard Manny; `available` gates whether it is unlocked, `done` whether it is
+/// already installed. Ingredient shape matches `CraftingRecipeIngredient`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeImprovement {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub available: bool,
+    pub done: bool,
+    pub duration_seconds: i64,
+    pub ingredients: Vec<CraftingRecipeIngredient>,
+    /// Free-form effect descriptors (e.g. `maxDeuteriumPercent`); the
+    /// description already summarizes them for display.
+    pub effects: Option<serde_json::Value>,
+}
+
 // ── Sector ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -212,6 +212,25 @@ pub enum Fabricator {
     Manny,
 }
 
+/// Probe-improvement wizard (API v67+): pick an improvement, then resolve which
+/// idle onboard Manny installs it (auto when a single one, else `PickBuilder`).
+#[derive(Default)]
+pub enum ImproveInput {
+    #[default]
+    Inactive,
+    PickImprovement {
+        selection: usize,
+        error: Option<String>,
+    },
+    PickBuilder {
+        improvement_id: String,
+        improvement_name: String,
+        mannies: Vec<(String, String)>, // (id, name)
+        selection: usize,
+        error: Option<String>,
+    },
+}
+
 /// Unified fabrication wizard: a single item-first catalog spanning both the
 /// atomic printer and Manny craft. `PickRecipe` lists every recipe sectioned by
 /// fabricator; selecting a Manny recipe with no pre-chosen builder advances to

--- a/src/app/inventory.rs
+++ b/src/app/inventory.rs
@@ -218,6 +218,17 @@ impl AppState {
         recipe.ingredients.iter().all(|ing| self.recipe_ingredient_have(ing) >= ing.quantity)
     }
 
+    /// Whether every ingredient of a probe improvement is currently on hand.
+    pub fn improvement_affordable(&self, imp: &crate::api::types::ProbeImprovement) -> bool {
+        imp.ingredients.iter().all(|ing| self.recipe_ingredient_have(ing) >= ing.quantity)
+    }
+
+    /// Whether at least one probe improvement is installable right now (unlocked
+    /// and not already done) — gates the Probe pane's "Improve probe…" action.
+    pub fn has_orderable_improvement(&self) -> bool {
+        self.probe_improvements.iter().any(|i| i.available && !i.done)
+    }
+
     pub fn inventory_waypoint_bookmark_id(&self) -> Option<String> {
         self.probe.as_ref()?.inventory.items.iter()
             .find(|i| i.item_type == "waypoint_bookmark")

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -84,6 +84,15 @@ impl AppState {
         }
     }
 
+    /// Surface a probe-improvement failure on whichever step is active.
+    pub fn set_improve_error(&mut self, msg: String) {
+        match self.improve {
+            ImproveInput::PickImprovement { ref mut error, .. } => *error = Some(msg),
+            ImproveInput::PickBuilder { ref mut error, .. } => *error = Some(msg),
+            ImproveInput::Inactive => {}
+        }
+    }
+
     pub fn set_salvage_error(&mut self, msg: String) {
         if let SalvageInput::Confirm { ref mut error, .. } = self.salvage {
             *error = Some(msg);

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,7 +1,7 @@
 use crate::api::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeInventory, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork, SectorObservation,
-    StorageContainer, VisitedSector,
+    ProbeImprovement, ProbeInventory, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork,
+    SectorObservation, StorageContainer, VisitedSector,
 };
 
 pub enum ApiMessage {
@@ -30,6 +30,9 @@ pub enum ApiMessage {
     AtomicPrinterCraftStarted,
     AtomicPrinterCraftError(String),
     RecipesFetched(Vec<CraftingRecipe>),
+    ProbeImprovementsFetched(Vec<ProbeImprovement>),
+    ImproveProbeStarted,
+    ImproveProbeError(String),
     RenameMannyDone(Manny),
     RenameMannyError(String),
     InspectStarted,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,8 +29,8 @@ pub use waypoints::*;
 
 use crate::api::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe,
-    ProbeAlert, ProbeInventory, ProbeMessage, ProbeSentMessage, ScutNetwork, SectorObservation,
-    StorageContainer, VisitedSector,
+    ProbeAlert, ProbeImprovement, ProbeInventory, ProbeMessage, ProbeSentMessage, ScutNetwork,
+    SectorObservation, StorageContainer, VisitedSector,
 };
 use chrono::{DateTime, Local, Utc};
 use tokio::time::Instant;
@@ -99,6 +99,7 @@ pub struct AppState {
     pub remote_mine: RemoteMineInput,
     pub jettison: JettisonInput,
     pub fabrication: FabricationInput,
+    pub improve: ImproveInput,
     pub salvage: SalvageInput,
     pub recall: RecallInput,
     pub refuel: RefuelInput,
@@ -119,6 +120,7 @@ pub struct AppState {
     pub map: MapView,
     pub api_version: Option<u32>,
     pub recipes: Vec<CraftingRecipe>,
+    pub probe_improvements: Vec<ProbeImprovement>,
     // ── Cockpit v2 (bloc U1) ────────────────────────────────────────────
     /// Active pane in the 3×3 grid (defaults to `Probe`, the centre).
     pub active_pane: Pane,

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -31,6 +31,8 @@ pub enum MenuAction {
     MindSnapshot,
     /// Inspect the SCUT relay network covering the current sector.
     ScutInspect,
+    /// Install a probe improvement with an idle Manny.
+    Improve,
     // Mannies pane (extra)
     DropStorageContainer,
     // Storage pane
@@ -234,6 +236,14 @@ impl super::AppState {
             enabled: has_scut,
             disabled_reason: (!has_scut).then(|| "no SCUT network here".to_string()),
         }];
+        // Probe improvements — installable when one is unlocked and not done.
+        let can_improve = self.has_orderable_improvement();
+        items.push(MenuItem {
+            action: MenuAction::Improve,
+            label: "Improve probe…".into(),
+            enabled: can_improve,
+            disabled_reason: (!can_improve).then(|| "no improvement available".to_string()),
+        });
         // Mind-snapshot recovery only applies to a dead/trapped probe.
         if self.probe_terminal_alert().is_some() {
             items.push(MenuItem {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1370,6 +1370,35 @@ fn probe_menu_offers_scut_inspect_disabled_without_coverage() {
     assert!(!item.enabled && item.disabled_reason.is_some(), "no coverage → disabled with a reason");
 }
 
+fn improvement(id: &str, available: bool, done: bool) -> crate::api::types::ProbeImprovement {
+    serde_json::from_str(&format!(
+        r#"{{"id":"{id}","name":"{id}","description":"d","available":{available},"done":{done},
+            "durationSeconds":300,"ingredients":[],"effects":null}}"#
+    )).unwrap()
+}
+
+#[test]
+fn has_orderable_improvement_gates_on_available_and_not_done() {
+    let mut state = AppState::default();
+    assert!(!state.has_orderable_improvement(), "none loaded");
+    state.probe_improvements = vec![improvement("deuterium_compression", false, false)];
+    assert!(!state.has_orderable_improvement(), "locked → not orderable");
+    state.probe_improvements = vec![improvement("deuterium_compression", true, true)];
+    assert!(!state.has_orderable_improvement(), "already done → not orderable");
+    state.probe_improvements = vec![improvement("deuterium_compression", true, false)];
+    assert!(state.has_orderable_improvement(), "unlocked and not done → orderable");
+}
+
+#[test]
+fn probe_menu_improve_enabled_only_with_an_orderable_improvement() {
+    let mut state = AppState::default();
+    state.active_pane = Pane::Probe;
+    state.probe_improvements = vec![improvement("deuterium_compression", true, false)];
+    let menu = state.build_context_menu().expect("probe menu");
+    let item = menu.items.iter().find(|i| i.action == MenuAction::Improve).expect("improve offered");
+    assert!(item.enabled, "orderable improvement → enabled");
+}
+
 #[test]
 fn inventory_context_menu_present_but_disabled_when_empty() {
     let mut state = AppState::default();

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -16,7 +16,7 @@ use crate::api::tasks::{
 };
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
-    ApiMessage, AppState, DeployInput, FabricationInput, DetachInput, DropCargoInput,
+    ApiMessage, AppState, DeployInput, FabricationInput, ImproveInput, DetachInput, DropCargoInput,
     CommandLine, DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction,
     MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
@@ -280,6 +280,14 @@ fn fire_menu_action(
                     fetch_scut_network(nets[0].0, client.clone(), tx.clone());
                 }
                 _ => state.scut_network = ScutNetworkInput::Picking { networks: nets, selection: 0 },
+            }
+            return;
+        }
+        MenuAction::Improve => {
+            if state.has_orderable_improvement() {
+                state.improve = ImproveInput::PickImprovement { selection: 0, error: None };
+            } else {
+                state.error = Some("no probe improvement available".into());
             }
             return;
         }

--- a/src/input/improve.rs
+++ b/src/input/improve.rs
@@ -1,0 +1,99 @@
+use crossterm::event::KeyCode;
+use tokio::sync::mpsc;
+
+use crate::api::client::ApiClient;
+use crate::api::tasks::fetch_improve_probe;
+use crate::app::{ApiMessage, AppState, ImproveInput};
+use super::geometry::list_nav;
+
+/// Drive the probe-improvement wizard: pick an improvement, then resolve which
+/// idle onboard Manny installs it (auto for a single one, else `PickBuilder`).
+pub(super) fn handle_improve_event(
+    code: KeyCode,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    match state.improve {
+        ImproveInput::PickImprovement { selection, .. } => {
+            let count = state.probe_improvements.len();
+            match code {
+                KeyCode::Esc => state.improve = ImproveInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, selection, count) {
+                        if let ImproveInput::PickImprovement { ref mut selection, .. } = state.improve {
+                            *selection = new_sel;
+                        }
+                    }
+                }
+                KeyCode::Enter => commit_improvement(selection, state, client, tx),
+                _ => {}
+            }
+        }
+        ImproveInput::PickBuilder { selection, ref mannies, .. } => {
+            let count = mannies.len();
+            match code {
+                KeyCode::Esc => state.improve = ImproveInput::Inactive,
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(new_sel) = list_nav(code, selection, count) {
+                        if let ImproveInput::PickBuilder { ref mut selection, .. } = state.improve {
+                            *selection = new_sel;
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    let picked = if let ImproveInput::PickBuilder { ref mannies, selection, ref improvement_id, .. } = state.improve {
+                        mannies.get(selection).map(|(id, _)| (id.clone(), improvement_id.clone()))
+                    } else {
+                        None
+                    };
+                    if let Some((manny_id, improvement_id)) = picked {
+                        fetch_improve_probe(manny_id, improvement_id, client.clone(), tx.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+        ImproveInput::Inactive => {}
+    }
+}
+
+/// Validate the selected improvement, then fire it (auto-picking the sole idle
+/// Manny) or advance to the builder-selection step.
+fn commit_improvement(
+    selection: usize,
+    state: &mut AppState,
+    client: &ApiClient,
+    tx: &mpsc::Sender<ApiMessage>,
+) {
+    let Some((id, name, done, available)) = state.probe_improvements.get(selection)
+        .map(|i| (i.id.clone(), i.name.clone(), i.done, i.available))
+    else {
+        return;
+    };
+    if done {
+        state.set_improve_error("already installed".into());
+        return;
+    }
+    if !available {
+        state.set_improve_error("not unlocked yet".into());
+        return;
+    }
+    let mannies = state.collect_idle_onboard_mannies();
+    match mannies.len() {
+        0 => state.set_improve_error("no idle Manny on board".into()),
+        1 => {
+            let (manny_id, _) = mannies.into_iter().next().unwrap();
+            fetch_improve_probe(manny_id, id, client.clone(), tx.clone());
+        }
+        _ => {
+            state.improve = ImproveInput::PickBuilder {
+                improvement_id: id,
+                improvement_name: name,
+                mannies,
+                selection: 0,
+                error: None,
+            };
+        }
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -9,8 +9,8 @@ use crate::app::{
     DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
     MessagesInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
     RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode,
-    GotoVisitedInput, InputMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput, TravelInput,
-    WaypointsInput,
+    GotoVisitedInput, ImproveInput, InputMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput,
+    TravelInput, WaypointsInput,
 };
 mod alerts;
 mod cockpit;
@@ -18,6 +18,7 @@ mod command;
 mod containers;
 mod craft;
 mod geometry;
+mod improve;
 mod jettison;
 mod map;
 mod messages;
@@ -36,6 +37,7 @@ use containers::{
 };
 use craft::handle_fabrication_event;
 use geometry::face_d2;
+use improve::handle_improve_event;
 use jettison::handle_jettison_event;
 use command::handle_command_event;
 use map::{handle_goto_visited_event, handle_map_event};
@@ -69,6 +71,7 @@ type WizardHandler = fn(KeyCode, &mut AppState, &ApiClient, &mpsc::Sender<ApiMes
 const WIZARD_INPUTS: &[(WizardGuard, WizardHandler)] = &[
     (|s| !matches!(s.jettison, JettisonInput::Inactive), handle_jettison_event),
     (|s| !matches!(s.fabrication, FabricationInput::Inactive), handle_fabrication_event),
+    (|s| !matches!(s.improve, ImproveInput::Inactive), handle_improve_event),
     (|s| !matches!(s.salvage, SalvageInput::Inactive), handle_salvage_event),
     (|s| !matches!(s.recall, RecallInput::Inactive), handle_recall_event),
     (|s| !matches!(s.refuel, RefuelInput::Inactive), handle_refuel_event),
@@ -427,5 +430,22 @@ mod tests {
         press(&mut state, KeyCode::Enter);
         press(&mut state, KeyCode::Enter);
         assert!(matches!(state.scut_network, ScutNetworkInput::Viewing { .. }), "a single network views directly");
+    }
+
+    #[tokio::test]
+    async fn improve_from_probe_menu_opens_the_picker() {
+        use crate::app::{ImproveInput, Pane};
+        let mut state = AppState::default();
+        state.active_pane = Pane::Probe;
+        state.probe_improvements = vec![serde_json::from_str(
+            r#"{"id":"deuterium_compression","name":"Deuterium compression","description":"d",
+                "available":true,"done":false,"durationSeconds":300,"ingredients":[],"effects":null}"#,
+        ).unwrap()];
+        press(&mut state, KeyCode::Enter); // open the Probe menu (Improve is the first enabled item)
+        press(&mut state, KeyCode::Enter); // fire it
+        assert!(
+            matches!(state.improve, ImproveInput::PickImprovement { .. }),
+            "an orderable improvement opens the picker"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use neumann_cockpit::api::tasks::{
     fetch_missions, fetch_sent_messages,
 };
 use neumann_cockpit::app::{
-    ApiMessage, AppState, ColorMode, ContainerRulesInput, FabricationInput,
+    ApiMessage, AppState, ColorMode, ContainerRulesInput, FabricationInput, ImproveInput,
     DeployInput,
     DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput,
     MessagesInput, MindSnapshotInput, MineInput, MissionsInput, RecallInput, RecoverInput,
@@ -291,6 +291,15 @@ async fn run(
                     }
                     ApiMessage::AtomicPrinterCraftError(e) => state.set_fabrication_error(e),
                     ApiMessage::RecipesFetched(recipes) => state.recipes = recipes,
+                    ApiMessage::ProbeImprovementsFetched(improvements) => {
+                        state.probe_improvements = improvements;
+                    }
+                    ApiMessage::ImproveProbeStarted => {
+                        state.improve = ImproveInput::Inactive;
+                        state.set_toast("probe improvement started");
+                        fetch_all(client.clone(), tx.clone());
+                    }
+                    ApiMessage::ImproveProbeError(e) => state.set_improve_error(e),
                     ApiMessage::InspectStarted => {
                         state.inspect = InspectInput::Inactive;
                         state.set_toast("inspect order sent");

--- a/src/ui/overlays/improve.rs
+++ b/src/ui/overlays/improve.rs
@@ -1,0 +1,182 @@
+use crate::app::{AppState, ImproveInput};
+use crate::ui::theme::palette;
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
+
+/// Render whichever step of the probe-improvement wizard is active.
+pub(crate) fn render_improve_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
+    match state.improve {
+        ImproveInput::PickImprovement { selection, ref error } => {
+            render_catalog(frame, area, state, selection, error.as_deref());
+        }
+        ImproveInput::PickBuilder { ref improvement_name, ref mannies, selection, ref error, .. } => {
+            let p = palette(state.color_mode);
+            let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
+            let prompt = format!("Install {improvement_name} with:");
+            let height = (names.len() as u16 + 6).clamp(8, 20);
+            render_pick_list(
+                frame, area, p, " IMPROVE PROBE — SELECT BUILDER ", 48, height,
+                Some(&prompt), &names, selection, error.as_deref(), "BUILD",
+            );
+        }
+        ImproveInput::Inactive => {}
+    }
+}
+
+/// Two-panel catalog: the improvement list on the left, the selected one's
+/// detail (status, duration, ingredient have/need, description) on the right.
+fn render_catalog(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AppState,
+    selection: usize,
+    error: Option<&str>,
+) {
+    let p = palette(state.color_mode);
+    let items = &state.probe_improvements;
+    let sel = items.get(selection);
+
+    let popup = centered_rect(72, area.height.saturating_sub(6).clamp(10, 22), area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" IMPROVE PROBE ".to_owned())
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(p.accent));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+    let panels = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
+        .split(layout[0]);
+
+    let dim = Style::default().fg(p.dim);
+    let text = Style::default().fg(p.text);
+
+    // ── Left: the improvement list.
+    let mut lines: Vec<Line> = Vec::new();
+    if items.is_empty() {
+        lines.push(Line::from(Span::styled("loading…", dim)));
+    }
+    for (i, imp) in items.iter().enumerate() {
+        let selected = i == selection;
+        let (mark, mark_color) = if imp.done {
+            ("✓", p.good)
+        } else if imp.available && state.improvement_affordable(imp) {
+            ("○", p.accent)
+        } else {
+            ("·", p.dim)
+        };
+        let name_style = if selected {
+            Style::default().fg(p.text).add_modifier(Modifier::BOLD)
+        } else if imp.done {
+            dim
+        } else {
+            text
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if selected { " ▶ " } else { "   " }, Style::default().fg(p.accent)),
+            Span::styled(format!("{mark} "), Style::default().fg(mark_color)),
+            Span::styled(imp.name.clone(), name_style),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(lines), panels[0]);
+
+    // ── Right: detail of the selected improvement.
+    let detail_block = Block::default()
+        .borders(Borders::LEFT)
+        .border_style(Style::default().fg(p.dim));
+    let detail_area = detail_block.inner(panels[1]);
+    frame.render_widget(detail_block, panels[1]);
+
+    let mut detail: Vec<Line> = Vec::new();
+    if let Some(imp) = sel {
+        detail.push(Line::from(Span::styled(
+            imp.name.clone(),
+            Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+        )));
+        let status = if imp.done {
+            Span::styled("already installed", Style::default().fg(p.good))
+        } else if !imp.available {
+            Span::styled("locked", Style::default().fg(p.warn))
+        } else {
+            Span::styled(format!("⏲ {} min", imp.duration_seconds / 60), dim)
+        };
+        detail.push(Line::from(status));
+        detail.push(Line::default());
+        detail.push(Line::from(Span::styled("INGREDIENTS   have/need", dim)));
+        for ing in &imp.ingredients {
+            let have = state.recipe_ingredient_have(ing);
+            let ok = have >= ing.quantity;
+            let (need, have_str) = if ing.unit == "item" {
+                (format!("{}", ing.quantity as u32), format!("{}", have as u32))
+            } else {
+                (format!("{:.2}", ing.quantity), format!("{have:.2}"))
+            };
+            detail.push(Line::from(vec![
+                Span::styled(if ok { "✓ " } else { "✗ " }, Style::default().fg(if ok { p.good } else { p.crit })),
+                Span::styled(format!("{:<19}", ing.ingredient_type), text),
+                Span::styled(format!("{have_str}/{need}"), Style::default().fg(if ok { p.text } else { p.crit })),
+            ]));
+        }
+        detail.push(Line::default());
+        for line in wrap(&imp.description, detail_area.width as usize) {
+            detail.push(Line::from(Span::styled(line, dim)));
+        }
+    }
+    if let Some(err) = error {
+        detail.push(Line::default());
+        detail.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+    }
+    frame.render_widget(Paragraph::new(detail), detail_area);
+
+    // Footer — Enter dimmed unless the selected improvement can be installed now.
+    let can = sel.map(|i| i.available && !i.done && state.improvement_affordable(i)).unwrap_or(false);
+    let commit = if can {
+        FooterKey::commit("[Enter]", "INSTALL")
+    } else {
+        FooterKey { key: "[Enter]", label: "INSTALL", tone: KeyTone::Disabled }
+    };
+    render_footer(frame, layout[1], p, &[
+        FooterKey::nav("[↑/↓]", "select"),
+        commit,
+        FooterKey::nav("[Esc]", "cancel"),
+    ]);
+}
+
+/// Greedy word-wrap to `width` columns (right detail panel is narrow).
+fn wrap(s: &str, width: usize) -> Vec<String> {
+    if width < 4 {
+        return vec![s.to_string()];
+    }
+    let mut lines = Vec::new();
+    let mut cur = String::new();
+    for word in s.split_whitespace() {
+        if cur.is_empty() {
+            cur = word.to_string();
+        } else if cur.chars().count() + 1 + word.chars().count() <= width {
+            cur.push(' ');
+            cur.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut cur));
+            cur = word.to_string();
+        }
+    }
+    if !cur.is_empty() {
+        lines.push(cur);
+    }
+    lines
+}
+

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod containers;
 pub(crate) mod craft;
 pub(crate) mod drop_container;
 pub(crate) mod help;
+pub(crate) mod improve;
 pub(crate) mod inventory_detail;
 pub(crate) mod jettison;
 pub(crate) mod map;
@@ -22,6 +23,7 @@ pub(crate) mod waypoints;
 pub(crate) use alerts::render_alerts_overlay;
 pub(crate) use containers::{render_container_rules_overlay, render_rename_container_overlay};
 pub(crate) use craft::render_fabrication_overlay;
+pub(crate) use improve::render_improve_overlay;
 pub(crate) use drop_container::render_drop_container_overlay;
 pub(crate) use help::{help_row_count, render_help_overlay};
 pub(crate) use inventory_detail::render_inventory_detail_overlay;
@@ -46,7 +48,7 @@ pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
 
 use crate::app::{
-    AlertsInput, AppState, ContainerRulesInput, FabricationInput, DeployInput,
+    AlertsInput, AppState, ContainerRulesInput, FabricationInput, ImproveInput, DeployInput,
     DetachInput, DropCargoInput, DropStorageContainerInput, GotoVisitedInput, InspectInput,
     JettisonInput, MessagesInput, MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput,
     RecallInput, RecoverInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput,
@@ -80,6 +82,7 @@ const WIZARD_OVERLAYS: &[(OverlayGuard, OverlayRender)] = &[
     (|s| !matches!(s.remote_mine, RemoteMineInput::Inactive), render_remote_mine_overlay),
     (|s| !matches!(s.jettison, JettisonInput::Inactive), render_jettison_overlay),
     (|s| !matches!(s.fabrication, FabricationInput::Inactive), render_fabrication_overlay),
+    (|s| !matches!(s.improve, ImproveInput::Inactive), render_improve_overlay),
     (|s| !matches!(s.salvage, SalvageInput::Inactive), render_salvage_overlay),
     (|s| !matches!(s.recall, RecallInput::Inactive), render_recall_overlay),
     (|s| !matches!(s.refuel, RefuelInput::Inactive), render_refuel_overlay),

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -2,7 +2,7 @@ use neumann_cockpit::api::types::{
     AlertPhase, AlertStatus, AlertType, ContainerInventory, CraftingRecipe, DamageWarningRule,
     DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask, Mission, MissionStatus,
     EndpointId, MannyTaskVisibility, MessageStatus, MissionStepStatus, MovementPhase, Probe,
-    ProbeMessage, ScutNetwork, ScutRelayStatus, SectorObject,
+    ProbeImprovement, ProbeMessage, ScutNetwork, ScutRelayStatus, SectorObject,
     ProbeAlert, ProbeInventory, ProbeMovement, ProbeStatus, SectorObjectType, SectorObservation,
     SensorMode, StorageContainer,
 };
@@ -794,4 +794,25 @@ fn alert_manny_report_with_payload() {
     assert_eq!(a.phase, AlertPhase::MannyReport);
     let report = a.report.expect("report payload");
     assert_eq!(report.object_id.as_deref(), Some("dc-1"));
+}
+
+// ── ProbeImprovement (API v67+) ────────────────────────────────────────────────
+
+#[test]
+fn probe_improvement_deserializes() {
+    let imp: ProbeImprovement = deser(
+        r#"{"id":"deuterium_compression","name":"Deuterium compression",
+            "description":"Compresses the tank to hold 200% fuel.",
+            "available":true,"done":false,"durationSeconds":300,
+            "ingredients":[
+                {"type":"electric_motor","quantity":1,"unit":"item","kind":"item"},
+                {"type":"steel_bar","quantity":2,"unit":"item","kind":"item"}],
+            "effects":{"maxDeuteriumPercent":200}}"#,
+    );
+    assert_eq!(imp.id, "deuterium_compression");
+    assert!(imp.available && !imp.done);
+    assert_eq!(imp.duration_seconds, 300);
+    assert_eq!(imp.ingredients.len(), 2);
+    assert_eq!(imp.ingredients[0].ingredient_type, "electric_motor");
+    assert!(imp.effects.is_some());
 }


### PR DESCRIPTION
## Context

Second slice of the v63→v71 catch-up: the **probe-improvement** gameplay feature (server API v67/v69). Builds on Lot A (#161) which added the `MannyTask::ImprovingProbe` variant and type drift.

## Changes

- **Endpoints**: `GET /api/probe/probe-improvements-available` (fetched non-fatally in `fetch_all`) and `POST /api/probe/mannies/{id}/improve-probe`.
- **Type**: `ProbeImprovement` (id, name, description, available, done, durationSeconds, ingredients, effects). Ingredient shape reuses `CraftingRecipeIngredient`.
- **Wizard** (`ImproveInput`): `PickImprovement` → `PickBuilder`. Two-panel catalog overlay (list + detail: status/duration/ingredient have-need/description). Picking resolves the installing Manny — auto for a single idle one, else a builder picker.
- **Launcher**: "Improve probe…" in the Probe pane menu, enabled only when an unlocked, not-yet-done improvement exists.

Known catalog (from the server): `deuterium_compression` (1 electric_motor + 2 steel_bar → deuterium tank 200%) and `reinforced_container_couplings` (1 integrated_circuit + 0.4 ECE carbon → ignores 5 extra containers in break-risk).

## Tests

235 passing, clippy clean. Added: `ProbeImprovement` serde, `has_orderable_improvement` gating, probe-menu enablement, and a menu→dispatch→picker integration test.

## Next

Lot C — migrate the deprecated `inspect-asteroid` to `inspect-sector-object` and handle `dormant_construct` (inspecting one unlocks an improvement, tying back to this PR).