### PR TITLE
feat(api): inspect-sector-object + dormant constructs (API v71 Lot C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,12 +122,12 @@ One unified phosphor theme (there is no classic/retro split any more). `theme.rs
 The four reused panels (Probe / Inventory / Scanner / Mannies) keep their internal content colours; gauge colors: green > 50 %, yellow 25–50 %, red < 25 %. Movement progress is derived from `started_at` / `arrival_at` client-side. Scanner history shows symbol + coords + distance and scrolls with the selection.
 
 **Overlays** (wizards, rendered on top of the grid; launched from the contextual menu or the reused panels):
-- **Mannies pane menu** (`Enter`) — Fabricate, Mine, Repair, Salvage, Inspect, Recover/Detach container, Refill deuterium, Drop cargo, Recall/Abandon, Rename. Each launches its wizard (`*Input`). Fabricate opens the unified catalog with the selected Manny pre-chosen as builder. Remote mine (SCUT-reachable manny) fetches the manny's sector first, then picks asteroid → resources/amount → mandatory detached container. Recall on a SCUT-remote manny is labelled **abandon**.
+- **Mannies pane menu** (`Enter`) — Fabricate, Mine, Repair, Salvage, Inspect, Recover/Detach container, Refill deuterium, Drop cargo, Recall/Abandon, Rename. Each launches its wizard (`*Input`). Fabricate opens the unified catalog with the selected Manny pre-chosen as builder. Inspect (`inspect-sector-object`, API v65) targets any inspectable object — asteroid, dormant construct, or detached container (`collect_inspectable_candidates`). Remote mine (SCUT-reachable manny) fetches the manny's sector first, then picks asteroid → resources/amount → mandatory detached container. Recall on a SCUT-remote manny is labelled **abandon**.
 - **Inventory pane menu** (`Enter`) — Fabricate, Move stock, Jettison, and **Deploy waypoint…** (only when a `waypoint_bookmark` is held; picks the installing Manny → sector target → name, firing `install-bookmark`). Fabricate opens the unified catalog with no builder pre-chosen.
 - **Missions pane** (`Enter`) — active-mission list with steps/status; abandon (confirmation).
 - **Comms pane** (`Enter`) — messaging inbox/sent (mark read, compose to a probe/planet recipient); alerts + damage-warnings live in the same pane.
 - **Storage pane** (`Enter`) — container browser with capacity bars; content view, rename, routing-rules editor (none → priority → exclusion → strict).
-- **Sector pane** (`Enter` on an object) — object-action picker (mine / inspect / salvage / recover / deploy waypoint); an inactive `scut_relay` offers **turn on relay** (needs a star + integrated_circuit) and salvage.
+- **Sector pane** (`Enter` on an object) — object-action picker (mine / inspect / salvage / recover / deploy waypoint); inspect is offered on asteroids, **dormant constructs**, and detached containers; an inactive `scut_relay` offers **turn on relay** (needs a star + integrated_circuit) and salvage.
 - **Map pane** — compact summary; `z` opens the full isometric map (pan `hjkl`, `g` travel to the centred sector, `c` coordinate center). `Enter` menu: open map, **Travel to coordinates…**, **Jump to visited sector…** (picker over `visited_sectors`), **Waypoints…** (picker over bookmarks/stars/mineable targets). Scanner `Enter` also offers **Travel here** to the selected observation.
 - **Travel** wizard — coordinate input (absolute, or relative with a leading `+`), live parity check, fuel/ETA preview + confirmation. Launched from Map/Scanner or `:travel`.
 - **Probe pane menu** (`Enter`) — **Inspect SCUT network…** (enabled when a SCUT relay covers the current sector; auto-views the sole network or picks among several via `scut-network/{id}`), **Improve probe…** (enabled when an unlocked, not-yet-done improvement exists; two-panel catalog → resolve the installing Manny → `improve-probe`), plus **Reassign mind snapshot** only when the probe is dead or trapped by a black hole (`probe.alert`); reassigns the snapshot to a fresh probe. Improvements are fetched in `fetch_all` (`ProbeImprovement`).
@@ -159,7 +159,7 @@ The four reused panels (Probe / Inventory / Scanner / Mannies) keep their intern
 | `/api/probe/mannies/{id}/recall` | POST | ✓ |
 | `/api/probe/mannies/{id}` | PATCH | ✓ (rename) |
 | `/api/probe/mannies/{id}/install-bookmark` | POST | ✓ |
-| `/api/probe/mannies/{id}/inspect-asteroid` | POST | ✓ |
+| `/api/probe/mannies/{id}/inspect-sector-object` | POST | ✓ |
 | `/api/probe/mannies/{id}/recover-storage-container` | POST | ✓ |
 | `/api/probe/mannies/{id}/detach-storage-container` | POST | ✓ |
 | `/api/probe/mannies/{id}/drop-manny-cargo` | POST | ✓ |

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -433,13 +433,15 @@ impl ApiClient {
         Ok(self.post::<Resp, _>(&path, &Body { container_id, mode, object_id }).await?.manny)
     }
 
-    pub async fn inspect_asteroid(&self, manny_id: &str, object_id: &str) -> Result<Manny> {
+    /// Inspect a sector object (asteroid, dormant construct, or detached
+    /// container). Replaces the deprecated `inspect-asteroid` endpoint (API v65).
+    pub async fn inspect_sector_object(&self, manny_id: &str, object_id: &str) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct Body<'a> { object_id: &'a str }
         #[derive(Deserialize)]
         struct Resp { manny: Manny }
-        let path = format!("/api/probe/mannies/{manny_id}/inspect-asteroid");
+        let path = format!("/api/probe/mannies/{manny_id}/inspect-sector-object");
         Ok(self.post::<Resp, _>(&path, &Body { object_id }).await?.manny)
     }
 

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -381,7 +381,7 @@ pub fn fetch_deploy(manny_id: String, object_id: String, name: String, client: A
 
 pub fn fetch_inspect(manny_id: String, object_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     tokio::spawn(async move {
-        let msg = match client.inspect_asteroid(&manny_id, &object_id).await {
+        let msg = match client.inspect_sector_object(&manny_id, &object_id).await {
             Ok(_) => ApiMessage::InspectStarted,
             Err(e) => ApiMessage::InspectError(e.to_string()),
         };

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -509,7 +509,7 @@ pub enum JettisonInput {
 pub enum InspectInput {
     #[default]
     Inactive,
-    PickAsteroid {
+    PickTarget {
         manny_id: String,
         manny_name: String,
         candidates: Vec<(String, String)>,

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -202,6 +202,30 @@ impl AppState {
         }
     }
 
+    /// Objects a Manny can inspect in the probe's current sector (API v65):
+    /// asteroids plus top-level dormant constructs and detached containers.
+    pub fn collect_inspectable_candidates(&self) -> Vec<(String, String)> {
+        let Some(sector) = self.probe_current_sector_scan() else { return Vec::new() };
+        let mut out = self.collect_asteroid_candidates_in(sector);
+        if let Some(objects) = sector.objects.as_ref() {
+            for o in objects {
+                let inspectable = matches!(
+                    o.object_type,
+                    SectorObjectType::DormantConstruct | SectorObjectType::DetachedContainer
+                );
+                if !inspectable {
+                    continue;
+                }
+                if let Some(id) = &o.id {
+                    if out.iter().all(|(existing, _)| existing != id) {
+                        out.push((id.clone(), o.name.clone().unwrap_or_else(|| "unnamed".into())));
+                    }
+                }
+            }
+        }
+        out
+    }
+
     pub fn collect_asteroid_candidates_in(
         &self,
         sector: &crate::api::types::SectorObservation,
@@ -313,7 +337,7 @@ impl AppState {
     }
 
     pub fn set_inspect_error(&mut self, msg: String) {
-        if let InspectInput::PickAsteroid { ref mut error, .. } = self.inspect {
+        if let InspectInput::PickTarget { ref mut error, .. } = self.inspect {
             *error = Some(msg);
         } else {
             // Inspect was dispatched without the picker overlay (single

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -264,6 +264,10 @@ impl AppState {
             }
             (ObjectProvenance::TopLevel, SectorObjectType::DetachedContainer) => {
                 actions.push(ObjectAction::Recover);
+                actions.push(ObjectAction::Inspect);
+            }
+            (ObjectProvenance::TopLevel, SectorObjectType::DormantConstruct) => {
+                actions.push(ObjectAction::Inspect);
             }
             // An inactive relay (status != On) can be turned on or salvaged.
             (ObjectProvenance::TopLevel, SectorObjectType::ScutRelay)

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1156,8 +1156,28 @@ fn actions_for_object_by_kind() {
     assert_eq!(state.actions_for_object(&entries[1]), vec![ObjectAction::Mine]);
     // manny wreck: salvage
     assert_eq!(state.actions_for_object(&entries[2]), vec![ObjectAction::Salvage]);
-    // detached container: recover
-    assert_eq!(state.actions_for_object(&entries[3]), vec![ObjectAction::Recover]);
+    // detached container: recover + inspect (API v65 lets a Manny inspect it)
+    assert_eq!(state.actions_for_object(&entries[3]), vec![ObjectAction::Recover, ObjectAction::Inspect]);
+}
+
+#[test]
+fn dormant_construct_offers_inspect() {
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+        {"id": "dc-1", "type": "dormant_construct", "name": "Relic",
+         "estimated": null, "summary": null, "mass": null, "massUnit": null,
+         "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+         "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+         "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+         "capacity": null, "capacityUnit": null,
+         "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []}
+    ]"#)];
+    let entries = state.scanner_objects();
+    assert_eq!(state.actions_for_object(&entries[0]), vec![ObjectAction::Inspect]);
+    // …and it shows up as an inspectable candidate for the Mannies-pane flow.
+    let cands = state.collect_inspectable_candidates();
+    assert!(cands.iter().any(|(id, _)| id == "dc-1"), "dormant construct is inspectable");
 }
 
 #[test]

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -449,14 +449,14 @@ fn fire_menu_action(
             }
         }
         MenuAction::Inspect if can => {
-            let candidates = state.collect_asteroid_candidates();
+            let candidates = state.collect_inspectable_candidates();
             match candidates.len() {
-                0 => state.error = Some("no asteroids in current sector — scan first".into()),
+                0 => state.error = Some("no inspectable objects in current sector — scan first".into()),
                 1 => {
                     let (object_id, _) = candidates.into_iter().next().unwrap();
                     fetch_inspect(id, object_id, client.clone(), tx.clone());
                 }
-                _ => state.inspect = InspectInput::PickAsteroid { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
+                _ => state.inspect = InspectInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
             }
         }
         MenuAction::Recover if can => {

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -286,7 +286,7 @@ pub(super) fn handle_inspect_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if let InspectInput::PickAsteroid { selection, candidates, .. } = &mut state.inspect {
+    if let InspectInput::PickTarget { selection, candidates, .. } = &mut state.inspect {
         if list_move(code, selection, candidates.len()) {
             return;
         }
@@ -295,7 +295,7 @@ pub(super) fn handle_inspect_event(
         KeyCode::Esc => state.inspect = InspectInput::Inactive,
         KeyCode::Enter => {
             let (manny_id, object_id) = {
-                let InspectInput::PickAsteroid { ref manny_id, ref candidates, selection, .. } = state.inspect else { return };
+                let InspectInput::PickTarget { ref manny_id, ref candidates, selection, .. } = state.inspect else { return };
                 (manny_id.clone(), candidates[selection].0.clone())
             };
             fetch_inspect(manny_id, object_id, client.clone(), tx.clone());

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -396,12 +396,12 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
 pub(crate) fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let InspectInput::PickAsteroid { ref manny_name, ref candidates, selection, ref error, .. } = state.inspect else { return };
+    let InspectInput::PickTarget { ref manny_name, ref candidates, selection, ref error, .. } = state.inspect else { return };
     let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     render_pick_list(frame, area, p, &format!(" INSPECT — {manny_name} "), 52, height,
-        Some("Select asteroid to inspect:"), &names, selection, error.as_deref(), "INSPECT");
+        Some("Select object to inspect:"), &names, selection, error.as_deref(), "INSPECT");
 }
 
 pub(crate) fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {


### PR DESCRIPTION
## Context

Final slice of the v63→v71 catch-up. Server API v65 deprecated `inspect-asteroid` in favour of `inspect-sector-object`, which accepts asteroids, **dormant constructs** (new v64 object), and detached containers. Builds on Lot A (#161, the `DormantConstruct` type) and Lot B (#163) — inspecting a dormant construct unlocks a probe improvement, closing the loop.

## Changes

- **client**: `inspect_asteroid` → `inspect_sector_object` (`POST /api/probe/mannies/{id}/inspect-sector-object`).
- **candidates**: new `collect_inspectable_candidates` — asteroids + top-level dormant constructs + detached containers (the set the server accepts). The Mannies-pane "Inspect…" uses it instead of the asteroid-only list.
- **Sector object-action menu**: Inspect is now offered on dormant constructs and detached containers (containers show **Recover + Inspect**).
- **rename**: `InspectInput::PickAsteroid` → `PickTarget`; overlay prompt "Select object to inspect".

## Tests

236 passing, clippy clean. Added `actions_for_object` cases for dormant construct + detached container, and a `collect_inspectable_candidates` check.

## v71 catch-up complete

Lot A (types, #161) · Lot B (probe improvements, #163) · Lot C (this). Remaining optional Lot D: type `MannyMiningTask` for artificial-object detection, message spatial provenance. Out of scope: forum + auth.