### PR TITLE
fix(pickers): numbered asteroid rows with reserves and danger

### DIFF
--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -1,6 +1,10 @@
-use crate::api::types::{ScutRelayStatus, SectorObjectType, SectorObservation};
+use crate::api::types::{DangerLevel, ScutRelayStatus, SectorObjectType, SectorObservation};
 use chrono::Utc;
 use super::*;
+
+/// Reserves (presence flags + amounts, indexed as [`RESOURCE_TYPES`]) paired
+/// with the danger level for a sector object — the inputs a pick-row label needs.
+pub type ObjectPickInfo = (Option<([bool; 4], [f64; 4])>, Option<DangerLevel>);
 
 /// Cyclic filter applied to the scan history list ([f] in the scanner).
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -173,6 +177,40 @@ impl AppState {
             }
         }
         None
+    }
+
+    /// Danger level for an object in `sector`, matched by top-level id or by a
+    /// nested mining-target id (which inherits its parent object's danger).
+    /// `None` when the object is absent from the scan or carries no danger.
+    fn danger_in(sector: &SectorObservation, object_id: &str) -> Option<DangerLevel> {
+        let objs = sector.objects.as_ref()?;
+        for o in objs {
+            if o.id.as_deref() == Some(object_id)
+                || o.minable_targets.iter().flatten().any(|t| t.id == object_id)
+            {
+                return o.danger_level.clone();
+            }
+        }
+        None
+    }
+
+    /// Reserves + danger for an object id in the probe's current sector scan,
+    /// used by the shared pick-row label. `(None, None)` when not scanned.
+    pub fn probe_object_pick_info(&self, object_id: &str) -> ObjectPickInfo {
+        match self.probe_current_sector_scan() {
+            Some(s) => (Self::reserves_in(s, object_id), Self::danger_in(s, object_id)),
+            None => (None, None),
+        }
+    }
+
+    /// Same as [`probe_object_pick_info`] but for a specific sector by
+    /// coordinates — used by the remote-mine picker (asteroid in a SCUT-reachable
+    /// sector, not the probe's own).
+    pub fn sector_object_pick_info(&self, x: i32, y: i32, z: i32, object_id: &str) -> ObjectPickInfo {
+        match self.sector_observation_at(x, y, z) {
+            Some(s) => (Self::reserves_in(s, object_id), Self::danger_in(s, object_id)),
+            None => (None, None),
+        }
     }
 
     /// Max sensible mining amount for the selected resources: the sum of their

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -9,27 +9,11 @@ use ratatui::{
 
 use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
-/// A mining-target picker row: `#n [name]  metals 1.20  ice 0.55 …`, listing
-/// each present resource (by its full label) with its remaining reserve when
-/// known.
+/// A mining-target picker row: `#n [name][ danger]  metals 1.20  ice 0.55 …`.
+/// Thin wrapper over the shared [`super::probe_object_label`] so every
+/// asteroid/object picker renders identically.
 fn asteroid_label(state: &AppState, index: usize, id: &str, name: &str) -> String {
-    let mut label = format!("#{}", index + 1);
-    if name != "unnamed" {
-        label.push_str(&format!(" {name}"));
-    }
-    if let Some((flags, res)) = state.probe_minable_reserves(id) {
-        for (k, &res_label) in RESOURCE_LABELS.iter().enumerate() {
-            if !flags[k] {
-                continue;
-            }
-            if res[k] > 0.0 {
-                label.push_str(&format!("  {res_label} {:.2}", res[k]));
-            } else {
-                label.push_str(&format!("  {res_label}"));
-            }
-        }
-    }
-    label
+    super::probe_object_label(state, index, id, name)
 }
 
 pub(crate) fn estimate_mine_duration(target_amount: f64) -> (i64, i64) {

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -53,8 +53,9 @@ use crate::app::{
     JettisonInput, MessagesInput, MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput,
     RecallInput, RecoverInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput,
     RepairInput, SalvageInput, ScanMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput,
-    TravelInput, WaypointsInput,
+    TravelInput, WaypointsInput, RESOURCE_LABELS,
 };
+use crate::api::types::DangerLevel;
 use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -193,6 +194,63 @@ pub(crate) fn render_footer(frame: &mut Frame, area: Rect, p: Palette, keys: &[F
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
+/// Format a sector-object pick row shared by every asteroid/object picker:
+/// `#n [name][ ⚠/☠]  metals 1.20  ice 0.55 …`. The name is dropped when it is a
+/// bare "unnamed" placeholder; danger and per-resource reserves are appended
+/// when known. Mirrors the Sector-pane object line so pickers read the same.
+pub(crate) fn object_pick_label(
+    index: usize,
+    name: &str,
+    reserves: Option<([bool; 4], [f64; 4])>,
+    danger: Option<&DangerLevel>,
+) -> String {
+    let mut label = format!("#{}", index + 1);
+    let name = name.trim();
+    if !name.is_empty() && name != "unnamed" {
+        label.push_str(&format!(" {name}"));
+    }
+    match danger {
+        Some(DangerLevel::Moderate) => label.push_str(" ⚠"),
+        Some(DangerLevel::Extreme) => label.push_str(" ☠"),
+        _ => {}
+    }
+    if let Some((flags, res)) = reserves {
+        for (k, &res_label) in RESOURCE_LABELS.iter().enumerate() {
+            if !flags[k] {
+                continue;
+            }
+            if res[k] > 0.0 {
+                label.push_str(&format!("  {res_label} {:.2}", res[k]));
+            } else {
+                label.push_str(&format!("  {res_label}"));
+            }
+        }
+    }
+    label
+}
+
+/// `object_pick_label` resolving reserves + danger from the probe's current
+/// sector — for pickers targeting objects here (mine, detach, inspect, deploy).
+pub(crate) fn probe_object_label(state: &AppState, index: usize, id: &str, name: &str) -> String {
+    let (reserves, danger) = state.probe_object_pick_info(id);
+    object_pick_label(index, name, reserves, danger.as_ref())
+}
+
+/// `object_pick_label` resolving from a specific sector by coordinates — for the
+/// remote-mine picker, whose asteroid lives in a SCUT-reachable sector.
+pub(crate) fn sector_object_label(
+    state: &AppState,
+    x: i32,
+    y: i32,
+    z: i32,
+    index: usize,
+    id: &str,
+    name: &str,
+) -> String {
+    let (reserves, danger) = state.sector_object_pick_info(x, y, z, id);
+    object_pick_label(index, name, reserves, danger.as_ref())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn render_pick_list(
     frame: &mut Frame,
@@ -260,9 +318,29 @@ pub(crate) fn render_pick_list(
 
 #[cfg(test)]
 mod tests {
-    use super::render_active_overlays;
+    use super::{object_pick_label, render_active_overlays, DangerLevel};
     use crate::app::{AppState, TravelInput};
     use ratatui::{backend::TestBackend, Terminal};
+
+    #[test]
+    fn object_pick_label_drops_placeholder_and_appends_danger_then_reserves() {
+        // Unnamed asteroid, extreme danger, deuterium + metals reserves.
+        let reserves = Some(([true, true, false, false], [0.42, 1.20, 0.0, 0.0]));
+        assert_eq!(
+            object_pick_label(0, "unnamed", reserves, Some(&DangerLevel::Extreme)),
+            "#1 ☠  deuterium 0.42  metals 1.20",
+        );
+        // Named target, moderate danger, present resource with unknown amount.
+        let reserves = Some(([false, true, false, false], [0.0; 4]));
+        assert_eq!(
+            object_pick_label(1, "Big Rock", reserves, Some(&DangerLevel::Moderate)),
+            "#2 Big Rock ⚠  metals",
+        );
+        // Non-asteroid (no reserves), no danger → bare numbered name.
+        assert_eq!(object_pick_label(2, "dormant construct", None, None), "#3 dormant construct");
+        // Low/Unknown danger adds no glyph.
+        assert_eq!(object_pick_label(0, "", None, Some(&DangerLevel::Low)), "#1");
+    }
 
     /// Render the overlays over a blank terminal and return all cell text.
     fn rendered_text(state: &AppState) -> String {

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -347,7 +347,9 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         }
 
         DeployInput::PickObject { candidates, selection, .. } => {
-            let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
+            let labels: Vec<String> = candidates.iter().enumerate()
+                .map(|(i, (id, n))| super::probe_object_label(state, i, id, n)).collect();
+            let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(18);
             render_pick_list(frame, area, p, " DEPLOY WAYPOINT ", 52, height,
                 None, &names, *selection, None, "confirm");
@@ -397,7 +399,9 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 pub(crate) fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
     let InspectInput::PickTarget { ref manny_name, ref candidates, selection, ref error, .. } = state.inspect else { return };
-    let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
+    let labels: Vec<String> = candidates.iter().enumerate()
+        .map(|(i, (id, n))| super::probe_object_label(state, i, id, n)).collect();
+    let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     render_pick_list(frame, area, p, &format!(" INSPECT — {manny_name} "), 52, height,
@@ -432,7 +436,9 @@ pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         }
 
         DetachInput::PickAsteroid { manny_name, container_name, asteroids, selection, error, .. } => {
-            let names: Vec<&str> = asteroids.iter().map(|(_, n)| n.as_str()).collect();
+            let labels: Vec<String> = asteroids.iter().enumerate()
+                .map(|(i, (id, n))| super::probe_object_label(state, i, id, n)).collect();
+            let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (asteroids.len() as u16 + 8).min(18);
             let prompt = format!("Attach to asteroid  (manny: {manny_name})");
             render_pick_list(frame, area, p, &format!(" DETACH — hide {container_name} "), 52, height,

--- a/src/ui/overlays/remote_mine.rs
+++ b/src/ui/overlays/remote_mine.rs
@@ -38,8 +38,10 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
             render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc]", "cancel")]);
         }
 
-        RemoteMineInput::PickAsteroid { manny_name, candidates, selection, .. } => {
-            let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
+        RemoteMineInput::PickAsteroid { manny_name, candidates, selection, x, y, z, .. } => {
+            let labels: Vec<String> = candidates.iter().enumerate()
+                .map(|(i, (id, n))| super::sector_object_label(state, *x, *y, *z, i, id, n)).collect();
+            let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
             render_pick_list(
                 frame, area, palette(state.color_mode), &format!(" REMOTE MINE — {manny_name} "), 52, height,


### PR DESCRIPTION
## Problem

When detaching a storage container onto an asteroid, the asteroid picker rendered every entry as a bare `unnamed` with no distinguishing info. The rich "mine-style" label (`#n [name][ ⚠/☠]  resource amount`) existed only privately in the mine overlay.

## Change

Extract the formatter into a shared `object_pick_label` (in `src/ui/overlays/mod.rs`) plus reusable `(reserves, danger)` lookups in `src/app/scan.rs` (`probe_object_pick_info` for the current sector, `sector_object_pick_info` for a remote SCUT-reachable sector). Wire it into all four asteroid/object pickers:

- **DETACH** (the reported bug)
- **INSPECT**
- **DEPLOY WAYPOINT**
- **REMOTE MINE** (resolved against the remote sector's cached scan)

Objects with no reserves (dormant constructs, detached containers) fall back cleanly to `#n name`. Danger uses the same `⚠` / `☠` convention as the Scanner pane.

Display-only change — no API or data-model impact.

## Verification

`cargo check` / `cargo clippy` clean, `cargo test` → 240 passed (added a focused unit test for `object_pick_label`).