### PR TITLE
fix(sector): mine top-level (wandering) asteroids + ellipsize long names

### DIFF
--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -182,17 +182,30 @@ impl AppState {
     }
 
     pub fn collect_mineable_candidates(&self) -> Vec<(String, String)> {
-        let sector = self.probe_current_sector_scan();
-        sector
-            .and_then(|s| s.objects.as_ref())
-            .map(|objects| {
-                objects.iter()
-                    .flat_map(|o| o.minable_targets.iter().flatten())
-                    .filter(|t| matches!(t.object_type, SectorObjectType::Asteroid))
-                    .map(|t| (t.id.clone(), t.name.clone().unwrap_or_else(|| "unnamed".into())))
-                    .collect()
-            })
-            .unwrap_or_default()
+        let Some(sector) = self.probe_current_sector_scan() else { return Vec::new() };
+        let Some(objects) = sector.objects.as_ref() else { return Vec::new() };
+        let mut out: Vec<(String, String)> = Vec::new();
+        for o in objects {
+            // Asteroids nested under a parent object (e.g. a solar system).
+            for t in o.minable_targets.iter().flatten() {
+                if matches!(t.object_type, SectorObjectType::Asteroid)
+                    && !out.iter().any(|(id, _)| id == &t.id)
+                {
+                    out.push((t.id.clone(), t.name.clone().unwrap_or_else(|| "unnamed".into())));
+                }
+            }
+            // Standalone top-level asteroids (e.g. a wandering asteroid) carry no
+            // parent minableTargets, so they must be collected directly or they
+            // never reach the mine picker.
+            if matches!(o.object_type, SectorObjectType::Asteroid) {
+                if let Some(id) = &o.id {
+                    if !out.iter().any(|(i, _)| i == id) {
+                        out.push((id.clone(), o.name.clone().unwrap_or_else(|| "unnamed".into())));
+                    }
+                }
+            }
+        }
+        out
     }
 
     pub fn collect_asteroid_candidates(&self) -> Vec<(String, String)> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -790,6 +790,30 @@ fn collect_mineable_candidates_returns_asteroid_targets() {
 }
 
 #[test]
+fn collect_mineable_candidates_includes_top_level_asteroid() {
+    // A wandering asteroid is a standalone top-level object (type asteroid, no
+    // parent minableTargets) — it must still reach the mine picker.
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+        {
+            "id": "deuterium-asteroid-abc", "type": "asteroid",
+            "name": "Astéroïde contenant du Deutérium",
+            "estimated": false, "summary": "Wandering asteroid body.", "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": "low", "salvageable": null,
+            "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
+            "capacity": null, "capacityUnit": null, "mannyMineable": true,
+            "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
+        }
+    ]"#)];
+    let candidates = state.collect_mineable_candidates();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].0, "deuterium-asteroid-abc");
+    assert_eq!(candidates[0].1, "Astéroïde contenant du Deutérium");
+}
+
+#[test]
 fn deuterium_station_detected_in_current_sector() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(2., 0., -2.));

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -247,7 +247,14 @@ pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bo
     for (i, e) in objs.iter().enumerate() {
         let color = object_color(&e.object_type, p);
         let icon = object_icon(&e.object_type).0;
-        let name: String = e.name.chars().take(16).collect();
+        // Keep the compact row width bounded, but mark a cut name with an
+        // ellipsis so a long label (e.g. "Astéroïde contenant du Deutérium")
+        // reads as truncated rather than broken mid-word.
+        let name: String = if e.name.chars().count() > 16 {
+            e.name.chars().take(15).chain(std::iter::once('…')).collect()
+        } else {
+            e.name.clone()
+        };
         let mut spans = vec![
             Span::styled(format!("{icon} "), Style::default().fg(color)),
             Span::styled(name, row_style(active, i == cur).patch(text)),


### PR DESCRIPTION
## Symptoms (live game)
A wandering asteroid (`type: asteroid`, `name: "Astéroïde contenant du Deutérium"`, `mannyMineable: true`):
1. **Does not appear** in the Mannies mine menu.
2. Shows a **broken name** in the Sector pane: `Astéroïde conten`.

## Root causes
1. `collect_mineable_candidates` only walked the `minable_targets` nested under a parent object (e.g. a solar system's asteroids). A wandering asteroid is a standalone top-level object with no `minableTargets`, so it was never collected.
2. The compact Sector row hard-truncated the name to 16 chars with no ellipsis, cutting it mid-word.

## Fix
1. Also collect top-level objects whose `type` is `asteroid` (deduped by id), in addition to nested targets.
2. Add an ellipsis (`…`) when a name exceeds 16 chars — row width unchanged, but a cut name now reads as truncated.

## Notes
- Bug present on `main`, independent of the multi-probe feature (#180).
- Test added: `collect_mineable_candidates_includes_top_level_asteroid`. `cargo test` 243 pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)