### PR TITLE
feat(cockpit): unique per-probe sigil (identicon) in the Probe pane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,9 @@ One unified phosphor theme (there is no classic/retro split any more). `theme.rs
 
 ### UI (`src/ui/`)
 
-`ui::render` → `cockpit_v2::render(frame, state)` is the single render entry point. Module layout: `cockpit_v2/` (`mod.rs` entry point — grid layout, status bar, boot screen; `grid.rs` responsive window; `panes.rs` compact renderers for the five promoted panes; `menu.rs` contextual-menu popup), `panels/` (the four original panel renderers, reused by the grid: `probe`, `inventory`, `scanner`, `mannies`), `overlays/` (one file per wizard overlay; `pickers.rs` groups the manny pick-list/confirm ones, `containers.rs` the storage-container ones, plus `alerts.rs` / `storage_move.rs`; `mod.rs` hosts `centered_rect` + `render_pick_list`), `theme.rs`.
+`ui::render` → `cockpit_v2::render(frame, state)` is the single render entry point. Module layout: `cockpit_v2/` (`mod.rs` entry point — grid layout, status bar, boot screen; `grid.rs` responsive window; `panes.rs` compact renderers for the five promoted panes; `menu.rs` contextual-menu popup), `panels/` (the four original panel renderers, reused by the grid: `probe`, `inventory`, `scanner`, `mannies`), `overlays/` (one file per wizard overlay; `pickers.rs` groups the manny pick-list/confirm ones, `containers.rs` the storage-container ones, plus `alerts.rs` / `storage_move.rs`; `mod.rs` hosts `centered_rect` + `render_pick_list`), `theme.rs`, `sigil.rs`.
+
+**Probe sigil** (`src/ui/sigil.rs`, API v81) — `probe_sigil(id)` builds a deterministic 7×7 mirror-symmetric identicon (FNV-1a over the id, stable across runs — **not** the randomized default hasher; 7×4 = 28 free bits ≈ 268M patterns). `sigil_lines(id, palette, indent)` renders it as 4 half-block (`▀▄█`) lines in the accent colour. The Probe pane pins the **active probe's** sigil to its top-right corner, always visible in every mode/theme, so probes/drones are told apart at a glance (`panels/probe.rs`).
 
 **The grid** — a 3×3 tiling dashboard of nine panes, each addressable by a key in the `e r t / d f g / c v b` square (identical on AZERTY and QWERTY; centre `f` = Probe). Model: *navigate then act*.
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod cockpit_v2;
 pub(crate) mod overlays;
 pub(crate) mod panels;
 pub(crate) mod preflight;
+pub(crate) mod sigil;
 pub(crate) mod theme;
 
 use crate::app::AppState;

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -9,6 +9,7 @@ use ratatui::{
     Frame,
 };
 
+use crate::ui::sigil::sigil_lines;
 use crate::ui::theme::{
     block_gauge_line, format_duration, movement_phase_label, palette, pane_block, probe_status_label,
     probe_status_style, ratio_color,
@@ -189,4 +190,21 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     ]));
 
     frame.render_widget(Paragraph::new(lines), content);
+
+    // ── Sigil (API v81) ──
+    // The active probe's unique signature, pinned to the pane's top-right so you
+    // can tell probes apart at a glance — always visible, every mode/theme.
+    // Drawn last so it sits over the (short) identity lines; the top-right
+    // corner is otherwise free. Skipped only when the pane is too narrow/short.
+    const SIGIL_W: u16 = 7; // 7 cells wide
+    const SIGIL_H: u16 = 4; // 7 rows packed into 4 half-block lines
+    if content.width >= SIGIL_W + 10 && content.height >= SIGIL_H {
+        let corner = Rect {
+            x: content.x + content.width - SIGIL_W,
+            y: content.y,
+            width: SIGIL_W,
+            height: SIGIL_H,
+        };
+        frame.render_widget(Paragraph::new(sigil_lines(probe.id as u64, p, "")), corner);
+    }
 }

--- a/src/ui/sigil.rs
+++ b/src/ui/sigil.rs
@@ -1,0 +1,99 @@
+//! Probe sigil — a deterministic 7×7 identicon derived from a probe id, giving
+//! each probe (and drone) a unique visual signature that never changes.
+//!
+//! The pattern is a visual hash: FNV-1a over the id diffuses sequential ids
+//! (5, 6, 7…) into very different grids, and a plain multiplicative hash keeps
+//! it **stable across runs and platforms** — unlike the standard library's
+//! randomized default hasher, which would reshuffle every launch. The left four
+//! columns are mirrored onto the right, so the grid reads as a balanced
+//! identicon rather than noise, leaving 7×4 = 28 free bits (~268M patterns).
+
+use ratatui::{
+    style::Style,
+    text::{Line, Span},
+};
+
+use crate::ui::theme::Palette;
+
+/// Build the 7×7 mirror-symmetric grid for `id`. Deterministic and stable.
+pub(crate) fn probe_sigil(id: u64) -> [[bool; 7]; 7] {
+    // FNV-1a (64-bit): offset basis + prime.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in id.to_le_bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    let mut grid = [[false; 7]; 7];
+    let mut bit = 0u32;
+    for row in grid.iter_mut() {
+        for x in 0..4 {
+            let on = (h >> bit) & 1 == 1;
+            bit += 1;
+            row[x] = on;
+            row[6 - x] = on; // mirror onto the right half
+        }
+    }
+    grid
+}
+
+/// Render the sigil as terminal lines: two grid rows packed per text line with
+/// `▀▄█` half-blocks (so cells read roughly square), drawn in the palette
+/// accent. 7 grid rows collapse to 4 lines; `indent` prefixes each line.
+pub(crate) fn sigil_lines(id: u64, p: Palette, indent: &str) -> Vec<Line<'static>> {
+    let grid = probe_sigil(id);
+    let style = Style::default().fg(p.accent);
+    let mut lines = Vec::new();
+    let mut y = 0;
+    while y < 7 {
+        let top = grid[y];
+        let bot = if y + 1 < 7 { grid[y + 1] } else { [false; 7] };
+        let mut s = String::from(indent);
+        for x in 0..7 {
+            s.push(match (top[x], bot[x]) {
+                (true, true) => '█',
+                (true, false) => '▀',
+                (false, true) => '▄',
+                (false, false) => ' ',
+            });
+        }
+        lines.push(Line::from(Span::styled(s, style)));
+        y += 2;
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_deterministic() {
+        assert_eq!(probe_sigil(5), probe_sigil(5));
+        assert_eq!(probe_sigil(42), probe_sigil(42));
+    }
+
+    #[test]
+    fn is_mirror_symmetric() {
+        for id in [0u64, 5, 6, 42, 1000, u64::MAX] {
+            let g = probe_sigil(id);
+            for (y, row) in g.iter().enumerate() {
+                for x in 0..7 {
+                    assert_eq!(row[x], row[6 - x], "row {y} not mirrored at col {x}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn sequential_ids_differ() {
+        // FNV diffusion must make neighbouring ids look clearly different.
+        assert_ne!(probe_sigil(5), probe_sigil(6));
+        assert_ne!(probe_sigil(6), probe_sigil(7));
+    }
+
+    #[test]
+    fn renders_four_lines() {
+        let p = crate::ui::theme::palette(crate::app::ColorMode::MonoGreen);
+        assert_eq!(sigil_lines(5, p, "  ").len(), 4);
+    }
+}


### PR DESCRIPTION
## What
Every probe now has a **unique visual signature** — a small deterministic identicon — so probes and drones can be told apart at a glance.

`probe_sigil(id)` builds a **7×7 mirror-symmetric** grid from an **FNV-1a** hash of the probe id:
- FNV-1a diffuses sequential ids (5, 6, 7…) into very different patterns.
- Stable across runs and platforms — deliberately **not** the randomized default hasher, which would reshuffle every launch.
- Mirror symmetry (left 4 cols mirrored) → reads as an identicon, not noise. 7×4 = **28 free bits ≈ 268M patterns**.

`sigil_lines(id, palette, indent)` renders it as **4 half-block (`▀▄█`) lines** in the accent colour — square-ish cells, theme-consistent (works identically in every phosphor theme).

## Where
The Probe pane pins the **active probe's** sigil to its **top-right corner**, always visible in every mode and theme (skipped only when the pane is too small to fit it). As you switch probes, the corner mark changes.

## Example (real output)
```
probe #5            probe #6            probe #42
   ▄   ▄            ▀▀ ▄ ▀▀            ▀█████▀
  ▀▀█▄█▀▀           ▀▄▀▄▀▄▀            ▄▀▄█▄▀▄
  ▀▄█▀█▄▀           ██ ▀ ██            ▀  █  ▀
  ▀     ▀            ▀   ▀             ▀▀▀ ▀▀▀
```

## Notes
- Independent of gameplay endpoints — pure client-side rendering off the probe id.
- Tests: determinism, mirror symmetry, sequential-ids-differ, 4-line render. `cargo test` 259 pass, clippy clean.
- Not driven in a live TUI here (needs a terminal + API); the pattern generation is unit-tested and the placement mirrors existing pane rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)