### PR TITLE
fix: cockpit Phase 0 — deuterium, container hierarchy, mining ETA, jettison guard

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -435,6 +435,9 @@ pub struct ProbeSystems {
 #[serde(rename_all = "camelCase")]
 pub struct ProbeFuel {
     pub deuterium: Option<f64>,
+    /// Current effective deuterium tank maximum; 100 by default, higher after
+    /// probe improvements. Used to scale the FUEL gauge instead of a hardcoded 100.
+    pub max_deuterium: Option<f64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -551,6 +551,13 @@ pub enum JettisonInput {
         buf: String,
         error: Option<String>,
     },
+    /// Confirmation for the irreversible resource jettison (stock is lost).
+    Confirm {
+        item_id: String,
+        item_name: String,
+        amount: Option<f64>,
+        error: Option<String>,
+    },
 }
 
 #[derive(Default)]

--- a/src/app/inventory.rs
+++ b/src/app/inventory.rs
@@ -204,14 +204,11 @@ impl AppState {
         if ing.unit == "item" {
             probe.inventory.items.iter().filter(|it| it.item_type == ing.ingredient_type).count() as f64
         } else if ing.ingredient_type == "deuterium" {
-            // Deuterium lives in the fuel tank, not in resource_stocks, so a stock
-            // lookup always yields 0 (the recipe reads as unaffordable). Pragmatic
-            // stopgap: report the tank level so the ingredient shows as satisfied
-            // while the tank holds fuel. Note the unit mismatch — recipe cost is in
-            // ECE, the tank level is in tank units (0..max_deuterium) — and the
-            // ECE<->tank conversion isn't exposed by the API. Pending a question to
-            // the game author for an exact readout.
-            probe.fuel.deuterium.unwrap_or(0.0)
+            // Deuterium lives in the fuel tank, not in resource_stocks. The tank
+            // level is a percentage (0..max_deuterium) where 100% of a size-1 tank
+            // holds 1.0 ECE, so divide by 100 to get the ECE amount the recipe is
+            // costed in (scales with tank upgrades, since max_deuterium grows).
+            probe.fuel.deuterium.unwrap_or(0.0) / 100.0
         } else {
             probe
                 .inventory

--- a/src/app/inventory.rs
+++ b/src/app/inventory.rs
@@ -203,6 +203,15 @@ impl AppState {
         let Some(probe) = &self.probe else { return 0.0 };
         if ing.unit == "item" {
             probe.inventory.items.iter().filter(|it| it.item_type == ing.ingredient_type).count() as f64
+        } else if ing.ingredient_type == "deuterium" {
+            // Deuterium lives in the fuel tank, not in resource_stocks, so a stock
+            // lookup always yields 0 (the recipe reads as unaffordable). Pragmatic
+            // stopgap: report the tank level so the ingredient shows as satisfied
+            // while the tank holds fuel. Note the unit mismatch — recipe cost is in
+            // ECE, the tank level is in tank units (0..max_deuterium) — and the
+            // ECE<->tank conversion isn't exposed by the API. Pending a question to
+            // the game author for an exact readout.
+            probe.fuel.deuterium.unwrap_or(0.0)
         } else {
             probe
                 .inventory

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -235,6 +235,23 @@ impl AppState {
         }
     }
 
+    /// Whether a mining job's per-trip travel is deducted: true only when the
+    /// destination container is hidden on the very asteroid being mined (the
+    /// server charges miningTravelSeconds = 0). Mining to the probe or to a
+    /// container elsewhere keeps normal travel.
+    pub fn mining_travel_deducted(&self, asteroid_id: &str, container_id: &str) -> bool {
+        self.current_sector()
+            .and_then(|s| s.objects.as_ref())
+            .is_some_and(|objs| {
+                objs.iter().any(|o| {
+                    o.id.as_deref() == Some(container_id)
+                        && matches!(o.object_type, SectorObjectType::DetachedContainer)
+                        && o.mode.as_deref() == Some("hidden_on_asteroid")
+                        && o.target_object_id.as_deref() == Some(asteroid_id)
+                })
+            })
+    }
+
     pub fn scanner_objects(&self) -> Vec<ScannerObjectEntry> {
         if !self.viewing_probe_sector() {
             return vec![];

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -96,6 +96,9 @@ pub struct ScannerObjectEntry {
     pub name: String,
     pub object_type: SectorObjectType,
     pub provenance: ObjectProvenance,
+    /// True for a detached container hidden on a listed asteroid: the Sector
+    /// pane renders it indented under its host (set during hierarchy ordering).
+    pub attached: bool,
 }
 
 impl AppState {
@@ -252,6 +255,7 @@ impl AppState {
                     name: o.name.clone().unwrap_or_default(),
                     object_type: o.object_type.clone(),
                     provenance: ObjectProvenance::TopLevel,
+                    attached: false,
                 });
             }
             for t in o.minable_targets.iter().flatten() {
@@ -260,6 +264,7 @@ impl AppState {
                     name: t.name.clone().unwrap_or_default(),
                     object_type: t.object_type.clone(),
                     provenance: ObjectProvenance::MinableTarget,
+                    attached: false,
                 });
             }
             for t in &o.bookmark_targets {
@@ -269,6 +274,7 @@ impl AppState {
                         name: t.name.clone().unwrap_or_default(),
                         object_type: t.object_type.clone(),
                         provenance: ObjectProvenance::BookmarkTarget,
+                        attached: false,
                     });
                 }
             }
@@ -284,7 +290,60 @@ impl AppState {
                 e.name = format!("{label} #{n}");
             }
         }
-        out
+
+        // Reorder into an asteroid→hosted-container hierarchy: each host keeps
+        // its scan order and is immediately followed by the detached containers
+        // hidden on it; drifting containers (and any whose host isn't listed)
+        // sink to the bottom. `attached` marks the ones the pane indents.
+        let listed: std::collections::HashSet<String> = out.iter().map(|e| e.id.clone()).collect();
+        let host_of = |id: &str| -> Option<String> {
+            objects
+                .iter()
+                .find(|o| {
+                    o.id.as_deref() == Some(id)
+                        && matches!(o.object_type, SectorObjectType::DetachedContainer)
+                        && o.mode.as_deref() == Some("hidden_on_asteroid")
+                })
+                .and_then(|o| o.target_object_id.clone())
+        };
+        let is_container = |id: &str| -> bool {
+            objects.iter().any(|o| {
+                o.id.as_deref() == Some(id)
+                    && matches!(o.object_type, SectorObjectType::DetachedContainer)
+            })
+        };
+        let mut hosts: Vec<ScannerObjectEntry> = Vec::new();
+        let mut hosted: std::collections::HashMap<String, Vec<ScannerObjectEntry>> =
+            std::collections::HashMap::new();
+        let mut drifting: Vec<ScannerObjectEntry> = Vec::new();
+        for mut e in out.into_iter() {
+            match host_of(&e.id) {
+                Some(h) if listed.contains(&h) => {
+                    e.attached = true;
+                    hosted.entry(h).or_default().push(e);
+                }
+                // Hidden on an asteroid that isn't in this sector list, or a
+                // free-floating container: both go to the bottom.
+                Some(_) => drifting.push(e),
+                None if is_container(&e.id) => drifting.push(e),
+                None => hosts.push(e),
+            }
+        }
+        let mut ordered: Vec<ScannerObjectEntry> = Vec::with_capacity(listed.len());
+        for h in hosts {
+            let kids = hosted.remove(&h.id);
+            ordered.push(h);
+            if let Some(kids) = kids {
+                ordered.extend(kids);
+            }
+        }
+        // Safety net for hosted entries whose host slipped past the guard, then
+        // the drifting containers, all pinned to the bottom.
+        for (_, kids) in hosted {
+            ordered.extend(kids);
+        }
+        ordered.extend(drifting);
+        ordered
     }
 
     /// Actions available for an entry, mirroring the manny-first candidate

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1194,6 +1194,38 @@ fn scanner_objects_order_top_level_then_nested() {
 }
 
 #[test]
+fn scanner_objects_nest_hidden_containers_under_host() {
+    // A container hidden on ast-1 surfaces right after ast-1 even though it
+    // appears later in scan order; a drifting container sinks to the bottom.
+    let tmpl = |id: &str, ty: &str, name: &str, mode: &str, target: &str| {
+        format!(
+            r#"{{"id": "{id}", "type": "{ty}", "name": "{name}",
+            "estimated": null, "summary": null, "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+            "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": {mode}, "targetObjectId": {target},
+            "capacity": null, "capacityUnit": null, "minableTargets": null,
+            "waypointBookmarks": [], "bookmarkTargets": []}}"#
+        )
+    };
+    let objects = format!(
+        "[{},{},{},{}]",
+        tmpl("ast-1", "asteroid", "Rock A", "null", "null"),
+        tmpl("c-drift", "detached_container", "Floater", "\"drifting\"", "null"),
+        tmpl("c-hidden", "detached_container", "Cache", "\"hidden_on_asteroid\"", "\"ast-1\""),
+        tmpl("ast-2", "asteroid", "Rock B", "null", "null"),
+    );
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., &objects)];
+    let entries = state.scanner_objects();
+    let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(ids, vec!["ast-1", "c-hidden", "ast-2", "c-drift"]);
+    let attached: Vec<bool> = entries.iter().map(|e| e.attached).collect();
+    assert_eq!(attached, vec![false, true, false, false]);
+}
+
+#[test]
 fn actions_for_object_by_kind() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1226,6 +1226,37 @@ fn scanner_objects_nest_hidden_containers_under_host() {
 }
 
 #[test]
+fn mining_travel_deducted_only_for_on_asteroid_container() {
+    let tmpl = |id: &str, ty: &str, mode: &str, target: &str| {
+        format!(
+            r#"{{"id": "{id}", "type": "{ty}", "name": "{id}",
+            "estimated": null, "summary": null, "mass": null, "massUnit": null,
+            "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
+            "mannyState": null, "mannyUid": null, "cargo": null, "itemType": null,
+            "quantity": null, "containerSpace": null, "mode": {mode}, "targetObjectId": {target},
+            "capacity": null, "capacityUnit": null, "minableTargets": null,
+            "waypointBookmarks": [], "bookmarkTargets": []}}"#
+        )
+    };
+    let objects = format!(
+        "[{},{},{},{}]",
+        tmpl("ast-1", "asteroid", "null", "null"),
+        tmpl("ast-2", "asteroid", "null", "null"),
+        tmpl("c-hidden", "detached_container", "\"hidden_on_asteroid\"", "\"ast-1\""),
+        tmpl("c-drift", "detached_container", "\"drifting\"", "null"),
+    );
+    let mut state = AppState::default();
+    state.probe = Some(probe_at(0., 0., 0.));
+    state.scan_history = vec![make_sector_with_objects(0., 0., 0., &objects)];
+    // Hidden on the mined asteroid → travel deducted.
+    assert!(state.mining_travel_deducted("ast-1", "c-hidden"));
+    // Hidden on a different asteroid → not deducted.
+    assert!(!state.mining_travel_deducted("ast-2", "c-hidden"));
+    // Drifting container → not deducted.
+    assert!(!state.mining_travel_deducted("ast-1", "c-drift"));
+}
+
+#[test]
 fn actions_for_object_by_kind() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));

--- a/src/input/jettison.rs
+++ b/src/input/jettison.rs
@@ -45,9 +45,11 @@ pub(super) fn handle_jettison_event(
                 KeyCode::Backspace => state.jettison_backspace(),
                 KeyCode::Char('m') | KeyCode::Char('M') => state.jettison_fill_max(),
                 KeyCode::Char(c) => state.jettison_type_char(c),
+                // Amount entered → move to an explicit confirmation before the
+                // irreversible drop, rather than firing straight away.
                 KeyCode::Enter => {
-                    let (item_id, amount) = {
-                        let JettisonInput::EnterAmount { ref item_id, ref buf, .. } = state.jettison else { return };
+                    let next = {
+                        let JettisonInput::EnterAmount { ref item_id, ref item_name, ref buf, .. } = state.jettison else { return };
                         let amount = if buf.is_empty() {
                             None
                         } else {
@@ -55,6 +57,24 @@ pub(super) fn handle_jettison_event(
                             if v <= 0.0 { return }
                             Some(v)
                         };
+                        JettisonInput::Confirm {
+                            item_id: item_id.clone(),
+                            item_name: item_name.clone(),
+                            amount,
+                            error: None,
+                        }
+                    };
+                    state.jettison = next;
+                }
+                _ => {}
+            }
+        }
+        JettisonInput::Confirm { .. } => {
+            match code {
+                KeyCode::Esc => state.jettison = JettisonInput::Inactive,
+                KeyCode::Enter => {
+                    let (item_id, amount) = {
+                        let JettisonInput::Confirm { ref item_id, amount, .. } = state.jettison else { return };
                         (item_id.clone(), amount)
                     };
                     fetch_jettison(item_id, amount, client.clone(), tx.clone());

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -255,10 +255,14 @@ pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bo
         } else {
             e.name.clone()
         };
-        let mut spans = vec![
-            Span::styled(format!("{icon} "), Style::default().fg(color)),
-            Span::styled(name, row_style(active, i == cur).patch(text)),
-        ];
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        // Detached containers hidden on an asteroid render indented under their
+        // host (see scanner_objects hierarchy ordering).
+        if e.attached {
+            spans.push(Span::styled("  └ ".to_string(), Style::default().fg(p.dim)));
+        }
+        spans.push(Span::styled(format!("{icon} "), Style::default().fg(color)));
+        spans.push(Span::styled(name, row_style(active, i == cur).patch(text)));
         spans.extend(sector_entry_tags(state, &e.id, p));
         if i == cur {
             sel_line = Some(lines.len());
@@ -308,6 +312,13 @@ fn sector_entry_tags(state: &AppState, id: &str, p: Palette) -> Vec<Span<'static
                 }
                 if let Some(c) = &o.category {
                     out.push(Span::styled(format!(" {c}"), dim));
+                }
+            }
+            SectorObjectType::DetachedContainer => {
+                // Containers hidden on an asteroid are shown indented under their
+                // host (scanner_objects hierarchy); only flag free-floating ones.
+                if o.mode.as_deref() == Some("drifting") {
+                    out.push(Span::styled("  drifting".to_string(), dim));
                 }
             }
             _ => {

--- a/src/ui/overlays/jettison.rs
+++ b/src/ui/overlays/jettison.rs
@@ -120,6 +120,50 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
             render_footer(frame, rows[1], p, &[
+                FooterKey::nav("[Enter]", "review"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ]);
+        }
+
+        JettisonInput::Confirm { item_name, amount, error, .. } => {
+            let popup = centered_rect(50, 8, area);
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .title(format!(" JETTISON — {item_name} "))
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(p.crit));
+            let inner = block.inner(popup);
+            frame.render_widget(block, popup);
+
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(inner);
+
+            let qty = match amount {
+                Some(v) => format!("{v:.3} ECE"),
+                None => "all stock".to_string(),
+            };
+            let mut lines = vec![
+                Line::from(Span::styled(
+                    format!("Jettison {qty} of {item_name}?"),
+                    Style::default().fg(p.crit),
+                )),
+                Line::from(Span::styled(
+                    "Discarded stock is lost.",
+                    Style::default().fg(p.dim),
+                )),
+            ];
+            if let Some(err) = error {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(
+                    format!("✗ {err}"),
+                    Style::default().fg(p.crit),
+                )));
+            }
+            frame.render_widget(Paragraph::new(lines), rows[0]);
+            render_footer(frame, rows[1], p, &[
                 FooterKey::danger("[Enter]", "JETTISON"),
                 FooterKey::nav("[Esc]", "cancel"),
             ]);

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -16,8 +16,16 @@ fn asteroid_label(state: &AppState, index: usize, id: &str, name: &str) -> Strin
     super::probe_object_label(state, index, id, name)
 }
 
-pub(crate) fn estimate_mine_duration(target_amount: f64) -> (i64, i64) {
-    const CARGO_CAP: f64 = 0.30;
+/// A rough pre-launch estimate of a mining job: round-trip count and a ballpark
+/// duration. Indicative only — the authoritative ETA comes from the server as
+/// `task_estimated_end_time` once the task starts (rendered in the Mannies pane
+/// via `manny_task_eta`). When `travel_deducted` is true the destination is a
+/// container hidden on the very asteroid being mined, so the server charges no
+/// per-trip travel (miningTravelSeconds = 0); otherwise a fixed travel estimate
+/// applies per trip (the real distance isn't known client-side). The per-trip
+/// cargo capacity is fixed at 0.05 ECE (per the API).
+pub(crate) fn estimate_mine_duration(target_amount: f64, travel_deducted: bool) -> (i64, i64) {
+    const CARGO_CAP: f64 = 0.05; // Manny cargo capacity per trip (ECE)
     const TRAVEL_SECS: i64 = 1800; // 900s each way
     const TICK_AMOUNT: f64 = 0.01;
     const TICK_SECS: i64 = 300;
@@ -27,7 +35,10 @@ pub(crate) fn estimate_mine_duration(target_amount: f64) -> (i64, i64) {
     for _ in 0..trips {
         let trip = remaining.min(CARGO_CAP);
         let ticks = (trip / TICK_AMOUNT).ceil() as i64;
-        total_secs += TRAVEL_SECS + ticks * TICK_SECS;
+        total_secs += ticks * TICK_SECS;
+        if !travel_deducted {
+            total_secs += TRAVEL_SECS;
+        }
         remaining -= trip;
     }
     (trips, total_secs)
@@ -132,13 +143,23 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 ]));
             }
 
-            // Time estimate
+            // Time estimate. Travel is deducted when mining into a container
+            // hidden on this very asteroid (no round trips); mining to the probe
+            // or a container elsewhere keeps travel.
             if let Ok(amount) = amount_buf.parse::<f64>() {
                 if amount > 0.0 {
-                    let (trips, secs) = estimate_mine_duration(amount);
+                    let travel_deducted = target_container
+                        .as_ref()
+                        .is_some_and(|(cid, _)| state.mining_travel_deducted(object_id, cid));
+                    let (trips, secs) = estimate_mine_duration(amount, travel_deducted);
+                    let dest = if travel_deducted { "on-site" } else { "+ travel" };
                     lines.push(Line::from(vec![
                         Span::styled(
-                            format!("{trips} trip{}  •  ~{}", if trips == 1 { "" } else { "s" }, format_duration(secs)),
+                            format!(
+                                "≈ {trips} trip{} · ~{} ({dest})",
+                                if trips == 1 { "" } else { "s" },
+                                format_duration(secs),
+                            ),
                             Style::default().fg(p.dim),
                         ),
                     ]));

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -115,7 +115,8 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
 
     // ── Vital gauges ──
     lines.push(Line::raw(""));
-    let fuel = probe.fuel.deuterium.map(|d| (d / 100.0).clamp(0.0, 1.0)).unwrap_or(0.0);
+    let max_deuterium = probe.fuel.max_deuterium.unwrap_or(100.0);
+    let fuel = probe.fuel.deuterium.map(|d| (d / max_deuterium).clamp(0.0, 1.0)).unwrap_or(0.0);
     lines.push(block_gauge_line("FUEL", fuel, &format!("{:.0}%", fuel * 100.0), ratio_color(fuel, p), p));
     if let Some(sys) = &probe.systems {
         let integ = (sys.integrity_percent.unwrap_or(100.0) / 100.0).clamp(0.0, 1.0);


### PR DESCRIPTION
Phase 0 fixes for the cockpit TUI.

- fabrication: deuterium read from resource_stocks (always 0.0, recipes greyed
  out); now sourced from the fuel tank and converted to ECE (100% of a size-1
  tank = 1.0 ECE → /100), scaling with tank upgrades. Adds ProbeFuel.maxDeuterium
  and fixes the FUEL gauge for improved probes.
- sector: detached containers nest under their host asteroid (indented);
  drifting ones sink to the bottom.
- mine: ETA preview corrected (0.05 cargo cap, was 0.30) and made destination-
  aware — travel deducted when mining into a container on the mined asteroid.
- jettison: resource jettison now requires an explicit confirmation step.

274 tests pass. Recommend squash-merge (deuterium has a follow-up refinement commit).
