### PR TITLE
feat(journal): capture the remaining pilot actions

### DIFF
--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -106,6 +106,93 @@ impl LogEvent {
             probe_id,
         )
     }
+
+    pub fn repair(pct: f64, probe_id: Option<u64>) -> Self {
+        Self::action(kind::REPAIR, format!("Ordered a hull repair to {pct:.0}%."), probe_id)
+    }
+
+    /// Fabrication order, on the atomic printer or at the manny bay.
+    pub fn craft(recipe: &str, atomic_printer: bool, probe_id: Option<u64>) -> Self {
+        let bay = if atomic_printer { "on the atomic printer" } else { "at the manny bay" };
+        Self::action(kind::CRAFT, format!("Queued «{recipe}» {bay}."), probe_id)
+    }
+
+    pub fn salvage(target: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::SALVAGE, format!("Sent a manny to salvage «{target}»."), probe_id)
+    }
+
+    pub fn recall(manny: &str, abandon: bool, probe_id: Option<u64>) -> Self {
+        let s = if abandon {
+            format!("Abandoned «{manny}» in a remote sector.")
+        } else {
+            format!("Recalled «{manny}».")
+        };
+        Self::action(kind::RECALL, s, probe_id)
+    }
+
+    pub fn recover(container: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::RECOVER, format!("Sent a manny to recover container «{container}»."), probe_id)
+    }
+
+    pub fn rename_manny(old: &str, new: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::RENAME, format!("Renamed manny «{old}» to «{new}»."), probe_id)
+    }
+
+    pub fn rename_container(new: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::RENAME, format!("Renamed a container to «{new}»."), probe_id)
+    }
+
+    pub fn rename_probe(new: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::RENAME, format!("Renamed the probe to «{new}»."), probe_id)
+    }
+
+    pub fn set_default_probe(name: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::RENAME, format!("Set «{name}» as the default probe."), probe_id)
+    }
+
+    pub fn improve(improvement: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::IMPROVE, format!("Began installing «{improvement}»."), probe_id)
+    }
+
+    pub fn inspect(target: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::INSPECT, format!("Sent a manny to inspect «{target}»."), probe_id)
+    }
+
+    pub fn refuel(probe_id: Option<u64>) -> Self {
+        Self::action(kind::REFUEL, "Sent a manny to refill the deuterium tank.".to_string(), probe_id)
+    }
+
+    pub fn assemble_probe(probe_id: Option<u64>) -> Self {
+        Self::action(kind::ASSEMBLE, "Began assembling a new drone (~3h).".to_string(), probe_id)
+    }
+
+    pub fn drop_cargo(probe_id: Option<u64>) -> Self {
+        Self::action(kind::DROP_CARGO, "Dumped a manny's onboard cargo.".to_string(), probe_id)
+    }
+
+    pub fn mind_snapshot(probe_id: Option<u64>) -> Self {
+        Self::action(kind::MIND_SNAPSHOT, "Reassigned the mind snapshot to a fresh probe.".to_string(), probe_id)
+    }
+
+    pub fn mission_abandon(title: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::MISSION, format!("Abandoned mission «{title}»."), probe_id)
+    }
+
+    pub fn relay_on(network: Option<&str>, probe_id: Option<u64>) -> Self {
+        let s = match network {
+            Some(n) if !n.is_empty() => format!("Turned on SCUT relay «{n}»."),
+            _ => "Turned on a SCUT relay.".to_string(),
+        };
+        Self::action(kind::RELAY, s, probe_id)
+    }
+
+    pub fn message_sent(recipient: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::MESSAGE, format!("Sent a message to «{recipient}»."), probe_id)
+    }
+
+    pub fn container_rules(container: &str, probe_id: Option<u64>) -> Self {
+        Self::action(kind::RULES, format!("Updated routing rules for «{container}»."), probe_id)
+    }
 }
 
 /// Event-kind tags. Local actions and reconstructed server events share this
@@ -117,6 +204,21 @@ pub mod kind {
     pub const STORAGE_MOVE: &str = "storage_move";
     pub const CONTAINER: &str = "container";
     pub const WAYPOINT: &str = "waypoint";
+    pub const REPAIR: &str = "repair";
+    pub const SALVAGE: &str = "salvage";
+    pub const RECALL: &str = "recall";
+    pub const RECOVER: &str = "recover";
+    pub const RENAME: &str = "rename";
+    pub const IMPROVE: &str = "improve";
+    pub const INSPECT: &str = "inspect";
+    pub const REFUEL: &str = "refuel";
+    pub const ASSEMBLE: &str = "assemble";
+    pub const DROP_CARGO: &str = "drop_cargo";
+    pub const MIND_SNAPSHOT: &str = "mind_snapshot";
+    pub const MISSION: &str = "mission";
+    pub const RELAY: &str = "relay";
+    pub const MESSAGE: &str = "message";
+    pub const RULES: &str = "rules";
     /// Reconstructed server-side event (alert / damage warning).
     pub const ALERT: &str = "alert";
 }

--- a/src/input/assemble.rs
+++ b/src/input/assemble.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_assemble_probe;
-use crate::app::{ApiMessage, AppState, AssembleProbeInput};
+use crate::app::{ApiMessage, AppState, AssembleProbeInput, LogEvent};
 
 use super::geometry::list_nav;
 
@@ -59,6 +59,7 @@ pub(super) fn handle_assemble_probe_event(
                 Some((manny, ids)) => {
                     state.assemble_probe = AssembleProbeInput::Inactive;
                     fetch_assemble_probe(manny, ids, client.clone(), tx.clone());
+                    state.log_event(LogEvent::assemble_probe(state.active_probe_id));
                 }
                 None => {
                     if let AssembleProbeInput::PickContainers { error, .. } =

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -17,7 +17,7 @@ use crate::api::tasks::{
 };
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
-    ApiMessage, AppState, AssembleProbeInput, CommsCategory, MissionsCategory, DeployInput, FabricationInput, ImproveInput, DetachInput, DropCargoInput,
+    ApiMessage, AppState, AssembleProbeInput, CommsCategory, MissionsCategory, DeployInput, FabricationInput, ImproveInput, DetachInput, DropCargoInput, LogEvent,
     CommandLine, DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction,
     MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
@@ -472,7 +472,8 @@ fn fire_menu_action(
             if let Some(active) = state.active_probe_summary() {
                 if !active.is_default && active.is_reachable {
                     let (id, name) = (active.id, active.name.clone());
-                    fetch_set_default_probe(id, name, client.clone(), tx.clone());
+                    fetch_set_default_probe(id, name.clone(), client.clone(), tx.clone());
+                    state.log_event(LogEvent::set_default_probe(&name, Some(id)));
                 }
             }
             return;
@@ -582,8 +583,9 @@ fn fire_menu_action(
             match candidates.len() {
                 0 => state.error = Some("no inspectable objects in current sector — scan first".into()),
                 1 => {
-                    let (object_id, _) = candidates.into_iter().next().unwrap();
+                    let (object_id, object_name) = candidates.into_iter().next().unwrap();
                     fetch_inspect(id, object_id, client.clone(), tx.clone());
+                    state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
                 }
                 _ => state.inspect = InspectInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
             }
@@ -593,8 +595,9 @@ fn fire_menu_action(
             match candidates.len() {
                 0 => state.error = Some("no detached containers in current sector — scan first".into()),
                 1 => {
-                    let (object_id, _) = candidates.into_iter().next().unwrap();
+                    let (object_id, container_name) = candidates.into_iter().next().unwrap();
                     fetch_recover(id, object_id, client.clone(), tx.clone());
+                    state.log_event(LogEvent::recover(&container_name, state.active_probe_id));
                 }
                 _ => state.recover = RecoverInput::PickContainer { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
             }

--- a/src/input/command.rs
+++ b/src/input/command.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_all, fetch_atomic_printer_craft, fetch_craft, fetch_mine};
 use crate::app::{
-    command_usage, ApiMessage, AppState, CommandFire, CompletionState, InputMode,
+    command_usage, ApiMessage, AppState, CommandFire, CompletionState, InputMode, LogEvent,
 };
 
 /// Route a key while the `:` command line is open. Typed characters are literal
@@ -31,12 +31,24 @@ pub(super) fn handle_command_event(
             if let Some(fire) = state.pending_fire.take() {
                 match fire {
                     CommandFire::AtomicCraft { recipe_id } => {
+                        let name = state.fabrication_recipes().iter()
+                            .find(|(_, r)| r.id == recipe_id).map(|(_, r)| r.name.clone());
                         fetch_atomic_printer_craft(recipe_id, client.clone(), tx.clone());
+                        if let Some(name) = name {
+                            state.log_event(LogEvent::craft(&name, true, state.active_probe_id));
+                        }
                     }
                     CommandFire::MannyCraft { manny_id, recipe_id } => {
+                        let name = state.fabrication_recipes().iter()
+                            .find(|(_, r)| r.id == recipe_id).map(|(_, r)| r.name.clone());
                         fetch_craft(manny_id, recipe_id, client.clone(), tx.clone());
+                        if let Some(name) = name {
+                            state.log_event(LogEvent::craft(&name, false, state.active_probe_id));
+                        }
                     }
                     CommandFire::Mine { manny_id, object_id, resources, amount, container_id } => {
+                        let resources_label = resources.join(", ");
+                        let destination = if container_id.is_some() { "a container" } else { "the probe" };
                         fetch_mine(
                             manny_id,
                             object_id,
@@ -46,6 +58,7 @@ pub(super) fn handle_command_event(
                             client.clone(),
                             tx.clone(),
                         );
+                        state.log_event(LogEvent::mine(&resources_label, amount, destination, state.active_probe_id));
                     }
                 }
             }

--- a/src/input/containers.rs
+++ b/src/input/containers.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_rename_container, fetch_update_container_rules};
-use crate::app::{ApiMessage, AppState, ContainerRulesInput, RenameContainerInput};
+use crate::app::{ApiMessage, AppState, ContainerRulesInput, LogEvent, RenameContainerInput};
 
 use super::geometry::list_nav;
 
@@ -65,7 +65,9 @@ pub(super) fn handle_rename_container_event(
                 state.set_rename_container_error("label cannot be empty".into());
                 return;
             }
+            let new_label = label.clone();
             fetch_rename_container(id, label, client.clone(), tx.clone());
+            state.log_event(LogEvent::rename_container(&new_label, state.active_probe_id));
         }
         KeyCode::Char(c) => {
             if let RenameContainerInput::Typing { buf, error, .. } = &mut state.rename_container {
@@ -119,9 +121,9 @@ pub(super) fn handle_container_rules_event(
             }
         }
         KeyCode::Enter => {
-            let (id, p, e, s) = {
+            let (id, p, e, s, label) = {
                 let ContainerRulesInput::Editing {
-                    container_id, priority, exclusion, strict_exclusion, ..
+                    container_id, priority, exclusion, strict_exclusion, container_label, ..
                 } = &state.container_rules
                 else {
                     return;
@@ -131,9 +133,11 @@ pub(super) fn handle_container_rules_event(
                     priority.clone(),
                     exclusion.clone(),
                     strict_exclusion.clone(),
+                    container_label.clone(),
                 )
             };
             fetch_update_container_rules(id, p, e, s, client.clone(), tx.clone());
+            state.log_event(LogEvent::container_rules(&label, state.active_probe_id));
         }
         _ => {}
     }

--- a/src/input/craft.rs
+++ b/src/input/craft.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_atomic_printer_craft, fetch_craft};
-use crate::app::{ApiMessage, AppState, Fabricator, FabricationInput};
+use crate::app::{ApiMessage, AppState, Fabricator, FabricationInput, LogEvent};
 use super::geometry::list_nav;
 
 /// Drive the unified fabrication wizard. `PickRecipe` browses the sectioned
@@ -50,13 +50,14 @@ pub(super) fn handle_fabrication_event(
                     }
                 }
                 KeyCode::Enter => {
-                    let picked = if let FabricationInput::PickBuilder { ref mannies, selection, ref recipe_id, .. } = state.fabrication {
-                        mannies.get(selection).map(|(id, _)| (id.clone(), recipe_id.clone()))
+                    let picked = if let FabricationInput::PickBuilder { ref mannies, selection, ref recipe_id, ref recipe_name, .. } = state.fabrication {
+                        mannies.get(selection).map(|(id, _)| (id.clone(), recipe_id.clone(), recipe_name.clone()))
                     } else {
                         None
                     };
-                    if let Some((manny_id, recipe_id)) = picked {
+                    if let Some((manny_id, recipe_id, recipe_name)) = picked {
                         fetch_craft(manny_id, recipe_id, client.clone(), tx.clone());
+                        state.log_event(LogEvent::craft(&recipe_name, false, state.active_probe_id));
                     }
                 }
                 _ => {}
@@ -82,6 +83,7 @@ fn commit_recipe(
         Fabricator::AtomicPrinter => {
             if state.has_atomic_printer() {
                 fetch_atomic_printer_craft(recipe_id, client.clone(), tx.clone());
+                state.log_event(LogEvent::craft(&recipe_name, true, state.active_probe_id));
             } else {
                 state.set_fabrication_error("no atomic printer in inventory".into());
             }
@@ -94,6 +96,7 @@ fn commit_recipe(
             };
             if let Some((manny_id, _)) = prefilled {
                 fetch_craft(manny_id, recipe_id, client.clone(), tx.clone());
+                state.log_event(LogEvent::craft(&recipe_name, false, state.active_probe_id));
                 return;
             }
             let mannies = state.collect_idle_onboard_mannies();
@@ -102,6 +105,7 @@ fn commit_recipe(
                 1 => {
                     let (manny_id, _) = mannies.into_iter().next().unwrap();
                     fetch_craft(manny_id, recipe_id, client.clone(), tx.clone());
+                    state.log_event(LogEvent::craft(&recipe_name, false, state.active_probe_id));
                 }
                 _ => {
                     state.fabrication = FabricationInput::PickBuilder {

--- a/src/input/fleet.rs
+++ b/src/input/fleet.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_rename_probe;
-use crate::app::{ApiMessage, AppState, ProbeSwitchInput, RenameProbeInput};
+use crate::app::{ApiMessage, AppState, LogEvent, ProbeSwitchInput, RenameProbeInput};
 
 use super::geometry::list_nav;
 
@@ -64,7 +64,9 @@ pub(super) fn handle_rename_probe_event(
                 _ => None,
             };
             if let Some((id, name)) = order {
+                let new_name = name.clone();
                 fetch_rename_probe(id, name, client.clone(), tx.clone());
+                state.log_event(LogEvent::rename_probe(&new_name, Some(id)));
             }
         }
         _ => {}

--- a/src/input/improve.rs
+++ b/src/input/improve.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_improve_probe;
-use crate::app::{ApiMessage, AppState, ImproveInput};
+use crate::app::{ApiMessage, AppState, ImproveInput, LogEvent};
 use super::geometry::list_nav;
 
 /// Drive the probe-improvement wizard: pick an improvement, then resolve which
@@ -42,13 +42,14 @@ pub(super) fn handle_improve_event(
                     }
                 }
                 KeyCode::Enter => {
-                    let picked = if let ImproveInput::PickBuilder { ref mannies, selection, ref improvement_id, .. } = state.improve {
-                        mannies.get(selection).map(|(id, _)| (id.clone(), improvement_id.clone()))
+                    let picked = if let ImproveInput::PickBuilder { ref mannies, selection, ref improvement_id, ref improvement_name, .. } = state.improve {
+                        mannies.get(selection).map(|(id, _)| (id.clone(), improvement_id.clone(), improvement_name.clone()))
                     } else {
                         None
                     };
-                    if let Some((manny_id, improvement_id)) = picked {
+                    if let Some((manny_id, improvement_id, improvement_name)) = picked {
                         fetch_improve_probe(manny_id, improvement_id, client.clone(), tx.clone());
+                        state.log_event(LogEvent::improve(&improvement_name, state.active_probe_id));
                     }
                 }
                 _ => {}
@@ -85,6 +86,7 @@ fn commit_improvement(
         1 => {
             let (manny_id, _) = mannies.into_iter().next().unwrap();
             fetch_improve_probe(manny_id, id, client.clone(), tx.clone());
+            state.log_event(LogEvent::improve(&name, state.active_probe_id));
         }
         _ => {
             state.improve = ImproveInput::PickBuilder {

--- a/src/input/messages.rs
+++ b/src/input/messages.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_mark_message_read, fetch_send_message};
-use crate::app::{ApiMessage, AppState, MessagesInput};
+use crate::app::{ApiMessage, AppState, LogEvent, MessagesInput};
 
 use super::geometry::list_nav;
 
@@ -101,12 +101,13 @@ pub(super) fn handle_messages_event(
                 }
             }
             KeyCode::Enter => {
-                let (kind, id, body) = {
-                    let MessagesInput::Compose { ref recipient_type, ref recipient_id, ref body_buf, .. } = state.messages_input else { return };
+                let (kind, id, body, recipient_name) = {
+                    let MessagesInput::Compose { ref recipient_type, ref recipient_id, ref body_buf, ref recipient_name, .. } = state.messages_input else { return };
                     if body_buf.trim().is_empty() { return }
-                    (recipient_type.clone(), recipient_id.clone(), body_buf.clone())
+                    (recipient_type.clone(), recipient_id.clone(), body_buf.clone(), recipient_name.clone())
                 };
                 fetch_send_message(kind, id, body, client.clone(), tx.clone());
+                state.log_event(LogEvent::message_sent(&recipient_name, state.active_probe_id));
             }
             _ => {}
         },

--- a/src/input/mine.rs
+++ b/src/input/mine.rs
@@ -301,7 +301,7 @@ pub(super) fn handle_remote_mine_event(
                     }
                 }
                 KeyCode::Enter => {
-                    let (manny_id, object_id, selected_resources, amount, container_id) = {
+                    let (manny_id, object_id, selected_resources, amount, container_id, destination) = {
                         let RemoteMineInput::PickContainer {
                             ref manny_id, ref object_id, resources, amount, ref containers, selection, ..
                         } = state.remote_mine else { return };
@@ -309,9 +309,11 @@ pub(super) fn handle_remote_mine_event(
                             .filter(|(i, _)| resources[*i])
                             .map(|(_, &t)| t.to_string())
                             .collect();
-                        (manny_id.clone(), object_id.clone(), selected, amount, containers[selection].0.clone())
+                        (manny_id.clone(), object_id.clone(), selected, amount, containers[selection].0.clone(), containers[selection].1.clone())
                     };
+                    let resources_label = selected_resources.join(", ");
                     fetch_mine(manny_id, object_id, selected_resources, amount, Some(container_id), client.clone(), tx.clone());
+                    state.log_event(LogEvent::mine(&resources_label, amount, &destination, state.active_probe_id));
                 }
                 _ => {}
             }

--- a/src/input/missions.rs
+++ b/src/input/missions.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::tasks::fetch_abandon_mission;
 use crate::api::types::MissionStatus;
-use crate::app::{ApiMessage, AppState, MissionsInput};
+use crate::app::{ApiMessage, AppState, LogEvent, MissionsInput};
 use crate::api::client::ApiClient;
 
 use super::geometry::list_nav;
@@ -48,14 +48,15 @@ pub(super) fn handle_missions_event(
                 state.missions_input = MissionsInput::Browsing { selection };
             }
             KeyCode::Enter | KeyCode::Char('y') => {
-                let mission_id = {
-                    let MissionsInput::ConfirmAbandon { ref mission_id, .. } = state.missions_input
+                let (mission_id, mission_title) = {
+                    let MissionsInput::ConfirmAbandon { ref mission_id, ref mission_title, .. } = state.missions_input
                     else {
                         return;
                     };
-                    mission_id.clone()
+                    (mission_id.clone(), mission_title.clone())
                 };
                 fetch_abandon_mission(mission_id, client.clone(), tx.clone());
+                state.log_event(LogEvent::mission_abandon(&mission_title, state.active_probe_id));
             }
             _ => {}
         },

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -42,11 +42,12 @@ pub(super) fn handle_salvage_event(
         SalvageInput::Confirm { .. } => match code {
             KeyCode::Esc => state.salvage = SalvageInput::Inactive,
             KeyCode::Enter => {
-                let (manny_id, object_id) = {
-                    let SalvageInput::Confirm { ref manny_id, ref object_id, .. } = state.salvage else { return };
-                    (manny_id.clone(), object_id.clone())
+                let (manny_id, object_id, object_name) = {
+                    let SalvageInput::Confirm { ref manny_id, ref object_id, ref object_name, .. } = state.salvage else { return };
+                    (manny_id.clone(), object_id.clone(), object_name.clone())
                 };
                 fetch_salvage(manny_id, object_id, client.clone(), tx.clone());
+                state.log_event(LogEvent::salvage(&object_name, state.active_probe_id));
             }
             _ => {}
         },
@@ -63,11 +64,12 @@ pub(super) fn handle_recall_event(
     match code {
         KeyCode::Esc => state.recall = RecallInput::Inactive,
         KeyCode::Enter => {
-            let manny_id = {
-                let RecallInput::Confirm { ref manny_id, .. } = state.recall else { return };
-                manny_id.clone()
+            let (manny_id, manny_name, remote) = {
+                let RecallInput::Confirm { ref manny_id, ref manny_name, remote, .. } = state.recall else { return };
+                (manny_id.clone(), manny_name.clone(), remote)
             };
             fetch_recall(manny_id, client.clone(), tx.clone());
+            state.log_event(LogEvent::recall(&manny_name, remote, state.active_probe_id));
         }
         _ => {}
     }
@@ -87,6 +89,7 @@ pub(super) fn handle_refuel_event(
                 manny_id.clone()
             };
             fetch_refill_deuterium(manny_id, client.clone(), tx.clone());
+            state.log_event(LogEvent::refuel(state.active_probe_id));
         }
         _ => {}
     }
@@ -102,6 +105,7 @@ pub(super) fn handle_mind_snapshot_event(
         KeyCode::Esc | KeyCode::Char('n') => state.mind_snapshot = MindSnapshotInput::Inactive,
         KeyCode::Enter | KeyCode::Char('y') => {
             fetch_reassign_mind_snapshot(client.clone(), tx.clone());
+            state.log_event(LogEvent::mind_snapshot(state.active_probe_id));
         }
         _ => {}
     }
@@ -188,6 +192,7 @@ pub(super) fn handle_drop_cargo_event(
                 manny_id.clone()
             };
             fetch_drop_manny_cargo(manny_id, client.clone(), tx.clone());
+            state.log_event(LogEvent::drop_cargo(state.active_probe_id));
         }
         _ => {}
     }
@@ -278,12 +283,14 @@ pub(super) fn handle_rename_manny_event(
         KeyCode::Backspace => state.rename_manny_backspace(),
         KeyCode::Char(c) => state.rename_manny_type_char(c),
         KeyCode::Enter => {
-            let (manny_id, name) = {
-                let RenameMannyInput::Typing { ref manny_id, ref buf, .. } = state.rename_manny else { return };
+            let (manny_id, name, old_name) = {
+                let RenameMannyInput::Typing { ref manny_id, ref buf, ref manny_name, .. } = state.rename_manny else { return };
                 if buf.is_empty() { return }
-                (manny_id.clone(), buf.clone())
+                (manny_id.clone(), buf.clone(), manny_name.clone())
             };
+            let new_name = name.clone();
             fetch_rename_manny(manny_id, name, client.clone(), tx.clone());
+            state.log_event(LogEvent::rename_manny(&old_name, &new_name, state.active_probe_id));
         }
         _ => {}
     }
@@ -303,11 +310,12 @@ pub(super) fn handle_inspect_event(
     match code {
         KeyCode::Esc => state.inspect = InspectInput::Inactive,
         KeyCode::Enter => {
-            let (manny_id, object_id) = {
+            let (manny_id, object_id, object_name) = {
                 let InspectInput::PickTarget { ref manny_id, ref candidates, selection, .. } = state.inspect else { return };
-                (manny_id.clone(), candidates[selection].0.clone())
+                (manny_id.clone(), candidates[selection].0.clone(), candidates[selection].1.clone())
             };
             fetch_inspect(manny_id, object_id, client.clone(), tx.clone());
+            state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
         }
         _ => {}
     }
@@ -327,11 +335,12 @@ pub(super) fn handle_recover_event(
     match code {
         KeyCode::Esc => state.recover = RecoverInput::Inactive,
         KeyCode::Enter => {
-            let (manny_id, object_id) = {
+            let (manny_id, object_id, container_name) = {
                 let RecoverInput::PickContainer { ref manny_id, ref candidates, selection, .. } = state.recover else { return };
-                (manny_id.clone(), candidates[selection].0.clone())
+                (manny_id.clone(), candidates[selection].0.clone(), candidates[selection].1.clone())
             };
             fetch_recover(manny_id, object_id, client.clone(), tx.clone());
+            state.log_event(LogEvent::recover(&container_name, state.active_probe_id));
         }
         _ => {}
     }

--- a/src/input/repair.rs
+++ b/src/input/repair.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_repair;
 use crate::app::{
-    ApiMessage, AppState, RepairInput,
+    ApiMessage, AppState, LogEvent, RepairInput,
 };
 pub(super) fn handle_repair_event(
     code: KeyCode,
@@ -25,6 +25,7 @@ pub(super) fn handle_repair_event(
                 (manny_id.clone(), pct)
             };
             fetch_repair(manny_id, pct, client.clone(), tx.clone());
+            state.log_event(LogEvent::repair(pct, state.active_probe_id));
         }
         _ => {}
     }

--- a/src/input/scanner.rs
+++ b/src/input/scanner.rs
@@ -9,7 +9,7 @@ use crate::api::tasks::{
     fetch_turn_on_relay,
 };
 use crate::app::{
-    ApiMessage, AppState, DeployInput, MineInput, ObjectAction, ObjectActionInput, SalvageInput,
+    ApiMessage, AppState, DeployInput, LogEvent, MineInput, ObjectAction, ObjectActionInput, SalvageInput,
     ScutNetworkInput, ScutRelayInput, WaypointsInput,
 };
 use super::geometry::list_nav;
@@ -42,6 +42,7 @@ pub(super) fn dispatch_object_action(
         }
         ObjectAction::Inspect => {
             fetch_inspect(manny_id, object_id, client.clone(), tx.clone());
+            state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
         }
         ObjectAction::Salvage => {
             state.salvage = SalvageInput::Confirm {
@@ -54,6 +55,7 @@ pub(super) fn dispatch_object_action(
         }
         ObjectAction::Recover => {
             fetch_recover(manny_id, object_id, client.clone(), tx.clone());
+            state.log_event(LogEvent::recover(&object_name, state.active_probe_id));
         }
         ObjectAction::DeployWaypoint => {
             state.deploy = DeployInput::EnterName {
@@ -111,7 +113,9 @@ pub(super) fn handle_scut_relay_event(
                 let name = if buf.trim().is_empty() { None } else { Some(buf.trim().to_string()) };
                 (manny_id.clone(), relay_id, name)
             };
+            let network = name.clone();
             fetch_turn_on_relay(manny_id, relay_id, name, client.clone(), tx.clone());
+            state.log_event(LogEvent::relay_on(network.as_deref(), state.active_probe_id));
         }
         _ => {}
     }


### PR DESCRIPTION
Ship's log — PR2: capture the remaining pilot actions (stacked on #188).

Extends the ship's log from PR1's first set to nearly every mutating action:
repair, craft (manny + atomic printer), salvage, recall/abandon, recover,
rename (manny/container/probe), set-default probe, improve, inspect, refuel,
assemble drone, drop cargo, mind-snapshot reassign, mission abandon, turn-on
relay, send message, routing rules, remote mine, and the one-shot :mine/:craft
command paths. Each gets a narrative captain's-log constructor.

Base: feat/ship-log (rebase onto main once #188 merges).

Follow-up (PR3): fold reconstructed server events (alerts / warnings /
missions) into the flow.

276 tests pass.
