### PR TITLE
feat(journal): merge server events into the ship's log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Copy `config.example.toml` to that path and fill in the API key (generated once 
 
 Scan history is persisted across runs in a local SQLite database (`cockpit.db`, under the XDG state dir); the legacy `scan_history.json` is migrated into it once, then removed (`src/store.rs`, issue #134).
 
-The same database holds the **ship's log** — an append-only `events` table recording pilot actions (travel, mine, deploy, drop/detach container, storage move…) as narrated captain's-log entries. Actions stage a pre-rendered line into `AppState::pending_journal` (mirroring `pending_fire`), which the event loop drains to persist and prepend to `AppState::journal`. The table is never trimmed (full history kept for long-term stats); only the most recent `store::JOURNAL_WINDOW` are loaded into memory at boot.
+The same database holds the **ship's log** — an append-only `events` table recording pilot actions (travel, mine, deploy, drop/detach container, storage move…) as narrated captain's-log entries. Actions stage a pre-rendered line into `AppState::pending_journal` (mirroring `pending_fire`), which the event loop drains to persist and prepend to `AppState::journal`. The table is never trimmed (full history kept for long-term stats); only the most recent `store::JOURNAL_WINDOW` are loaded into memory at boot. The Missions-pane view (`AppState::ship_log_entries`) merges these captured actions with reconstructed server events (alerts + damage warnings, projected fresh from memory rather than persisted, since the server keeps them), newest first.
 
 ## Architecture
 

--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -216,7 +216,7 @@ impl super::AppState {
             // mission: its steps. Otherwise (Missions category): the list.
             Pane::Missions => match drill {
                 None => MissionsCategory::ALL.len(),
-                Some(DrillLevel::MissionsCat(MissionsCategory::ShipsLog)) => self.journal.len(),
+                Some(DrillLevel::MissionsCat(MissionsCategory::ShipsLog)) => self.ship_log_entries().len(),
                 Some(DrillLevel::Mission(id)) => self
                     .missions
                     .iter()
@@ -596,6 +596,27 @@ mod tests {
         assert_eq!(s.missions_category(), Some(MissionsCategory::ShipsLog));
         assert_eq!(s.pane_item_count(Pane::Missions), 2);
         assert_eq!(s.breadcrumb(), vec!["COCKPIT", "MISSIONS", "Ship's log"]);
+    }
+
+    #[test]
+    fn ship_log_merges_actions_and_server_alerts_newest_first() {
+        use crate::app::LogEvent;
+        let mut s = crate::app::AppState::default();
+        // A local action stamped now (2026+).
+        s.journal = vec![LogEvent::action("test", "did a thing", None)];
+        // A server alert dated far in the past.
+        let alert: crate::api::types::ProbeAlert = serde_json::from_str(
+            r#"{"id": 1, "type": "anomaly_detected", "status": "unread",
+                "message": "anomaly detected", "phase": "detection",
+                "createdAt": "2000-01-01T00:00:00+00:00"}"#,
+        )
+        .unwrap();
+        s.alerts = vec![alert];
+        let entries = s.ship_log_entries();
+        assert_eq!(entries.len(), 2, "action + alert merged");
+        assert_eq!(entries[0].summary, "did a thing", "newest (now) first");
+        assert_eq!(entries[1].summary, "anomaly detected");
+        assert_eq!(entries[1].kind, crate::app::kind::ALERT, "alert tagged as server event");
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -325,6 +325,29 @@ impl AppState {
         self.pending_journal.push(ev);
     }
 
+    /// The ship's-log flow shown in the pane: locally-captured actions merged
+    /// with reconstructed server events (alerts + damage warnings), newest
+    /// first, capped at the memory window. Server events live on the server and
+    /// are re-sent on each fetch, so they're projected fresh here rather than
+    /// persisted locally (no dedup needed — this recomputes per render).
+    pub fn ship_log_entries(&self) -> Vec<LogEvent> {
+        fn project(a: &ProbeAlert) -> LogEvent {
+            LogEvent {
+                occurred_at: a.scheduled_at.or(a.created_at).unwrap_or_else(Utc::now),
+                kind: crate::app::kind::ALERT.to_string(),
+                probe_id: None,
+                summary: a.message.clone(),
+                data: serde_json::Value::Null,
+            }
+        }
+        let mut all = self.journal.clone();
+        all.extend(self.alerts.iter().map(project));
+        all.extend(self.damage_warnings.iter().map(project));
+        all.sort_by_key(|e| std::cmp::Reverse(e.occurred_at));
+        all.truncate(crate::store::JOURNAL_WINDOW);
+        all
+    }
+
     /// Toast message while fresh (< 5 s); expired toasts are not shown.
     pub fn active_toast(&self) -> Option<&str> {
         self.toast

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -568,14 +568,16 @@ fn render_ship_log(frame: &mut Frame, area: Rect, state: &AppState, active: bool
     let dim = Style::default().fg(p.dim);
     let mut lines = Vec::new();
     let mut sel_line = None;
-    if state.journal.is_empty() {
+    // Actions merged with reconstructed server events (alerts / warnings).
+    let entries = state.ship_log_entries();
+    if entries.is_empty() {
         lines.push(Line::styled("ship's log empty — your actions will appear here", dim));
     } else {
         let cur = cursor(state, Pane::Missions);
         // Compact: truncate each line to the pane width with an ellipsis.
         // Zoomed: full width, so the whole captain's-log sentence reads out.
         let width = area.width.saturating_sub(2) as usize;
-        for (i, e) in state.journal.iter().enumerate() {
+        for (i, e) in entries.iter().enumerate() {
             if i == cur {
                 sel_line = Some(lines.len());
             }


### PR DESCRIPTION
Ship's log — PR3: merge reconstructed server events (stacked on #189).

The ship's log now folds server-side alerts and damage warnings into the
captured-action flow via AppState::ship_log_entries(): projected fresh from
memory each render (not persisted — the server keeps them, so no dedup),
sorted newest-first and capped at the memory window. The Missions pane and its
cursor count read through it; server events render in the warning colour.

Missions are excluded (the API's Mission type carries no timestamps, and they
already have their own category).

Base: feat/ship-log-pr2 (rebase down the stack as #188/#189 merge).

277 tests pass.
