### PR TITLE
feat(mannies): idle-Manny indicator and cycling key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,13 +114,13 @@ One unified phosphor theme (there is no classic/retro split any more). `theme.rs
  ↑↓ move · hl drill · z zoom · Enter act · ertdfgcvb pane · F1 hints
 ```
 
-**Keys** — `e r t d f g c v b` activate a pane · `j`/`k` (`↑`/`↓`) move the cursor · `l`/`→` drill in, `h`/`←` drill out (Missions → steps, Comms → message) · `Enter` opens the contextual action menu · `z` zooms the active pane full-screen · `Tab`/`Shift+Tab` cycle panes · `:` command mode · `F1` toggle hints · `F2` cycle color mode · `F5` refresh · `?` help · `q` quit · `Esc` closes menu / leaves zoom / drills up.
+**Keys** — `e r t d f g c v b` activate a pane · `j`/`k` (`↑`/`↓`) move the cursor · `l`/`→` drill in, `h`/`←` drill out (Missions → steps, Comms → message) · `Enter` opens the contextual action menu · `z` zooms the active pane full-screen · `Tab`/`Shift+Tab` cycle panes · `:` command mode · `i` jump to the next idle Manny (focuses the Mannies pane) · `F1` toggle hints · `F2` cycle color mode · `F5` refresh · `?` help · `q` quit · `Esc` closes menu / leaves zoom / drills up.
 
 **Contextual menu** (`Enter`) — built per active pane + selection (`build_context_menu` → `Vec<MenuItem>`, disabled items shown with a reason). Firing an item launches the existing wizard (`MenuAction` → the matching `*Input`). Panes with rich wizards (Missions, Comms, Storage, Sector objects) reuse their legacy overlays instead of the popup.
 
 **Responsive** — `grid::visible_panes` fits `rows × cols` whole panes (each 1..=3 from a minimum cell size) and slides the window to keep the active pane visible: 3×3 on a large terminal, 2×2 on a half-screen, a single row on a short wide split, one pane when tiny. A position mini-map in the status bar (the nine keys in three groups) shows where the active pane sits whenever the grid is reduced.
 
-**Status bar** — `[MODE]` tag (NAV / MENU / CMD, or ZOOM) · breadcrumb (`COCKPIT › PANE › …`) · transient error (crit) or success toast · right-aligned meta (`⟳` while loading, active probe `⏻ name` when the fleet has >1 probe or the pilot is off the default — accented when non-default, `⚠` when unreachable, `≣ SCUT`, unread `! n`, `API vN`, clock). A second **hints line** (toggle `F1`) shows the keys valid for the active pane.
+**Status bar** — `[MODE]` tag (NAV / MENU / CMD, or ZOOM) · breadcrumb (`COCKPIT › PANE › …`) · transient error (crit) or success toast · right-aligned meta (`⟳` while loading, active probe `⏻ name` when the fleet has >1 probe or the pilot is off the default — accented when non-default, `⚠` when unreachable, `≣ SCUT`, `⚙ N idle` (idle Mannies, bold warn — `i` cycles to the next), unread `! n`, `API vN`, clock). A second **hints line** (toggle `F1`) shows the keys valid for the active pane.
 
 **Boot** (`src/app/boot.rs` + `cockpit_v2::render_boot`) — on startup the probe core boots first (centre pane self-check), then the eight subsystems come online centre-out, each typing a themed teletype self-check (SUDDAR array, SCUT link, autofactory, manny bay…). Once done it holds on `ANY KEY TO CONTINUE` in the centre pane; any key drops into the live cockpit (or skips the animation). Driven by the bounded boot tick.
 

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -333,6 +333,39 @@ impl AppState {
             .unwrap_or_default()
     }
 
+    /// Indices (into `mannies`) of idle Mannies — onboard and free to take an
+    /// order. Backs the status-bar "N idle" indicator and the idle-cycling key.
+    fn idle_manny_indices(&self) -> Vec<usize> {
+        self.mannies.as_ref().map_or(Vec::new(), |ms| {
+            ms.iter()
+                .enumerate()
+                .filter(|(_, m)| {
+                    m.location.location_type == crate::api::types::MannyLocationType::Probe
+                        && m.can_receive_orders
+                })
+                .map(|(i, _)| i)
+                .collect()
+        })
+    }
+
+    /// How many Mannies are idle (onboard, awaiting orders).
+    pub fn idle_manny_count(&self) -> usize {
+        self.idle_manny_indices().len()
+    }
+
+    /// Focus the Mannies pane and move its cursor to the next idle Manny after
+    /// the current selection, wrapping around. No-op when none are idle.
+    pub fn cycle_to_next_idle_manny(&mut self) {
+        let idle = self.idle_manny_indices();
+        let Some(&first) = idle.first() else {
+            self.set_toast("no idle mannies");
+            return;
+        };
+        self.active_pane = crate::app::Pane::Mannies;
+        let cur = self.mannies_selection;
+        self.mannies_selection = idle.iter().copied().find(|&i| i > cur).unwrap_or(first);
+    }
+
     pub fn collect_deploy_candidates(&self) -> Vec<(String, String)> {
         self.probe_current_sector_scan()
             .and_then(|s| s.objects.as_ref())

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -482,6 +482,27 @@ fn manny_next_advances() {
 }
 
 #[test]
+fn idle_manny_count_and_cycling() {
+    let mut state = AppState::default();
+    state.mannies = Some(vec![
+        make_manny("m0", "probe", false, Some("mining")), // busy
+        make_manny("m1", "probe", true, None),            // idle
+        make_manny("m2", "sector", true, None),           // not onboard
+        make_manny("m3", "probe", true, None),            // idle
+    ]);
+    assert_eq!(state.idle_manny_count(), 2, "only onboard, order-ready mannies");
+
+    state.mannies_selection = 0;
+    state.cycle_to_next_idle_manny();
+    assert_eq!(state.active_pane, crate::app::Pane::Mannies, "focuses the Mannies pane");
+    assert_eq!(state.mannies_selection, 1, "first idle after index 0");
+    state.cycle_to_next_idle_manny();
+    assert_eq!(state.mannies_selection, 3, "next idle");
+    state.cycle_to_next_idle_manny();
+    assert_eq!(state.mannies_selection, 1, "wraps to the first idle");
+}
+
+#[test]
 fn manny_next_wraps() {
     let mut state = AppState::default();
     state.mannies = Some(vec![

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -72,6 +72,8 @@ pub fn handle_cockpit_event(
         KeyCode::Char('z') => state.toggle_zoom(),
         KeyCode::Char(':') => state.mode = InputMode::Command(CommandLine::default()),
         KeyCode::Char('?') => state.help_open = true,
+        // Jump to the next idle Manny (focuses the Mannies pane).
+        KeyCode::Char('i') => state.cycle_to_next_idle_manny(),
         KeyCode::F(1) => state.hints_visible = !state.hints_visible,
         // Esc backs out one step: leave zoom first, then drill up.
         KeyCode::Esc => {

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -307,6 +307,12 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
     if !state.scut_coverage().is_empty() {
         meta.push(("≣ SCUT".to_string(), accent));
     }
+    // Idle-Manny nudge: bold warning colour so free workers don't go unnoticed
+    // (`i` cycles to the next one).
+    let idle = state.idle_manny_count();
+    if idle > 0 {
+        meta.push((format!("⚙ {idle} idle"), Style::default().fg(p.warn).add_modifier(Modifier::BOLD)));
+    }
     let unread = state.unread_alert_count();
     if unread > 0 {
         // Urgency signal: crit_style survives the mono palettes (bold+REVERSED).

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -29,6 +29,8 @@ const LEFT: &[Section] = &[
             ("d f g", "Sector · Probe · Missions"),
             ("c v b", "Inventory · Storage · Mannies"),
             ("j k / ↑↓", "move cursor in pane"),
+            ("PgUp PgDn", "page through long lists"),
+            ("Home End", "jump to first / last"),
             ("l / h", "drill in / out (→ ←)"),
             ("Tab", "cycle panes (Shift-Tab reverse)"),
             ("z", "zoom active pane full screen"),
@@ -40,6 +42,7 @@ const LEFT: &[Section] = &[
         &[
             ("Enter", "contextual action menu"),
             (":", "command line (see right)"),
+            ("i", "jump to next idle Manny"),
             ("F1", "toggle hints line"),
             ("F2", "cycle color mode"),
             ("F5", "refresh"),


### PR DESCRIPTION
Phase 1 — P1.4: idle-Manny indicator and cycling (last of Phase 1).

- Status bar shows a bold "⚙ N idle" nudge when Mannies are onboard and free to
  take an order.
- `i` focuses the Mannies pane and jumps to the next idle Manny, wrapping.
- Backed by idle_manny_count / cycle_to_next_idle_manny.
- Help overlay audit: added `i`, and the pre-existing PgUp/PgDn + Home/End
  paging keys that had drifted out of the help screen.

278 tests pass. Completes Phase 1 (journal #188-190 merged, naming #192, this).
