### PR TITLE
refactor(api): factor the tokio::spawn mould in tasks.rs

### DIFF
--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -1,63 +1,82 @@
 use crate::api::client::ApiClient;
 use crate::api::types::EndpointId;
 use crate::app::ApiMessage;
+use std::fmt::Display;
+use std::future::Future;
 use tokio::sync::mpsc;
 
-pub fn fetch_api_version(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+/// Spawn an **action** task: await `fut`, map its `Ok`/`Err` to an `ApiMessage`
+/// and send the result. This is the shape of every wrapper whose failure must
+/// reach the pilot — the error is stringified into the `on_err` message.
+///
+/// Callers pass an `async move { … }` that owns the client + args, so the future
+/// is `'static` and self-contained. `on_ok` is often a variant constructor
+/// (`ApiMessage::MoveStarted`) or `|_| ApiMessage::Started` when the value is
+/// unused; `on_err` is the matching error-variant constructor.
+fn spawn_action<T, E>(
+    tx: mpsc::Sender<ApiMessage>,
+    fut: impl Future<Output = Result<T, E>> + Send + 'static,
+    on_ok: impl FnOnce(T) -> ApiMessage + Send + 'static,
+    on_err: impl FnOnce(String) -> ApiMessage + Send + 'static,
+) where
+    T: Send + 'static,
+    E: Display + Send + 'static,
+{
     tokio::spawn(async move {
-        if let Ok(v) = client.get_api_version().await {
-            let _ = tx.send(ApiMessage::VersionFetched(v)).await;
+        let msg = match fut.await {
+            Ok(v) => on_ok(v),
+            Err(e) => on_err(e.to_string()),
+        };
+        let _ = tx.send(msg).await;
+    });
+}
+
+/// Spawn a **non-fatal fetch** task: await `fut`, send `on_ok(v)` on success,
+/// drop errors silently. For background refreshes (roster, alerts, missions…)
+/// whose failure should not disturb the cockpit.
+fn spawn_fetch<T, E>(
+    tx: mpsc::Sender<ApiMessage>,
+    fut: impl Future<Output = Result<T, E>> + Send + 'static,
+    on_ok: impl FnOnce(T) -> ApiMessage + Send + 'static,
+) where
+    T: Send + 'static,
+    E: Send + 'static,
+{
+    tokio::spawn(async move {
+        if let Ok(v) = fut.await {
+            let _ = tx.send(on_ok(v)).await;
         }
     });
 }
 
+pub fn fetch_api_version(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    spawn_fetch(tx, async move { client.get_api_version().await }, ApiMessage::VersionFetched);
+}
+
 pub fn fetch_all(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    let c1 = client.clone();
-    let tx1 = tx.clone();
-    tokio::spawn(async move {
-        let msg = match c1.get_probe().await {
-            Ok(p) => ApiMessage::ProbeUpdated(p),
-            Err(e) => ApiMessage::Error(e.to_string()),
-        };
-        let _ = tx1.send(msg).await;
-    });
+    // Probe is the one fatal fetch — a failure surfaces as an error toast and
+    // drives the refresh backoff.
+    let c = client.clone();
+    spawn_action(
+        tx.clone(),
+        async move { c.get_probe().await },
+        ApiMessage::ProbeUpdated,
+        ApiMessage::Error,
+    );
 
-    let c2 = client.clone();
-    let tx2 = tx.clone();
-    tokio::spawn(async move {
-        if let Ok(m) = c2.get_mannies().await {
-            let _ = tx2.send(ApiMessage::ManniesUpdated(m)).await;
-        }
-    });
+    // Mannies, sector, visited sectors and the fleet roster are all non-fatal.
+    let c = client.clone();
+    spawn_fetch(tx.clone(), async move { c.get_mannies().await }, ApiMessage::ManniesUpdated);
+    let c = client.clone();
+    spawn_fetch(tx.clone(), async move { c.get_probe_sector().await }, ApiMessage::SectorUpdated);
+    let c = client.clone();
+    spawn_fetch(tx.clone(), async move { c.get_visited_sectors().await }, ApiMessage::VisitedSectorsFetched);
+    // Fleet roster (API v81 multi-probe): drives the probe switcher.
+    let c = client.clone();
+    spawn_fetch(tx.clone(), async move { c.get_probes().await }, ApiMessage::FleetFetched);
 
-    let c3 = client.clone();
-    let tx3 = tx.clone();
-    tokio::spawn(async move {
-        if let Ok(s) = c3.get_probe_sector().await {
-            let _ = tx3.send(ApiMessage::SectorUpdated(s)).await;
-        }
-    });
-
-    // Non-fatal, like mannies and sector.
-    let c4 = client.clone();
-    let tx4 = tx.clone();
-    tokio::spawn(async move {
-        if let Ok(v) = c4.get_visited_sectors().await {
-            let _ = tx4.send(ApiMessage::VisitedSectorsFetched(v)).await;
-        }
-    });
-
-    // Fleet roster (API v81 multi-probe): non-fatal, drives the probe switcher.
-    let cf = client.clone();
-    let txf = tx.clone();
-    tokio::spawn(async move {
-        if let Ok(list) = cf.get_probes().await {
-            let _ = txf.send(ApiMessage::FleetFetched(list)).await;
-        }
-    });
-
-    // Alerts + damage warnings + missions + probe improvements: non-fatal, same
-    // pattern as mannies/sector.
+    // Alerts + damage warnings + missions + probe improvements: same non-fatal
+    // pattern, each in its own wrapper.
     fetch_alerts(client.clone(), tx.clone());
     fetch_missions(client.clone(), tx.clone());
     fetch_probe_improvements(client.clone(), tx.clone());
@@ -65,11 +84,11 @@ pub fn fetch_all(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
 }
 
 pub fn fetch_probe_improvements(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok(improvements) = client.get_probe_improvements().await {
-            let _ = tx.send(ApiMessage::ProbeImprovementsFetched(improvements)).await;
-        }
-    });
+    spawn_fetch(
+        tx,
+        async move { client.get_probe_improvements().await },
+        ApiMessage::ProbeImprovementsFetched,
+    );
 }
 
 pub fn fetch_improve_probe(
@@ -78,37 +97,32 @@ pub fn fetch_improve_probe(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.improve_probe(&manny_id, &improvement).await {
-            Ok(_) => ApiMessage::ImproveProbeStarted,
-            Err(e) => ApiMessage::ImproveProbeError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.improve_probe(&manny_id, &improvement).await },
+        |_| ApiMessage::ImproveProbeStarted,
+        ApiMessage::ImproveProbeError,
+    );
 }
 
 pub fn fetch_missions(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok(m) = client.get_missions().await {
-            let _ = tx.send(ApiMessage::MissionsFetched(m)).await;
-        }
-    });
+    spawn_fetch(tx, async move { client.get_missions().await }, ApiMessage::MissionsFetched);
 }
 
 pub fn fetch_messages(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok((messages, _pag)) = client.get_messages().await {
-            let _ = tx.send(ApiMessage::MessagesFetched(messages)).await;
-        }
-    });
+    spawn_fetch(
+        tx,
+        async move { client.get_messages().await },
+        |(messages, _pag)| ApiMessage::MessagesFetched(messages),
+    );
 }
 
 pub fn fetch_sent_messages(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok((messages, _pag)) = client.get_sent_messages().await {
-            let _ = tx.send(ApiMessage::SentMessagesFetched(messages)).await;
-        }
-    });
+    spawn_fetch(
+        tx,
+        async move { client.get_sent_messages().await },
+        |(messages, _pag)| ApiMessage::SentMessagesFetched(messages),
+    );
 }
 
 pub fn fetch_send_message(
@@ -118,129 +132,119 @@ pub fn fetch_send_message(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.send_message(&recipient_type, &recipient_id, &body).await {
-            Ok(m) => ApiMessage::MessageSent(m),
-            Err(e) => ApiMessage::MessageSendError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.send_message(&recipient_type, &recipient_id, &body).await },
+        ApiMessage::MessageSent,
+        ApiMessage::MessageSendError,
+    );
 }
 
 pub fn fetch_mark_message_read(id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.mark_message_read(id).await {
-            Ok(m) => ApiMessage::MessageMarkedRead(m),
-            Err(e) => ApiMessage::ActionError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.mark_message_read(id).await },
+        ApiMessage::MessageMarkedRead,
+        ApiMessage::ActionError,
+    );
 }
 
 pub fn fetch_abandon_mission(mission_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.abandon_mission(&mission_id).await {
-            Ok(m) => ApiMessage::MissionAbandoned(m),
-            Err(e) => ApiMessage::MissionAbandonError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.abandon_mission(&mission_id).await },
+        ApiMessage::MissionAbandoned,
+        ApiMessage::MissionAbandonError,
+    );
 }
 
 pub fn fetch_alerts(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok(a) = client.get_alerts().await {
-            let _ = tx.send(ApiMessage::AlertsFetched(a)).await;
-        }
-    });
+    spawn_fetch(tx, async move { client.get_alerts().await }, ApiMessage::AlertsFetched);
 }
 
 pub fn fetch_damage_warnings(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok((warnings, rule)) = client.get_damage_warnings().await {
-            let _ = tx.send(ApiMessage::DamageWarningsFetched(warnings, rule)).await;
-        }
-    });
+    spawn_fetch(
+        tx,
+        async move { client.get_damage_warnings().await },
+        |(warnings, rule)| ApiMessage::DamageWarningsFetched(warnings, rule),
+    );
 }
 
 pub fn fetch_ack_alert(id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.ack_alert(id).await {
-            Ok(a) => ApiMessage::AlertAcknowledged(a),
-            Err(e) => ApiMessage::ActionError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.ack_alert(id).await },
+        ApiMessage::AlertAcknowledged,
+        ApiMessage::ActionError,
+    );
 }
 
 pub fn fetch_ack_damage_warning(id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.ack_damage_warning(id).await {
-            Ok(w) => ApiMessage::DamageWarningAcknowledged(w),
-            Err(e) => ApiMessage::ActionError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.ack_damage_warning(id).await },
+        ApiMessage::DamageWarningAcknowledged,
+        ApiMessage::ActionError,
+    );
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn fetch_storage_move(
-    actor_manny_id: String,
-    kind: String,
-    to_container_id: String,
-    from_container_id: Option<String>,
-    resource_type: Option<String>,
-    amount: Option<f64>,
-    item_ids: Option<Vec<String>>,
-    client: ApiClient,
-    tx: mpsc::Sender<ApiMessage>,
-) {
-    tokio::spawn(async move {
-        let msg = match client
-            .storage_move(
-                &actor_manny_id,
-                &kind,
-                &to_container_id,
-                from_container_id.as_deref(),
-                resource_type.as_deref(),
-                amount,
-                item_ids,
-            )
-            .await
-        {
-            Ok((m, inv)) => ApiMessage::StorageMoveDone(m, inv),
-            Err(e) => ApiMessage::StorageMoveError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+/// Parameters of a storage-move task, grouped into a struct so the wrapper stays
+/// under clippy's argument-count threshold (was a 9-arg signature).
+pub struct StorageMoveArgs {
+    pub actor_manny_id: String,
+    pub kind: String,
+    pub to_container_id: String,
+    pub from_container_id: Option<String>,
+    pub resource_type: Option<String>,
+    pub amount: Option<f64>,
+    pub item_ids: Option<Vec<String>>,
+}
+
+pub fn fetch_storage_move(args: StorageMoveArgs, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+    spawn_action(
+        tx,
+        async move {
+            client
+                .storage_move(
+                    &args.actor_manny_id,
+                    &args.kind,
+                    &args.to_container_id,
+                    args.from_container_id.as_deref(),
+                    args.resource_type.as_deref(),
+                    args.amount,
+                    args.item_ids,
+                )
+                .await
+        },
+        |(m, inv)| ApiMessage::StorageMoveDone(m, inv),
+        ApiMessage::StorageMoveError,
+    );
 }
 
 pub fn fetch_storage_containers(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok(c) = client.get_storage_containers().await {
-            let _ = tx.send(ApiMessage::StorageContainersFetched(c)).await;
-        }
-    });
+    spawn_fetch(
+        tx,
+        async move { client.get_storage_containers().await },
+        ApiMessage::StorageContainersFetched,
+    );
 }
 
 pub fn fetch_storage_container_detail(id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.get_storage_container(&id).await {
-            Ok((c, inv)) => ApiMessage::StorageContainerDetailFetched(c, inv),
-            Err(e) => ApiMessage::StorageContainerDetailError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.get_storage_container(&id).await },
+        |(c, inv)| ApiMessage::StorageContainerDetailFetched(c, inv),
+        ApiMessage::StorageContainerDetailError,
+    );
 }
 
 pub fn fetch_rename_container(id: String, label: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.rename_storage_container(&id, &label).await {
-            Ok((c, inv)) => ApiMessage::RenameContainerDone(c, inv),
-            Err(e) => ApiMessage::RenameContainerError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.rename_storage_container(&id, &label).await },
+        |(c, inv)| ApiMessage::RenameContainerDone(c, inv),
+        ApiMessage::RenameContainerError,
+    );
 }
 
 pub fn fetch_update_container_rules(
@@ -251,41 +255,34 @@ pub fn fetch_update_container_rules(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.update_container_rules(&id, priority, exclusion, strict_exclusion).await {
-            Ok((c, inv)) => ApiMessage::UpdateContainerRulesDone(c, inv),
-            Err(e) => ApiMessage::UpdateContainerRulesError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.update_container_rules(&id, priority, exclusion, strict_exclusion).await },
+        |(c, inv)| ApiMessage::UpdateContainerRulesDone(c, inv),
+        ApiMessage::UpdateContainerRulesError,
+    );
 }
 
 pub fn fetch_mannies(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok(m) = client.get_mannies().await {
-            let _ = tx.send(ApiMessage::ManniesUpdated(m)).await;
-        }
-    });
+    spawn_fetch(tx, async move { client.get_mannies().await }, ApiMessage::ManniesUpdated);
 }
 
 pub fn fetch_move(x: i32, y: i32, z: i32, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.move_probe(x, y, z).await {
-            Ok(mv) => ApiMessage::MoveStarted(mv),
-            Err(e) => ApiMessage::MoveError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.move_probe(x, y, z).await },
+        ApiMessage::MoveStarted,
+        ApiMessage::MoveError,
+    );
 }
 
 pub fn fetch_repair(manny_id: String, integrity_percent: f64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.repair_manny(&manny_id, integrity_percent).await {
-            Ok(_) => ApiMessage::RepairStarted,
-            Err(e) => ApiMessage::RepairError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.repair_manny(&manny_id, integrity_percent).await },
+        |_| ApiMessage::RepairStarted,
+        ApiMessage::RepairError,
+    );
 }
 
 pub fn fetch_mine(
@@ -297,115 +294,104 @@ pub fn fetch_mine(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.mine_manny(&manny_id, &object_id, resources, target_amount, target_container_id).await {
-            Ok(_) => ApiMessage::MineStarted,
-            Err(e) => ApiMessage::MineError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move {
+            client.mine_manny(&manny_id, &object_id, resources, target_amount, target_container_id).await
+        },
+        |_| ApiMessage::MineStarted,
+        ApiMessage::MineError,
+    );
 }
 
 pub fn fetch_jettison(item_id: String, amount: Option<f64>, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.jettison_inventory(&item_id, amount).await {
-            Ok(inv) => ApiMessage::JettisonDone(inv),
-            Err(e) => ApiMessage::JettisonError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.jettison_inventory(&item_id, amount).await },
+        ApiMessage::JettisonDone,
+        ApiMessage::JettisonError,
+    );
 }
 
 pub fn fetch_craft(manny_id: String, recipe: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.craft_manny(&manny_id, &recipe).await {
-            Ok(_) => ApiMessage::CraftStarted,
-            Err(e) => ApiMessage::CraftError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.craft_manny(&manny_id, &recipe).await },
+        |_| ApiMessage::CraftStarted,
+        ApiMessage::CraftError,
+    );
 }
 
 pub fn fetch_crafting_recipes(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        if let Ok(recipes) = client.get_crafting_recipes().await {
-            let _ = tx.send(ApiMessage::RecipesFetched(recipes)).await;
-        }
-    });
+    spawn_fetch(tx, async move { client.get_crafting_recipes().await }, ApiMessage::RecipesFetched);
 }
 
 pub fn fetch_atomic_printer_craft(recipe: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.craft_atomic_printer(&recipe).await {
-            Ok(()) => ApiMessage::AtomicPrinterCraftStarted,
-            Err(e) => ApiMessage::AtomicPrinterCraftError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.craft_atomic_printer(&recipe).await },
+        |()| ApiMessage::AtomicPrinterCraftStarted,
+        ApiMessage::AtomicPrinterCraftError,
+    );
 }
 
 pub fn fetch_salvage(manny_id: String, object_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.salvage_manny(&manny_id, &object_id).await {
-            Ok(_) => ApiMessage::SalvageStarted,
-            Err(e) => ApiMessage::SalvageError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.salvage_manny(&manny_id, &object_id).await },
+        |_| ApiMessage::SalvageStarted,
+        ApiMessage::SalvageError,
+    );
 }
 
 pub fn fetch_recall(manny_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.recall_manny(&manny_id).await {
-            Ok(_) => ApiMessage::RecallStarted,
-            Err(e) => ApiMessage::RecallError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.recall_manny(&manny_id).await },
+        |_| ApiMessage::RecallStarted,
+        ApiMessage::RecallError,
+    );
 }
 
 pub fn fetch_sector(coords: Option<(i32, i32, i32)>, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let result = match coords {
-            None => client.get_probe_sector().await,
-            Some((x, y, z)) => client.get_sector(x, y, z).await,
-        };
-        let msg = match result {
-            Ok(s) => ApiMessage::SectorUpdated(s),
-            Err(e) => ApiMessage::ScanError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move {
+            match coords {
+                None => client.get_probe_sector().await,
+                Some((x, y, z)) => client.get_sector(x, y, z).await,
+            }
+        },
+        ApiMessage::SectorUpdated,
+        ApiMessage::ScanError,
+    );
 }
 
 pub fn fetch_deploy(manny_id: String, object_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.install_bookmark_manny(&manny_id, &object_id, &name).await {
-            Ok(_) => ApiMessage::DeployStarted,
-            Err(e) => ApiMessage::DeployError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.install_bookmark_manny(&manny_id, &object_id, &name).await },
+        |_| ApiMessage::DeployStarted,
+        ApiMessage::DeployError,
+    );
 }
 
 pub fn fetch_inspect(manny_id: String, object_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.inspect_sector_object(&manny_id, &object_id).await {
-            Ok(_) => ApiMessage::InspectStarted,
-            Err(e) => ApiMessage::InspectError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.inspect_sector_object(&manny_id, &object_id).await },
+        |_| ApiMessage::InspectStarted,
+        ApiMessage::InspectError,
+    );
 }
 
 pub fn fetch_recover(manny_id: String, object_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.recover_storage_container(&manny_id, &object_id).await {
-            Ok(_) => ApiMessage::RecoverStarted,
-            Err(e) => ApiMessage::RecoverError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.recover_storage_container(&manny_id, &object_id).await },
+        |_| ApiMessage::RecoverStarted,
+        ApiMessage::RecoverError,
+    );
 }
 
 pub fn fetch_detach(
@@ -416,13 +402,14 @@ pub fn fetch_detach(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.detach_storage_container(&manny_id, &container_id, &mode, object_id.as_deref()).await {
-            Ok(_) => ApiMessage::DetachStarted,
-            Err(e) => ApiMessage::DetachError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move {
+            client.detach_storage_container(&manny_id, &container_id, &mode, object_id.as_deref()).await
+        },
+        |_| ApiMessage::DetachStarted,
+        ApiMessage::DetachError,
+    );
 }
 
 pub fn fetch_drop_storage_container(
@@ -432,16 +419,14 @@ pub fn fetch_drop_storage_container(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client
-            .drop_storage_container_on_planet(&manny_id, &container_id, &planet_id)
-            .await
-        {
-            Ok(m) => ApiMessage::DropStorageContainerStarted(m),
-            Err(e) => ApiMessage::DropStorageContainerError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move {
+            client.drop_storage_container_on_planet(&manny_id, &container_id, &planet_id).await
+        },
+        ApiMessage::DropStorageContainerStarted,
+        ApiMessage::DropStorageContainerError,
+    );
 }
 
 pub fn fetch_assemble_probe(
@@ -450,33 +435,30 @@ pub fn fetch_assemble_probe(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.assemble_probe(&manny_id, &container_ids).await {
-            Ok((m, inv)) => ApiMessage::AssembleProbeStarted(m, inv),
-            Err(e) => ApiMessage::AssembleProbeError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.assemble_probe(&manny_id, &container_ids).await },
+        |(m, inv)| ApiMessage::AssembleProbeStarted(m, inv),
+        ApiMessage::AssembleProbeError,
+    );
 }
 
 pub fn fetch_drop_manny_cargo(manny_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.drop_manny_cargo(&manny_id).await {
-            Ok(m) => ApiMessage::DropMannyCargoStarted(m),
-            Err(e) => ApiMessage::DropMannyCargoError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.drop_manny_cargo(&manny_id).await },
+        ApiMessage::DropMannyCargoStarted,
+        ApiMessage::DropMannyCargoError,
+    );
 }
 
 pub fn fetch_refill_deuterium(manny_id: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.refill_deuterium_tank(&manny_id).await {
-            Ok(_) => ApiMessage::DeuteriumRefuelStarted,
-            Err(e) => ApiMessage::DeuteriumRefuelError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.refill_deuterium_tank(&manny_id).await },
+        |_| ApiMessage::DeuteriumRefuelStarted,
+        ApiMessage::DeuteriumRefuelError,
+    );
 }
 
 pub fn fetch_transfer_deuterium(
@@ -486,26 +468,21 @@ pub fn fetch_transfer_deuterium(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client
-            .transfer_deuterium_to_probe(&manny_id, target_probe_id, amount)
-            .await
-        {
-            Ok(_) => ApiMessage::DeuteriumTransferStarted,
-            Err(e) => ApiMessage::DeuteriumTransferError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.transfer_deuterium_to_probe(&manny_id, target_probe_id, amount).await },
+        |_| ApiMessage::DeuteriumTransferStarted,
+        ApiMessage::DeuteriumTransferError,
+    );
 }
 
 pub fn fetch_scut_network(network_id: i64, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.get_scut_network(network_id).await {
-            Ok(n) => ApiMessage::ScutNetworkFetched(n),
-            Err(e) => ApiMessage::ScutNetworkError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.get_scut_network(network_id).await },
+        ApiMessage::ScutNetworkFetched,
+        ApiMessage::ScutNetworkError,
+    );
 }
 
 pub fn fetch_turn_on_relay(
@@ -515,13 +492,12 @@ pub fn fetch_turn_on_relay(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.turn_on_relay(&manny_id, relay_id, network_name.as_deref()).await {
-            Ok(_) => ApiMessage::ScutRelayTurnedOn,
-            Err(e) => ApiMessage::ScutRelayTurnOnError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.turn_on_relay(&manny_id, relay_id, network_name.as_deref()).await },
+        |_| ApiMessage::ScutRelayTurnedOn,
+        ApiMessage::ScutRelayTurnOnError,
+    );
 }
 
 /// Promote a probe to the player's default (`PATCH /api/probe/{id}`). The
@@ -532,13 +508,12 @@ pub fn fetch_set_default_probe(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.patch_probe(probe_id, None, Some(true)).await {
-            Ok(list) => ApiMessage::DefaultProbeSet(list, name),
-            Err(e) => ApiMessage::ActionError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.patch_probe(probe_id, None, Some(true)).await },
+        move |list| ApiMessage::DefaultProbeSet(list, name),
+        ApiMessage::ActionError,
+    );
 }
 
 /// Rename a probe (`PATCH /api/probe/{id}` with `name`, API v81).
@@ -548,31 +523,31 @@ pub fn fetch_rename_probe(
     client: ApiClient,
     tx: mpsc::Sender<ApiMessage>,
 ) {
-    tokio::spawn(async move {
-        let msg = match client.patch_probe(probe_id, Some(&name), None).await {
-            Ok(list) => ApiMessage::ProbeRenamed(list, name),
-            Err(e) => ApiMessage::RenameProbeError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    // `name` is needed both in the request and in the success message; clone so
+    // the future can borrow one copy while the `on_ok` closure owns the other.
+    let label = name.clone();
+    spawn_action(
+        tx,
+        async move { client.patch_probe(probe_id, Some(&name), None).await },
+        move |list| ApiMessage::ProbeRenamed(list, label),
+        ApiMessage::RenameProbeError,
+    );
 }
 
 pub fn fetch_reassign_mind_snapshot(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.reassign_mind_snapshot().await {
-            Ok(probe) => ApiMessage::MindSnapshotReassigned(probe),
-            Err(e) => ApiMessage::MindSnapshotReassignError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.reassign_mind_snapshot().await },
+        ApiMessage::MindSnapshotReassigned,
+        ApiMessage::MindSnapshotReassignError,
+    );
 }
 
 pub fn fetch_rename_manny(manny_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    tokio::spawn(async move {
-        let msg = match client.rename_manny(&manny_id, &name).await {
-            Ok(manny) => ApiMessage::RenameMannyDone(manny),
-            Err(e) => ApiMessage::RenameMannyError(e.to_string()),
-        };
-        let _ = tx.send(msg).await;
-    });
+    spawn_action(
+        tx,
+        async move { client.rename_manny(&manny_id, &name).await },
+        ApiMessage::RenameMannyDone,
+        ApiMessage::RenameMannyError,
+    );
 }

--- a/src/input/storage_move.rs
+++ b/src/input/storage_move.rs
@@ -2,7 +2,7 @@ use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
-use crate::api::tasks::fetch_storage_move;
+use crate::api::tasks::{fetch_storage_move, StorageMoveArgs};
 use crate::app::{ApiMessage, AppState, LogEvent, StorageMoveInput, MOVE_RESOURCE_TYPES};
 
 use super::geometry::list_nav;
@@ -184,13 +184,15 @@ fn handle_resource(
             let to_id = containers[*to_sel].0.clone();
             let to_name = containers[*to_sel].1.clone();
             fetch_storage_move(
-                actor,
-                "resource".into(),
-                to_id,
-                Some(from_id),
-                Some(resource.clone()),
-                Some(amount),
-                None,
+                StorageMoveArgs {
+                    actor_manny_id: actor,
+                    kind: "resource".into(),
+                    to_container_id: to_id,
+                    from_container_id: Some(from_id),
+                    resource_type: Some(resource.clone()),
+                    amount: Some(amount),
+                    item_ids: None,
+                },
                 client.clone(),
                 tx.clone(),
             );
@@ -238,13 +240,15 @@ fn handle_item(
             let to_name = containers[*to_sel].1.clone();
             let count = ids.len();
             fetch_storage_move(
-                actor,
-                "item".into(),
-                to_id,
-                None,
-                None,
-                None,
-                Some(ids),
+                StorageMoveArgs {
+                    actor_manny_id: actor,
+                    kind: "item".into(),
+                    to_container_id: to_id,
+                    from_container_id: None,
+                    resource_type: None,
+                    amount: None,
+                    item_ids: Some(ids),
+                },
                 client.clone(),
                 tx.clone(),
             );


### PR DESCRIPTION
## What

Every endpoint wrapper in `src/api/tasks.rs` hand-rolled the same `tokio::spawn` scaffold — spawn, await the client call, match `Ok`/`Err` into an `ApiMessage` (or drop errors for background fetches), send on the channel. ~45 near-identical blocks.

## How

Two helpers replace the scaffold:

- `spawn_action(tx, fut, on_ok, on_err)` — actions whose failure must reach the pilot; the error is stringified into `on_err`.
- `spawn_fetch(tx, fut, on_ok)` — non-fatal background refreshes (roster, alerts, missions…); errors are dropped silently.

Each wrapper passes an `async move { client.foo(&args).await }` future that owns its captures (so it is `'static`, sidestepping the client's `&self`/`&args` borrow), plus the message constructors. `tokio::spawn` now appears exactly twice in the file.

`fetch_storage_move`'s 9 parameters are grouped into a `StorageMoveArgs` struct, which removes the last `#[allow(clippy::too_many_arguments)]` in `tasks.rs`. Both call sites in `src/input/storage_move.rs` are updated.

## Behaviour

Unchanged. The 45 public `fetch_*` wrappers keep their names; only `fetch_storage_move`'s signature changes (params → struct).

## Tests

- `cargo test`: 281 passed. `cargo clippy` (lib): clean.
- No `#[allow(clippy::too_many_arguments)]` left in `tasks.rs`.

This unblocks #212 (the generic spawner is now testable in isolation).

Closes #209.