### PR TITLE
refactor(app): collapse the 31 wizard fields into one ActiveWizard enum

### DIFF
--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -191,7 +191,7 @@ impl AppState {
             "travel" => {
                 // Accept "x y z" or "+dx dy dz" (commas tolerated).
                 let buf = args.join(" ").replace(',', " ");
-                self.travel = TravelInput::Typing(buf);
+                self.active_wizard = ActiveWizard::Travel(TravelInput::Typing(buf));
                 self.travel_submit();
             }
             "goto" => match parse_coords(&args) {
@@ -236,11 +236,11 @@ impl AppState {
                     self.set_toast("recipes loading — F5 to refresh");
                 } else if args.is_empty() {
                     // Bare `:craft` opens the wizard (unchanged).
-                    self.fabrication = FabricationInput::PickRecipe {
+                    self.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe {
                         prefilled_manny: None,
                         selection: 0,
                         error: None,
-                    };
+                    });
                 } else {
                     // `:craft <recipe>` fires directly.
                     self.craft_command(&args.join(" "));
@@ -311,13 +311,13 @@ impl AppState {
                     }
                     // Ambiguous builder → let the pilot pick in the wizard.
                     _ => {
-                        self.fabrication = FabricationInput::PickBuilder {
+                        self.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickBuilder {
                             recipe_id,
                             recipe_name,
                             mannies,
                             selection: 0,
                             error: None,
-                        };
+                        });
                     }
                 }
             }
@@ -344,7 +344,7 @@ impl AppState {
             0 => self.set_toast("no mineable objects in current sector — scan first"),
             1 => {
                 let (object_id, object_name) = candidates.into_iter().next().unwrap();
-                self.mine = MineInput::Configure {
+                self.active_wizard = ActiveWizard::Mine(MineInput::Configure {
                     manny_id,
                     manny_name,
                     object_id,
@@ -354,10 +354,10 @@ impl AppState {
                     amount_mode: false,
                     target_container: None,
                     error: None,
-                };
+                });
             }
             _ => {
-                self.mine = MineInput::PickAsteroid { manny_id, manny_name, candidates, selection: 0 };
+                self.active_wizard = ActiveWizard::Mine(MineInput::PickAsteroid { manny_id, manny_name, candidates, selection: 0 });
             }
         }
     }

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -9,10 +9,7 @@ pub enum ScanMode {
     DirectionPick,
 }
 
-#[derive(Default)]
 pub enum RepairInput {
-    #[default]
-    Inactive,
     Typing {
         manny_id: String,
         manny_name: String,
@@ -21,10 +18,7 @@ pub enum RepairInput {
     },
 }
 
-#[derive(Default)]
 pub enum TravelInput {
-    #[default]
-    Inactive,
     Typing(String),
     Confirming {
         x: i32,
@@ -62,10 +56,7 @@ pub enum ProbeSwitchInput {
 
 /// Rename-probe wizard (API v81): text entry that renames the piloted probe
 /// via `PATCH /api/probe/{id}`.
-#[derive(Default)]
 pub enum RenameProbeInput {
-    #[default]
-    Inactive,
     Typing {
         probe_id: u64,
         current_name: String,
@@ -78,10 +69,7 @@ pub enum RenameProbeInput {
 /// additional containers. Single step — the container multi-select and the
 /// (always-visible) ingredient bill live together; `Enter` with two selected
 /// fires the 3-hour task.
-#[derive(Default)]
 pub enum AssembleProbeInput {
-    #[default]
-    Inactive,
     PickContainers {
         manny_id: String,
         manny_name: String,
@@ -103,10 +91,7 @@ pub const DETACH_MODES: [(&str, &str); 2] = [
     ("hidden_on_asteroid", "hidden — attach to asteroid"),
 ];
 
-#[derive(Default)]
 pub enum ObjectActionInput {
-    #[default]
-    Inactive,
     PickAction {
         object_id: String,
         object_name: String,
@@ -122,10 +107,7 @@ pub enum ObjectActionInput {
     },
 }
 
-#[derive(Default)]
 pub enum AlertsInput {
-    #[default]
-    Inactive,
     /// `show_warnings` selects the Warnings tab; otherwise the Alerts tab.
     /// The entries themselves live in `AppState::alerts` / `damage_warnings`.
     Browsing {
@@ -134,10 +116,7 @@ pub enum AlertsInput {
     },
 }
 
-#[derive(Default)]
 pub enum RenameContainerInput {
-    #[default]
-    Inactive,
     Typing {
         container_id: String,
         current_label: String,
@@ -146,10 +125,7 @@ pub enum RenameContainerInput {
     },
 }
 
-#[derive(Default)]
 pub enum ContainerRulesInput {
-    #[default]
-    Inactive,
     /// Each routable type in `types` is assigned to at most one of the three
     /// lists; `selection` cursors `types`, cycled none → priority → exclusion
     /// → strict via Space.
@@ -169,10 +145,7 @@ pub enum ContainerRulesInput {
 /// not in storage containers, so it is excluded (matches the v44 schema).
 pub const MOVE_RESOURCE_TYPES: [&str; 3] = ["metals", "ice", "carbon_compounds"];
 
-#[derive(Default)]
 pub enum StorageMoveInput {
-    #[default]
-    Inactive,
     PickManny {
         mannies: Vec<(String, String)>,
         selection: usize,
@@ -205,10 +178,7 @@ pub enum StorageMoveInput {
     },
 }
 
-#[derive(Default)]
 pub enum DropStorageContainerInput {
-    #[default]
-    Inactive,
     PickContainer {
         manny_id: String,
         manny_name: String,
@@ -226,10 +196,7 @@ pub enum DropStorageContainerInput {
     },
 }
 
-#[derive(Default)]
 pub enum DropCargoInput {
-    #[default]
-    Inactive,
     /// Confirmation for the irreversible cargo drop (resources are lost).
     Confirm {
         manny_id: String,
@@ -238,10 +205,7 @@ pub enum DropCargoInput {
     },
 }
 
-#[derive(Default)]
 pub enum WaypointsInput {
-    #[default]
-    Inactive,
     Browsing {
         entries: Vec<WaypointEntry>,
         selection: usize,
@@ -260,10 +224,7 @@ pub enum Fabricator {
 
 /// Probe-improvement wizard (API v67+): pick an improvement, then resolve which
 /// idle onboard Manny installs it (auto when a single one, else `PickBuilder`).
-#[derive(Default)]
 pub enum ImproveInput {
-    #[default]
-    Inactive,
     PickImprovement {
         selection: usize,
         error: Option<String>,
@@ -281,10 +242,7 @@ pub enum ImproveInput {
 /// atomic printer and Manny craft. `PickRecipe` lists every recipe sectioned by
 /// fabricator; selecting a Manny recipe with no pre-chosen builder advances to
 /// `PickBuilder`, atomic recipes fire straight away.
-#[derive(Default)]
 pub enum FabricationInput {
-    #[default]
-    Inactive,
     PickRecipe {
         /// A builder Manny (id, name) pre-chosen when the catalog was opened
         /// from the Mannies pane on an orderable Manny. Manny recipes skip the
@@ -303,10 +261,7 @@ pub enum FabricationInput {
     },
 }
 
-#[derive(Default)]
 pub enum MineInput {
-    #[default]
-    Inactive,
     PickAsteroid {
         manny_id: String,
         manny_name: String,
@@ -330,10 +285,7 @@ pub enum MineInput {
 
 /// Remote mining of an idle Manny in a SCUT-reachable sector (API v60).
 /// Targets the Manny's sector; a detached container there is mandatory.
-#[derive(Default)]
 pub enum RemoteMineInput {
-    #[default]
-    Inactive,
     /// Waiting for the Manny's sector scan to arrive.
     Loading {
         manny_id: String,
@@ -375,10 +327,7 @@ pub enum RemoteMineInput {
     },
 }
 
-#[derive(Default)]
 pub enum SalvageInput {
-    #[default]
-    Inactive,
     PickTarget {
         manny_id: String,
         manny_name: String,
@@ -394,10 +343,7 @@ pub enum SalvageInput {
     },
 }
 
-#[derive(Default)]
 pub enum RecallInput {
-    #[default]
-    Inactive,
     Confirm {
         manny_id: String,
         manny_name: String,
@@ -408,10 +354,7 @@ pub enum RecallInput {
     },
 }
 
-#[derive(Default)]
 pub enum RefuelInput {
-    #[default]
-    Inactive,
     /// Confirmation to send a Manny to refill the probe deuterium tank.
     Confirm {
         manny_id: String,
@@ -426,10 +369,7 @@ pub enum RefuelInput {
 /// the percentage to transfer. The same-sector constraint is server-validated
 /// (the roster carries no coordinates), so a wrong target surfaces as an error
 /// in `EnterAmount`.
-#[derive(Default)]
 pub enum TransferDeuteriumInput {
-    #[default]
-    Inactive,
     /// Choose the destination probe from the roster (id, name pairs).
     PickTarget {
         manny_id: String,
@@ -448,19 +388,13 @@ pub enum TransferDeuteriumInput {
     },
 }
 
-#[derive(Default)]
 pub enum MindSnapshotInput {
-    #[default]
-    Inactive,
     /// Confirmation for the irreversible mind-snapshot reassignment to a fresh
     /// probe (only offered when the probe is dead or trapped by a black hole).
     Confirm { error: Option<String> },
 }
 
-#[derive(Default)]
 pub enum ScutRelayInput {
-    #[default]
-    Inactive,
     /// Turn-on wizard for an inactive relay: optional network name then confirm.
     EnterNetworkName {
         manny_id: String,
@@ -472,10 +406,7 @@ pub enum ScutRelayInput {
     },
 }
 
-#[derive(Default)]
 pub enum MessagesInput {
-    #[default]
-    Inactive,
     /// Browsing inbox (sent_tab=false) or sent (true); entries in AppState.
     Browsing { sent_tab: bool, selection: usize },
     /// Reading one message full-screen (its full body + emission sector).
@@ -495,10 +426,7 @@ pub enum MessagesInput {
     },
 }
 
-#[derive(Default)]
 pub enum ScutNetworkInput {
-    #[default]
-    Inactive,
     /// Several networks cover the sector — pick which one to inspect.
     Picking {
         networks: Vec<(i64, String)>, // (network id, name)
@@ -509,10 +437,7 @@ pub enum ScutNetworkInput {
     Viewing { error: Option<String> },
 }
 
-#[derive(Default)]
 pub enum MissionsInput {
-    #[default]
-    Inactive,
     /// Browsing the mission list; entries live in `AppState::missions`.
     Browsing { selection: usize },
     /// Confirmation for abandoning the selected active mission.
@@ -524,10 +449,7 @@ pub enum MissionsInput {
     },
 }
 
-#[derive(Default)]
 pub enum RenameMannyInput {
-    #[default]
-    Inactive,
     Typing {
         manny_id: String,
         manny_name: String,
@@ -536,10 +458,7 @@ pub enum RenameMannyInput {
     },
 }
 
-#[derive(Default)]
 pub enum DeployInput {
-    #[default]
-    Inactive,
     PickManny {
         mannies: Vec<(String, String)>,
         selection: usize,
@@ -558,10 +477,7 @@ pub enum DeployInput {
     },
 }
 
-#[derive(Default)]
 pub enum JettisonInput {
-    #[default]
-    Inactive,
     ConfirmManny {
         item_id: String,
         manny_name: String,
@@ -588,10 +504,7 @@ pub enum JettisonInput {
     },
 }
 
-#[derive(Default)]
 pub enum InspectInput {
-    #[default]
-    Inactive,
     PickTarget {
         manny_id: String,
         manny_name: String,
@@ -601,10 +514,7 @@ pub enum InspectInput {
     },
 }
 
-#[derive(Default)]
 pub enum RecoverInput {
-    #[default]
-    Inactive,
     PickContainer {
         manny_id: String,
         manny_name: String,
@@ -614,10 +524,7 @@ pub enum RecoverInput {
     },
 }
 
-#[derive(Default)]
 pub enum DetachInput {
-    #[default]
-    Inactive,
     PickContainer {
         manny_id: String,
         manny_name: String,
@@ -641,4 +548,46 @@ pub enum DetachInput {
         selection: usize,
         error: Option<String>,
     },
+}
+
+/// The single modal wizard the cockpit currently has open — a sum type over the
+/// 31 mutually-exclusive wizards, replacing 31 coexisting `*Input` fields on
+/// `AppState`. Because only one variant can be held at a time, "two wizards open
+/// at once" is now unrepresentable (the invariant is a compile-time fact, not a
+/// convention). `None` is the sole idle state (it replaced every `*Input::Inactive`).
+#[derive(Default)]
+pub enum ActiveWizard {
+    #[default]
+    None,
+    Repair(RepairInput),
+    Travel(TravelInput),
+    AssembleProbe(AssembleProbeInput),
+    RenameProbe(RenameProbeInput),
+    Jettison(JettisonInput),
+    Fabrication(FabricationInput),
+    Improve(ImproveInput),
+    Salvage(SalvageInput),
+    Recall(RecallInput),
+    Refuel(RefuelInput),
+    TransferDeuterium(TransferDeuteriumInput),
+    MindSnapshot(MindSnapshotInput),
+    ScutRelay(ScutRelayInput),
+    ScutNetwork(ScutNetworkInput),
+    Missions(MissionsInput),
+    Messages(MessagesInput),
+    RenameManny(RenameMannyInput),
+    Deploy(DeployInput),
+    Inspect(InspectInput),
+    Recover(RecoverInput),
+    Detach(DetachInput),
+    Alerts(AlertsInput),
+    RenameContainer(RenameContainerInput),
+    ContainerRules(ContainerRulesInput),
+    StorageMove(StorageMoveInput),
+    DropCargo(DropCargoInput),
+    DropContainer(DropStorageContainerInput),
+    ObjectAction(ObjectActionInput),
+    Waypoints(WaypointsInput),
+    Mine(MineInput),
+    RemoteMine(RemoteMineInput),
 }

--- a/src/app/inventory.rs
+++ b/src/app/inventory.rs
@@ -140,7 +140,7 @@ impl AppState {
     }
 
     pub fn jettison_type_char(&mut self, c: char) {
-        if let JettisonInput::EnterAmount { ref mut buf, .. } = self.jettison {
+        if let ActiveWizard::Jettison(JettisonInput::EnterAmount { buf, .. }) = &mut self.active_wizard {
             if c.is_ascii_digit() || (c == '.' && !buf.contains('.')) {
                 buf.push(c);
             }
@@ -148,13 +148,13 @@ impl AppState {
     }
 
     pub fn jettison_backspace(&mut self) {
-        if let JettisonInput::EnterAmount { ref mut buf, .. } = self.jettison {
+        if let ActiveWizard::Jettison(JettisonInput::EnterAmount { buf, .. }) = &mut self.active_wizard {
             buf.pop();
         }
     }
 
     pub fn jettison_fill_max(&mut self) {
-        if let JettisonInput::EnterAmount { ref mut buf, max_amount, ref mut error, .. } = self.jettison {
+        if let ActiveWizard::Jettison(JettisonInput::EnterAmount { buf, max_amount, error, .. }) = &mut self.active_wizard {
             *buf = format!("{max_amount:.4}");
             *error = None;
         }
@@ -167,11 +167,13 @@ impl AppState {
     }
 
     pub fn set_jettison_error(&mut self, msg: String) {
-        match self.jettison {
-            JettisonInput::ConfirmManny { ref mut error, .. } => *error = Some(msg),
-            JettisonInput::ConfirmRelay { ref mut error, .. } => *error = Some(msg),
-            JettisonInput::EnterAmount { ref mut error, .. } => *error = Some(msg),
-            _ => {}
+        if let ActiveWizard::Jettison(jettison) = &mut self.active_wizard {
+            match jettison {
+                JettisonInput::ConfirmManny { error, .. } => *error = Some(msg),
+                JettisonInput::ConfirmRelay { error, .. } => *error = Some(msg),
+                JettisonInput::EnterAmount { error, .. } => *error = Some(msg),
+                _ => {}
+            }
         }
     }
 

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -41,7 +41,7 @@ impl AppState {
     }
 
     pub fn repair_type_char(&mut self, c: char) {
-        if let RepairInput::Typing { ref mut buf, ref mut error, .. } = self.repair {
+        if let ActiveWizard::Repair(RepairInput::Typing { buf, error, .. }) = &mut self.active_wizard {
             if c.is_ascii_digit() || (c == '.' && !buf.contains('.')) {
                 buf.push(c);
                 *error = None;
@@ -50,63 +50,65 @@ impl AppState {
     }
 
     pub fn repair_backspace(&mut self) {
-        if let RepairInput::Typing { ref mut buf, .. } = self.repair {
+        if let ActiveWizard::Repair(RepairInput::Typing { buf, .. }) = &mut self.active_wizard {
             buf.pop();
         }
     }
 
     pub fn repair_fill_max(&mut self) {
         let max = self.repair_max_percent();
-        if let RepairInput::Typing { ref mut buf, ref mut error, .. } = self.repair {
+        if let ActiveWizard::Repair(RepairInput::Typing { buf, error, .. }) = &mut self.active_wizard {
             *buf = format!("{:.2}", max);
             *error = None;
         }
     }
 
     pub fn set_repair_error(&mut self, msg: String) {
-        if let RepairInput::Typing { ref mut error, .. } = self.repair {
+        if let ActiveWizard::Repair(RepairInput::Typing { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_mine_error(&mut self, msg: String) {
-        if let MineInput::Configure { ref mut error, .. } = self.mine {
+        if let ActiveWizard::Mine(MineInput::Configure { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     /// Surface a craft failure on whichever fabrication step is active.
     pub fn set_fabrication_error(&mut self, msg: String) {
-        match self.fabrication {
-            FabricationInput::PickRecipe { ref mut error, .. } => *error = Some(msg),
-            FabricationInput::PickBuilder { ref mut error, .. } => *error = Some(msg),
-            FabricationInput::Inactive => {}
+        if let ActiveWizard::Fabrication(fab) = &mut self.active_wizard {
+            match fab {
+                FabricationInput::PickRecipe { error, .. } => *error = Some(msg),
+                FabricationInput::PickBuilder { error, .. } => *error = Some(msg),
+            }
         }
     }
 
     /// Surface a probe-improvement failure on whichever step is active.
     pub fn set_improve_error(&mut self, msg: String) {
-        match self.improve {
-            ImproveInput::PickImprovement { ref mut error, .. } => *error = Some(msg),
-            ImproveInput::PickBuilder { ref mut error, .. } => *error = Some(msg),
-            ImproveInput::Inactive => {}
+        if let ActiveWizard::Improve(improve) = &mut self.active_wizard {
+            match improve {
+                ImproveInput::PickImprovement { error, .. } => *error = Some(msg),
+                ImproveInput::PickBuilder { error, .. } => *error = Some(msg),
+            }
         }
     }
 
     pub fn set_salvage_error(&mut self, msg: String) {
-        if let SalvageInput::Confirm { ref mut error, .. } = self.salvage {
+        if let ActiveWizard::Salvage(SalvageInput::Confirm { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_recall_error(&mut self, msg: String) {
-        if let RecallInput::Confirm { ref mut error, .. } = self.recall {
+        if let ActiveWizard::Recall(RecallInput::Confirm { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_refuel_error(&mut self, msg: String) {
-        if let RefuelInput::Confirm { ref mut error, .. } = self.refuel {
+        if let ActiveWizard::Refuel(RefuelInput::Confirm { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
@@ -125,31 +127,31 @@ impl AppState {
     }
 
     pub fn set_transfer_deuterium_error(&mut self, msg: String) {
-        if let TransferDeuteriumInput::EnterAmount { ref mut error, .. } = self.transfer_deuterium {
+        if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_mind_snapshot_error(&mut self, msg: String) {
-        if let MindSnapshotInput::Confirm { ref mut error } = self.mind_snapshot {
+        if let ActiveWizard::MindSnapshot(MindSnapshotInput::Confirm { error }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_scut_relay_error(&mut self, msg: String) {
-        if let ScutRelayInput::EnterNetworkName { ref mut error, .. } = self.scut_relay {
+        if let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_mission_abandon_error(&mut self, msg: String) {
-        if let MissionsInput::ConfirmAbandon { ref mut error, .. } = self.missions_input {
+        if let ActiveWizard::Missions(MissionsInput::ConfirmAbandon { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_message_send_error(&mut self, msg: String) {
-        if let MessagesInput::Compose { ref mut error, .. } = self.messages_input {
+        if let ActiveWizard::Messages(MessagesInput::Compose { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
@@ -299,19 +301,19 @@ impl AppState {
     }
 
     pub fn set_deploy_error(&mut self, msg: String) {
-        if let DeployInput::EnterName { ref mut error, .. } = self.deploy {
+        if let ActiveWizard::Deploy(DeployInput::EnterName { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_rename_manny_error(&mut self, msg: String) {
-        if let RenameMannyInput::Typing { ref mut error, .. } = self.rename_manny {
+        if let ActiveWizard::RenameManny(RenameMannyInput::Typing { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn rename_manny_type_char(&mut self, c: char) {
-        if let RenameMannyInput::Typing { ref mut buf, .. } = self.rename_manny {
+        if let ActiveWizard::RenameManny(RenameMannyInput::Typing { buf, .. }) = &mut self.active_wizard {
             if buf.len() < 40 {
                 buf.push(c);
             }
@@ -319,13 +321,13 @@ impl AppState {
     }
 
     pub fn rename_manny_backspace(&mut self) {
-        if let RenameMannyInput::Typing { ref mut buf, .. } = self.rename_manny {
+        if let ActiveWizard::RenameManny(RenameMannyInput::Typing { buf, .. }) = &mut self.active_wizard {
             buf.pop();
         }
     }
 
     pub fn deploy_type_char(&mut self, c: char) {
-        if let DeployInput::EnterName { ref mut name_buf, .. } = self.deploy {
+        if let ActiveWizard::Deploy(DeployInput::EnterName { name_buf, .. }) = &mut self.active_wizard {
             if name_buf.len() < 80 {
                 name_buf.push(c);
             }
@@ -333,7 +335,7 @@ impl AppState {
     }
 
     pub fn deploy_backspace(&mut self) {
-        if let DeployInput::EnterName { ref mut name_buf, .. } = self.deploy {
+        if let ActiveWizard::Deploy(DeployInput::EnterName { name_buf, .. }) = &mut self.active_wizard {
             name_buf.pop();
         }
     }
@@ -402,7 +404,7 @@ impl AppState {
     }
 
     pub fn set_inspect_error(&mut self, msg: String) {
-        if let InspectInput::PickTarget { ref mut error, .. } = self.inspect {
+        if let ActiveWizard::Inspect(InspectInput::PickTarget { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         } else {
             // Inspect was dispatched without the picker overlay (single
@@ -412,7 +414,7 @@ impl AppState {
     }
 
     pub fn set_recover_error(&mut self, msg: String) {
-        if let RecoverInput::PickContainer { ref mut error, .. } = self.recover {
+        if let ActiveWizard::Recover(RecoverInput::PickContainer { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         } else {
             self.error = Some(format!("recover: {msg}"));
@@ -420,10 +422,12 @@ impl AppState {
     }
 
     pub fn set_detach_error(&mut self, msg: String) {
-        match self.detach {
-            DetachInput::PickMode { ref mut error, .. } => *error = Some(msg),
-            DetachInput::PickAsteroid { ref mut error, .. } => *error = Some(msg),
-            _ => {}
+        if let ActiveWizard::Detach(detach) = &mut self.active_wizard {
+            match detach {
+                DetachInput::PickMode { error, .. } => *error = Some(msg),
+                DetachInput::PickAsteroid { error, .. } => *error = Some(msg),
+                _ => {}
+            }
         }
     }
 
@@ -481,8 +485,8 @@ impl AppState {
     /// When the awaited remote sector arrives, advance the remote-mine wizard
     /// to asteroid selection (or abort with an error if it has no asteroids).
     pub fn remote_mine_sector_loaded(&mut self, x: i32, y: i32, z: i32) {
-        let (manny_id, manny_name) = match &self.remote_mine {
-            RemoteMineInput::Loading { manny_id, manny_name, x: lx, y: ly, z: lz }
+        let (manny_id, manny_name) = match &self.active_wizard {
+            ActiveWizard::RemoteMine(RemoteMineInput::Loading { manny_id, manny_name, x: lx, y: ly, z: lz })
                 if (*lx, *ly, *lz) == (x, y, z) =>
             {
                 (manny_id.clone(), manny_name.clone())
@@ -494,11 +498,11 @@ impl AppState {
             None => return,
         };
         if candidates.is_empty() {
-            self.remote_mine = RemoteMineInput::Inactive;
+            self.close_wizard();
             self.error = Some("no mineable asteroid in the Manny's sector".into());
             return;
         }
-        self.remote_mine = RemoteMineInput::PickAsteroid {
+        self.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid {
             manny_id,
             manny_name,
             x,
@@ -506,14 +510,16 @@ impl AppState {
             z,
             candidates,
             selection: 0,
-        };
+        });
     }
 
     pub fn set_remote_mine_error(&mut self, msg: String) {
-        match self.remote_mine {
-            RemoteMineInput::Configure { ref mut error, .. } => *error = Some(msg),
-            RemoteMineInput::PickContainer { ref mut error, .. } => *error = Some(msg),
-            _ => {}
+        if let ActiveWizard::RemoteMine(rm) = &mut self.active_wizard {
+            match rm {
+                RemoteMineInput::Configure { error, .. } => *error = Some(msg),
+                RemoteMineInput::PickContainer { error, .. } => *error = Some(msg),
+                _ => {}
+            }
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -93,24 +93,16 @@ pub struct AppState {
     pub scan_filter: ScanFilter,
     /// Some(idx) when the scanner panel is in object-browsing mode.
     pub scanner_obj_selection: Option<usize>,
-    pub object_action: ObjectActionInput,
-    pub waypoints: WaypointsInput,
     /// Persistent alerts and damage warnings (fetched in `fetch_all`).
     pub alerts: Vec<ProbeAlert>,
     pub damage_warnings: Vec<ProbeAlert>,
     pub damage_warning_rule: Option<DamageWarningRule>,
-    pub alerts_input: AlertsInput,
     /// Storage containers fetched on demand when the containers overlay opens.
     pub storage_containers: Vec<StorageContainer>,
     pub storage_container_detail: Option<(StorageContainer, ContainerInventory)>,
     /// Error from the last container-detail fetch, shown in the drill-in instead
     /// of a "fetching…" line that would otherwise hang forever.
     pub storage_container_detail_error: Option<String>,
-    pub rename_container: RenameContainerInput,
-    pub container_rules: ContainerRulesInput,
-    pub storage_move: StorageMoveInput,
-    pub drop_cargo: DropCargoInput,
-    pub drop_container: DropStorageContainerInput,
     pub help_open: bool,
     /// Vertical scroll offset of the help overlay (rows). Reset when it closes.
     pub help_scroll: u16,
@@ -120,36 +112,17 @@ pub struct AppState {
     pub toast: Option<(String, DateTime<Local>)>,
     /// Sectors already visited by the probe (server-side history).
     pub visited_sectors: Vec<VisitedSector>,
-    pub travel: TravelInput,
     pub goto_visited: GotoVisitedInput,
     pub probe_switch: ProbeSwitchInput,
-    pub assemble_probe: AssembleProbeInput,
-    pub rename_probe: RenameProbeInput,
-    pub repair: RepairInput,
-    pub mine: MineInput,
-    pub remote_mine: RemoteMineInput,
-    pub jettison: JettisonInput,
-    pub fabrication: FabricationInput,
-    pub improve: ImproveInput,
-    pub salvage: SalvageInput,
-    pub recall: RecallInput,
-    pub refuel: RefuelInput,
-    pub transfer_deuterium: TransferDeuteriumInput,
-    pub mind_snapshot: MindSnapshotInput,
-    pub scut_relay: ScutRelayInput,
-    pub scut_network: ScutNetworkInput,
     pub scut_network_view: Option<ScutNetwork>,
     pub missions: Vec<Mission>,
-    pub missions_input: MissionsInput,
     pub messages: Vec<ProbeMessage>,
     pub sent_messages: Vec<ProbeSentMessage>,
-    pub messages_input: MessagesInput,
-    pub deploy: DeployInput,
-    pub rename_manny: RenameMannyInput,
-    pub inspect: InspectInput,
-    pub recover: RecoverInput,
-    pub detach: DetachInput,
     pub map: MapView,
+    /// The single modal wizard currently open (or `None`). Replaces the 31
+    /// mutually-exclusive `*Input` fields — only one can be held at a time, so
+    /// two wizards open at once is unrepresentable.
+    pub active_wizard: ActiveWizard,
     pub api_version: Option<u32>,
     pub recipes: Vec<CraftingRecipe>,
     pub probe_improvements: Vec<ProbeImprovement>,
@@ -230,7 +203,7 @@ impl AppState {
     }
 
     pub fn set_rename_probe_error(&mut self, msg: String) {
-        if let RenameProbeInput::Typing { ref mut error, .. } = self.rename_probe {
+        if let ActiveWizard::RenameProbe(RenameProbeInput::Typing { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
@@ -301,39 +274,41 @@ impl AppState {
     }
 
     pub fn set_rename_container_error(&mut self, msg: String) {
-        if let RenameContainerInput::Typing { ref mut error, .. } = self.rename_container {
+        if let ActiveWizard::RenameContainer(RenameContainerInput::Typing { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_container_rules_error(&mut self, msg: String) {
-        if let ContainerRulesInput::Editing { ref mut error, .. } = self.container_rules {
+        if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_storage_move_error(&mut self, msg: String) {
-        match &mut self.storage_move {
+        if let ActiveWizard::StorageMove(
             StorageMoveInput::ConfigureResource { error, .. }
-            | StorageMoveInput::ConfigureItem { error, .. } => *error = Some(msg),
-            _ => {}
+            | StorageMoveInput::ConfigureItem { error, .. },
+        ) = &mut self.active_wizard
+        {
+            *error = Some(msg);
         }
     }
 
     pub fn set_drop_cargo_error(&mut self, msg: String) {
-        if let DropCargoInput::Confirm { ref mut error, .. } = self.drop_cargo {
+        if let ActiveWizard::DropCargo(DropCargoInput::Confirm { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_assemble_probe_error(&mut self, msg: String) {
-        if let AssembleProbeInput::PickContainers { ref mut error, .. } = self.assemble_probe {
+        if let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
 
     pub fn set_drop_container_error(&mut self, msg: String) {
-        if let DropStorageContainerInput::PickPlanet { ref mut error, .. } = self.drop_container {
+        if let ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet { error, .. }) = &mut self.active_wizard {
             *error = Some(msg);
         }
     }
@@ -342,12 +317,19 @@ impl AppState {
         self.toast = Some((msg.into(), Local::now()));
     }
 
+    /// Close whatever modal wizard is open (back to the idle cockpit). Replaces
+    /// the per-wizard `state.<field> = <Input>::Inactive` resets — with a single
+    /// `active_wizard` field there is now one way to close any wizard.
+    pub fn close_wizard(&mut self) {
+        self.active_wizard = ActiveWizard::None;
+    }
+
     /// Common tail of a successful action: show a confirmation toast and stage
-    /// the follow-up refresh. The wizard reset stays at the call site — it varies
-    /// (some actions reset two inputs, some return to a browsing state) — but the
-    /// toast + refetch pair is uniform, and centralising the refetch here removes
-    /// the `client.clone()`/`tx.clone()` spawn scattered across every match arm.
-    /// The event loop drains `pending_refetch` and dispatches the actual fetch.
+    /// the follow-up refresh. The wizard reset stays at the call site — most
+    /// arms `close_wizard()` first, but a few (mission abandon, message sent)
+    /// return to a browsing state and keep their overlay open, so closing here
+    /// would be wrong. The event loop drains `pending_refetch` and dispatches
+    /// the actual fetch.
     pub fn finish_action(&mut self, toast: impl Into<String>, refetch: Refetch) {
         self.set_toast(toast);
         self.pending_refetch = Some(refetch);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -117,9 +117,9 @@ fn probe_sector_coords_rounds_floats() {
 #[test]
 fn travel_submit_even_sum_no_error() {
     let mut state = AppState::default();
-    state.travel = TravelInput::Typing("2 0 -2".into());
+    state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("2 0 -2".into()));
     state.travel_submit();
-    if let TravelInput::Confirming { x, y, z, error, .. } = &state.travel {
+    if let ActiveWizard::Travel(TravelInput::Confirming { x, y, z, error, .. }) = &state.active_wizard {
         assert_eq!((*x, *y, *z), (2, 0, -2));
         assert!(error.is_none(), "expected no error, got {error:?}");
     } else {
@@ -130,9 +130,9 @@ fn travel_submit_even_sum_no_error() {
 #[test]
 fn travel_submit_odd_sum_sets_error() {
     let mut state = AppState::default();
-    state.travel = TravelInput::Typing("1 0 0".into());
+    state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("1 0 0".into()));
     state.travel_submit();
-    if let TravelInput::Confirming { error, .. } = &state.travel {
+    if let ActiveWizard::Travel(TravelInput::Confirming { error, .. }) = &state.active_wizard {
         assert!(error.is_some(), "expected parity error");
         assert!(error.as_ref().unwrap().contains("even"));
     } else {
@@ -144,25 +144,25 @@ fn travel_submit_odd_sum_sets_error() {
 fn travel_submit_not_typing_is_noop() {
     let mut state = AppState::default();
     state.travel_submit();
-    assert!(matches!(state.travel, TravelInput::Inactive));
+    assert!(matches!(state.active_wizard, ActiveWizard::None));
 }
 
 #[test]
 fn travel_submit_invalid_input_is_noop() {
     let mut state = AppState::default();
-    state.travel = TravelInput::Typing("abc".into());
+    state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("abc".into()));
     state.travel_submit();
-    assert!(matches!(state.travel, TravelInput::Typing(_)));
+    assert!(matches!(state.active_wizard, ActiveWizard::Travel(TravelInput::Typing(_))));
 }
 
 #[test]
 fn travel_relative_input_resolves_from_probe_position() {
     let mut state = AppState::default();
     state.probe = Some(make_probe(7.0, 2.0, 0.0, -2.0));
-    state.travel = TravelInput::Typing("+2 0 -2".into());
+    state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("+2 0 -2".into()));
     assert_eq!(state.resolve_travel_target(), Some((4, 0, -4)));
     state.travel_submit();
-    if let TravelInput::Confirming { x, y, z, error, .. } = &state.travel {
+    if let ActiveWizard::Travel(TravelInput::Confirming { x, y, z, error, .. }) = &state.active_wizard {
         assert_eq!((*x, *y, *z), (4, 0, -4));
         assert!(error.is_none());
     } else {
@@ -173,20 +173,20 @@ fn travel_relative_input_resolves_from_probe_position() {
 #[test]
 fn travel_relative_without_probe_position_is_noop() {
     let mut state = AppState::default();
-    state.travel = TravelInput::Typing("+2 0 0".into());
+    state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("+2 0 0".into()));
     assert_eq!(state.resolve_travel_target(), None);
     state.travel_submit();
-    assert!(matches!(state.travel, TravelInput::Typing(_)));
+    assert!(matches!(state.active_wizard, ActiveWizard::Travel(TravelInput::Typing(_))));
 }
 
 #[test]
 fn travel_plus_only_accepted_as_first_char() {
     let mut state = AppState::default();
-    state.travel = TravelInput::Typing(String::new());
+    state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
     state.travel_type_char('+');
     state.travel_type_char('2');
     state.travel_type_char('+'); // rejected mid-buffer
-    if let TravelInput::Typing(ref buf) = state.travel {
+    if let ActiveWizard::Travel(TravelInput::Typing(ref buf)) = state.active_wizard {
         assert_eq!(buf, "+2");
     } else {
         panic!("expected Typing variant");
@@ -346,7 +346,7 @@ fn jettison_for_selected_stock_enters_amount() {
             assert_eq!(item_name, "Metals");
             assert_eq!(max_amount, 0.5);
         }
-        other => panic!("expected EnterAmount, got {:?}", std::mem::discriminant(&other.unwrap_or_default())),
+        other => panic!("expected Ok(EnterAmount), got a different result: {}", other.is_ok()),
     }
 }
 
@@ -384,15 +384,15 @@ fn jettison_for_selected_passive_group_errors() {
 #[test]
 fn jettison_fill_max_sets_buffer() {
     let mut state = AppState::default();
-    state.jettison = JettisonInput::EnterAmount {
+    state.active_wizard = ActiveWizard::Jettison(JettisonInput::EnterAmount {
         item_id: "stock-metals".into(),
         item_name: "Metals".into(),
         max_amount: 0.5,
         buf: "0.1".into(),
         error: Some("previous".into()),
-    };
+    });
     state.jettison_fill_max();
-    if let JettisonInput::EnterAmount { ref buf, ref error, .. } = state.jettison {
+    if let ActiveWizard::Jettison(JettisonInput::EnterAmount { ref buf, ref error, .. }) = state.active_wizard {
         assert_eq!(buf, "0.5000");
         assert!(error.is_none());
     } else {
@@ -910,11 +910,11 @@ fn busy_or_too_far_manny_not_remote_minable() {
 #[test]
 fn remote_mine_advances_to_pick_asteroid_when_sector_loads() {
     let mut state = AppState::default();
-    state.remote_mine = RemoteMineInput::Loading {
+    state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::Loading {
         manny_id: "mny_remote".into(),
         manny_name: "manny-r".into(),
         x: 2, y: 0, z: -2,
-    };
+    });
     state.scan_history = vec![make_sector_with_objects(2., 0., -2., r#"[
         {
             "id": "ast-9", "type": "asteroid", "name": "Rock", "summary": null,
@@ -926,7 +926,7 @@ fn remote_mine_advances_to_pick_asteroid_when_sector_loads() {
         }
     ]"#)];
     state.remote_mine_sector_loaded(2, 0, -2);
-    assert!(matches!(state.remote_mine, RemoteMineInput::PickAsteroid { .. }));
+    assert!(matches!(state.active_wizard, ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { .. })));
 }
 
 #[test]
@@ -1920,7 +1920,7 @@ fn run_command_travel_and_goto() {
     state.probe = Some(probe_at(0., 0., 0.));
     // even-sum target → travel confirm
     state.run_command("travel 2 0 -2");
-    assert!(matches!(state.travel, TravelInput::Confirming { x: 2, y: 0, z: -2, .. }));
+    assert!(matches!(state.active_wizard, ActiveWizard::Travel(TravelInput::Confirming { x: 2, y: 0, z: -2, .. })));
 
     state.run_command("goto 1 1 0");
     assert!(state.map.open);
@@ -2013,7 +2013,7 @@ fn mine_bare_opens_configure_from_context() {
     let mut state = mineable_state();
     assert!(!state.run_command("mine"));
     assert!(
-        matches!(state.mine, MineInput::Configure { ref object_id, ref manny_id, .. }
+        matches!(state.active_wizard, ActiveWizard::Mine(MineInput::Configure { ref object_id, ref manny_id, .. })
             if object_id == "ast-1" && manny_id == "m1"),
         "bare :mine opens the wizard on the sole manny + asteroid"
     );
@@ -2117,7 +2117,7 @@ fn craft_bare_still_opens_wizard() {
     )
     .unwrap()];
     state.run_command("craft");
-    assert!(matches!(state.fabrication, FabricationInput::PickRecipe { .. }));
+    assert!(matches!(state.active_wizard, ActiveWizard::Fabrication(FabricationInput::PickRecipe { .. })));
     assert!(state.pending_fire.is_none());
 }
 

--- a/src/app/travel.rs
+++ b/src/app/travel.rs
@@ -4,7 +4,7 @@ use super::*;
 
 impl AppState {
     pub fn travel_type_char(&mut self, c: char) {
-        if let TravelInput::Typing(ref mut buf) = self.travel {
+        if let ActiveWizard::Travel(TravelInput::Typing(buf)) = &mut self.active_wizard {
             if c == '-' || c == ' ' || c.is_ascii_digit() || (c == '+' && buf.is_empty()) {
                 buf.push(c);
             }
@@ -12,7 +12,7 @@ impl AppState {
     }
 
     pub fn travel_backspace(&mut self) {
-        if let TravelInput::Typing(ref mut buf) = self.travel {
+        if let ActiveWizard::Travel(TravelInput::Typing(buf)) = &mut self.active_wizard {
             buf.pop();
         }
     }
@@ -43,7 +43,7 @@ impl AppState {
     /// Destination currently typed in the travel overlay, resolved to
     /// absolute coordinates (None while incomplete or invalid).
     pub fn resolve_travel_target(&self) -> Option<(i32, i32, i32)> {
-        let TravelInput::Typing(ref buf) = self.travel else { return None };
+        let ActiveWizard::Travel(TravelInput::Typing(buf)) = &self.active_wizard else { return None };
         Self::parse_travel_buf(buf, self.probe_sector_coords())
     }
 
@@ -55,12 +55,12 @@ impl AppState {
             None
         };
         let (sector_distance, fuel_cost, eta_minutes) = self.travel_preview(x, y, z);
-        self.travel = TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error };
+        self.active_wizard = ActiveWizard::Travel(TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error });
     }
 
     pub fn travel_go_sector(&mut self, x: i32, y: i32, z: i32) {
         let (sector_distance, fuel_cost, eta_minutes) = self.travel_preview(x, y, z);
-        self.travel = TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error: None };
+        self.active_wizard = ActiveWizard::Travel(TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error: None });
     }
 
     fn travel_preview(&self, x: i32, y: i32, z: i32) -> (Option<i64>, Option<f64>, Option<i64>) {
@@ -90,7 +90,7 @@ impl AppState {
     }
 
     pub fn set_travel_error(&mut self, msg: String) {
-        if let TravelInput::Confirming { ref mut error, .. } = self.travel {
+        if let ActiveWizard::Travel(TravelInput::Confirming { error, .. }) = &mut self.active_wizard {
             *error = Some(format!("API: {msg}"));
         }
     }
@@ -100,6 +100,6 @@ impl AppState {
         if let Some(ref mut probe) = self.probe {
             probe.movement = Some(mv);
         }
-        self.travel = TravelInput::Inactive;
+        self.close_wizard();
     }
 }

--- a/src/input/alerts.rs
+++ b/src/input/alerts.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_ack_alert, fetch_ack_damage_warning};
-use crate::app::{AlertsInput, ApiMessage, AppState};
+use crate::app::{ActiveWizard, AlertsInput, ApiMessage, AppState};
 
 use super::geometry::list_nav;
 
@@ -22,26 +22,26 @@ pub(super) fn handle_alerts_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let AlertsInput::Browsing { selection, show_warnings } = state.alerts_input else {
+    let ActiveWizard::Alerts(AlertsInput::Browsing { selection, show_warnings }) = state.active_wizard else {
         return;
     };
     let count = tab_len(state, show_warnings);
     match code {
         KeyCode::Esc | KeyCode::Char('A') | KeyCode::Char('q') => {
-            state.alerts_input = AlertsInput::Inactive;
+            state.close_wizard();
         }
         KeyCode::Tab | KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l') => {
             // Switch tab and clamp the selection to the new tab's length.
             let next = !show_warnings;
             let new_count = tab_len(state, next);
-            state.alerts_input = AlertsInput::Browsing {
+            state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing {
                 selection: selection.min(new_count.saturating_sub(1)),
                 show_warnings: next,
-            };
+            });
         }
         KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
             if let Some(new_sel) = list_nav(code, selection, count) {
-                state.alerts_input = AlertsInput::Browsing { selection: new_sel, show_warnings };
+                state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing { selection: new_sel, show_warnings });
             }
         }
         KeyCode::Enter => {

--- a/src/input/assemble.rs
+++ b/src/input/assemble.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_assemble_probe;
-use crate::app::{ApiMessage, AppState, AssembleProbeInput, LogEvent};
+use crate::app::{ActiveWizard, ApiMessage, AppState, AssembleProbeInput, LogEvent};
 
 use super::geometry::list_nav;
 
@@ -17,10 +17,10 @@ pub(super) fn handle_assemble_probe_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc => state.assemble_probe = AssembleProbeInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-            if let AssembleProbeInput::PickContainers { containers, cursor, .. } =
-                &mut state.assemble_probe
+            if let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { containers, cursor, .. }) =
+                &mut state.active_wizard
             {
                 if let Some(ns) = list_nav(code, *cursor, containers.len()) {
                     *cursor = ns;
@@ -28,8 +28,8 @@ pub(super) fn handle_assemble_probe_event(
             }
         }
         KeyCode::Char(' ') => {
-            if let AssembleProbeInput::PickContainers { selected, cursor, error, .. } =
-                &mut state.assemble_probe
+            if let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { selected, cursor, error, .. }) =
+                &mut state.active_wizard
             {
                 let cur = *cursor;
                 if let Some(pos) = selected.iter().position(|&i| i == cur) {
@@ -45,8 +45,8 @@ pub(super) fn handle_assemble_probe_event(
         }
         KeyCode::Enter => {
             // Extract the order without holding a borrow across the fire.
-            let order = match &state.assemble_probe {
-                AssembleProbeInput::PickContainers { manny_id, containers, selected, .. }
+            let order = match &state.active_wizard {
+                ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { manny_id, containers, selected, .. })
                     if selected.len() == 2 =>
                 {
                     let ids: Vec<String> =
@@ -57,13 +57,13 @@ pub(super) fn handle_assemble_probe_event(
             };
             match order {
                 Some((manny, ids)) => {
-                    state.assemble_probe = AssembleProbeInput::Inactive;
+                    state.close_wizard();
                     fetch_assemble_probe(manny, ids, client.clone(), tx.clone());
                     state.log_event(LogEvent::assemble_probe(state.active_probe_id));
                 }
                 None => {
-                    if let AssembleProbeInput::PickContainers { error, .. } =
-                        &mut state.assemble_probe
+                    if let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { error, .. }) =
+                        &mut state.active_wizard
                     {
                         *error = Some("select exactly two empty containers".into());
                     }

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -17,7 +17,7 @@ use crate::api::tasks::{
 };
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
-    ApiMessage, AppState, AssembleProbeInput, CommsCategory, MissionsCategory, DeployInput, FabricationInput, ImproveInput, DetachInput, DropCargoInput, LogEvent,
+    ActiveWizard, ApiMessage, AppState, AssembleProbeInput, CommsCategory, MissionsCategory, DeployInput, FabricationInput, ImproveInput, DetachInput, DropCargoInput, LogEvent,
     CommandLine, DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction,
     MessagesInput,
     MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
@@ -119,7 +119,7 @@ fn open_actions(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiM
                     state.set_toast("no missions");
                 } else {
                     let selection = state.pane_nav[Pane::Missions.index()].cursor;
-                    state.missions_input = MissionsInput::Browsing { selection };
+                    state.active_wizard = ActiveWizard::Missions(MissionsInput::Browsing { selection });
                 }
             }
         },
@@ -136,7 +136,7 @@ fn comms_activate(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<Ap
     match state.comms_drill() {
         None => match CommsCategory::ALL.get(cursor) {
             Some(CommsCategory::Messages) => {
-                state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 };
+                state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 });
                 fetch_messages(client.clone(), tx.clone());
                 fetch_sent_messages(client.clone(), tx.clone());
             }
@@ -236,12 +236,12 @@ fn open_sector_object_actions(state: &mut AppState) {
         state.set_toast(format!("no actions for {}", entry.name));
         return;
     }
-    state.object_action = ObjectActionInput::PickAction {
+    state.active_wizard = ActiveWizard::ObjectAction(ObjectActionInput::PickAction {
         object_id: entry.id.clone(),
         object_name: entry.name.clone(),
         actions,
         selection: 0,
-    };
+    });
 }
 
 fn handle_menu_key(
@@ -305,7 +305,7 @@ fn fire_menu_action(
     match action {
         MenuAction::Jettison => {
             match state.jettison_for_selected() {
-                Ok(input) => state.jettison = input,
+                Ok(input) => state.active_wizard = ActiveWizard::Jettison(input),
                 Err(msg) => state.error = Some(msg),
             }
             return;
@@ -316,11 +316,11 @@ fn fire_menu_action(
             if state.fabrication_recipes().is_empty() {
                 state.error = Some("recipes not loaded yet — F5 to refresh".into());
             } else {
-                state.fabrication = FabricationInput::PickRecipe {
+                state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe {
                     prefilled_manny: None,
                     selection: 0,
                     error: None,
-                };
+                });
             }
             return;
         }
@@ -330,13 +330,13 @@ fn fire_menu_action(
                 0 => state.error = Some("no idle Manny on board".into()),
                 1 => {
                     let (id, name) = mannies.into_iter().next().unwrap();
-                    state.storage_move = StorageMoveInput::PickKind {
+                    state.active_wizard = ActiveWizard::StorageMove(StorageMoveInput::PickKind {
                         actor_manny_id: id,
                         actor_manny_name: name,
                         selection: 0,
-                    };
+                    });
                 }
-                _ => state.storage_move = StorageMoveInput::PickManny { mannies, selection: 0 },
+                _ => state.active_wizard = ActiveWizard::StorageMove(StorageMoveInput::PickManny { mannies, selection: 0 }),
             }
             return;
         }
@@ -349,7 +349,7 @@ fn fire_menu_action(
             } else if state.collect_deploy_candidates().is_empty() {
                 state.error = Some("no target object in current sector — scan first".into());
             } else {
-                state.deploy = DeployInput::PickManny { mannies, selection: 0 };
+                state.active_wizard = ActiveWizard::Deploy(DeployInput::PickManny { mannies, selection: 0 });
             }
             return;
         }
@@ -358,17 +358,17 @@ fn fire_menu_action(
             match nets.len() {
                 0 => state.error = Some("no SCUT network covers this sector".into()),
                 1 => {
-                    state.scut_network = ScutNetworkInput::Viewing { error: None };
+                    state.active_wizard = ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { error: None });
                     state.scut_network_view = None;
                     fetch_scut_network(nets[0].0, client.clone(), tx.clone());
                 }
-                _ => state.scut_network = ScutNetworkInput::Picking { networks: nets, selection: 0 },
+                _ => state.active_wizard = ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks: nets, selection: 0 }),
             }
             return;
         }
         MenuAction::Improve => {
             if state.has_orderable_improvement() {
-                state.improve = ImproveInput::PickImprovement { selection: 0, error: None };
+                state.active_wizard = ActiveWizard::Improve(ImproveInput::PickImprovement { selection: 0, error: None });
             } else {
                 state.error = Some("no probe improvement available".into());
             }
@@ -376,7 +376,7 @@ fn fire_menu_action(
         }
         MenuAction::MindSnapshot => {
             if state.probe_terminal_alert().is_some() {
-                state.mind_snapshot = MindSnapshotInput::Confirm { error: None };
+                state.active_wizard = ActiveWizard::MindSnapshot(MindSnapshotInput::Confirm { error: None });
             }
             return;
         }
@@ -386,12 +386,12 @@ fn fire_menu_action(
                     state.storage_container(&id).map(|c| (c.id.clone(), c.label.clone()))
                 {
                     let buf = state.next_name_suggestion();
-                    state.rename_container = RenameContainerInput::Typing {
+                    state.active_wizard = ActiveWizard::RenameContainer(RenameContainerInput::Typing {
                         container_id,
                         current_label: label,
                         buf,
                         error: None,
-                    };
+                    });
                 }
             }
             return;
@@ -399,7 +399,7 @@ fn fire_menu_action(
         MenuAction::EditContainerRules => {
             if let Some(id) = state.storage_selected_container_id() {
                 if let Some(editor) = state.rules_editor_for(&id) {
-                    state.container_rules = editor;
+                    state.active_wizard = ActiveWizard::ContainerRules(editor);
                 }
             }
             return;
@@ -442,7 +442,7 @@ fn fire_menu_action(
             return;
         }
         MenuAction::Travel => {
-            state.travel = TravelInput::Typing(String::new());
+            state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
             return;
         }
         MenuAction::GotoVisited => {
@@ -454,7 +454,7 @@ fn fire_menu_action(
         MenuAction::Waypoints => {
             let entries = state.collect_waypoints();
             if !entries.is_empty() {
-                state.waypoints = WaypointsInput::Browsing { entries, selection: 0 };
+                state.active_wizard = ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, selection: 0 });
             }
             return;
         }
@@ -484,12 +484,12 @@ fn fire_menu_action(
         MenuAction::RenameProbe => {
             if let Some((id, name)) = state.active_probe_identity() {
                 let buf = state.next_name_suggestion();
-                state.rename_probe = RenameProbeInput::Typing {
+                state.active_wizard = ActiveWizard::RenameProbe(RenameProbeInput::Typing {
                     probe_id: id,
                     current_name: name,
                     buf,
                     error: None,
-                };
+                });
             }
             return;
         }
@@ -510,17 +510,17 @@ fn fire_menu_action(
 
     match action {
         MenuAction::Repair if can => {
-            state.repair = RepairInput::Typing { manny_id: id, manny_name: name, buf: String::new(), error: None };
+            state.active_wizard = ActiveWizard::Repair(RepairInput::Typing { manny_id: id, manny_name: name, buf: String::new(), error: None });
         }
         MenuAction::Fabricate if can => {
             if state.fabrication_recipes().is_empty() {
                 state.error = Some("recipes not loaded yet — F5 to refresh".into());
             } else {
-                state.fabrication = FabricationInput::PickRecipe {
+                state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe {
                     prefilled_manny: Some((id, name)),
                     selection: 0,
                     error: None,
-                };
+                });
             }
         }
         MenuAction::AssembleProbe if can => {
@@ -528,25 +528,25 @@ fn fire_menu_action(
             if containers.len() < 2 {
                 state.error = Some("need two empty additional containers".into());
             } else {
-                state.assemble_probe = AssembleProbeInput::PickContainers {
+                state.active_wizard = ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers {
                     manny_id: id,
                     manny_name: name,
                     containers,
                     selected: Vec::new(),
                     cursor: 0,
                     error: None,
-                };
+                });
             }
         }
         MenuAction::Mine => {
             if remote_minable {
-                state.remote_mine = RemoteMineInput::Loading {
+                state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::Loading {
                     manny_id: id,
                     manny_name: name,
                     x: coords.0,
                     y: coords.1,
                     z: coords.2,
-                };
+                });
                 state.set_toast("fetching remote sector…");
                 fetch_sector(Some(coords), client.clone(), tx.clone());
             } else if can {
@@ -555,7 +555,7 @@ fn fire_menu_action(
                     0 => state.error = Some("no mineable objects in current sector — scan first".into()),
                     1 => {
                         let (object_id, object_name) = candidates.into_iter().next().unwrap();
-                        state.mine = MineInput::Configure {
+                        state.active_wizard = ActiveWizard::Mine(MineInput::Configure {
                             manny_id: id,
                             manny_name: name,
                             object_id,
@@ -565,9 +565,9 @@ fn fire_menu_action(
                             amount_mode: false,
                             target_container: None,
                             error: None,
-                        };
+                        });
                     }
-                    _ => state.mine = MineInput::PickAsteroid { manny_id: id, manny_name: name, candidates, selection: 0 },
+                    _ => state.active_wizard = ActiveWizard::Mine(MineInput::PickAsteroid { manny_id: id, manny_name: name, candidates, selection: 0 }),
                 }
             }
         }
@@ -577,9 +577,9 @@ fn fire_menu_action(
                 0 => state.error = Some("no salvageable objects in current sector — scan first".into()),
                 1 => {
                     let (object_id, object_name) = candidates.into_iter().next().unwrap();
-                    state.salvage = SalvageInput::Confirm { manny_id: id, manny_name: name, object_id, object_name, error: None };
+                    state.active_wizard = ActiveWizard::Salvage(SalvageInput::Confirm { manny_id: id, manny_name: name, object_id, object_name, error: None });
                 }
-                _ => state.salvage = SalvageInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0 },
+                _ => state.active_wizard = ActiveWizard::Salvage(SalvageInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0 }),
             }
         }
         MenuAction::Inspect if can => {
@@ -591,7 +591,7 @@ fn fire_menu_action(
                     fetch_inspect(id, object_id, client.clone(), tx.clone());
                     state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
                 }
-                _ => state.inspect = InspectInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
+                _ => state.active_wizard = ActiveWizard::Inspect(InspectInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0, error: None }),
             }
         }
         MenuAction::Recover if can => {
@@ -603,7 +603,7 @@ fn fire_menu_action(
                     fetch_recover(id, object_id, client.clone(), tx.clone());
                     state.log_event(LogEvent::recover(&container_name, state.active_probe_id));
                 }
-                _ => state.recover = RecoverInput::PickContainer { manny_id: id, manny_name: name, candidates, selection: 0, error: None },
+                _ => state.active_wizard = ActiveWizard::Recover(RecoverInput::PickContainer { manny_id: id, manny_name: name, candidates, selection: 0, error: None }),
             }
         }
         MenuAction::Detach if can => {
@@ -612,9 +612,9 @@ fn fire_menu_action(
                 0 => state.error = Some("no detachable containers in inventory".into()),
                 1 => {
                     let (container_id, container_name) = containers.into_iter().next().unwrap();
-                    state.detach = DetachInput::PickMode { manny_id: id, manny_name: name, container_id, container_name, selection: 0, error: None };
+                    state.active_wizard = ActiveWizard::Detach(DetachInput::PickMode { manny_id: id, manny_name: name, container_id, container_name, selection: 0, error: None });
                 }
-                _ => state.detach = DetachInput::PickContainer { manny_id: id, manny_name: name, containers, selection: 0 },
+                _ => state.active_wizard = ActiveWizard::Detach(DetachInput::PickContainer { manny_id: id, manny_name: name, containers, selection: 0 }),
             }
         }
         MenuAction::DropStorageContainer if can => {
@@ -629,7 +629,7 @@ fn fire_menu_action(
                     state.error = Some("no planet in current sector — scan first".into());
                 } else if containers.len() == 1 {
                     let (container_id, container_name) = containers.into_iter().next().unwrap();
-                    state.drop_container = DropStorageContainerInput::PickPlanet {
+                    state.active_wizard = ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet {
                         manny_id: id,
                         manny_name: name,
                         container_id,
@@ -637,20 +637,20 @@ fn fire_menu_action(
                         planets,
                         selection: 0,
                         error: None,
-                    };
+                    });
                 } else {
-                    state.drop_container = DropStorageContainerInput::PickContainer {
+                    state.active_wizard = ActiveWizard::DropContainer(DropStorageContainerInput::PickContainer {
                         manny_id: id,
                         manny_name: name,
                         containers,
                         selection: 0,
-                    };
+                    });
                 }
             }
         }
         MenuAction::Refuel if can => {
             if state.deuterium_station_in_current_sector() {
-                state.refuel = RefuelInput::Confirm { manny_id: id, manny_name: name, error: None };
+                state.active_wizard = ActiveWizard::Refuel(RefuelInput::Confirm { manny_id: id, manny_name: name, error: None });
             } else {
                 state.error = Some("no deuterium refuel station in this sector".into());
             }
@@ -660,23 +660,23 @@ fn fire_menu_action(
             if targets.is_empty() {
                 state.error = Some("no other probe in the fleet".into());
             } else {
-                state.transfer_deuterium = TransferDeuteriumInput::PickTarget {
+                state.active_wizard = ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget {
                     manny_id: id,
                     manny_name: name,
                     targets,
                     selection: 0,
-                };
+                });
             }
         }
         MenuAction::DropCargo if waiting_space => {
-            state.drop_cargo = DropCargoInput::Confirm { manny_id: id, manny_name: name, error: None };
+            state.active_wizard = ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_id: id, manny_name: name, error: None });
         }
         MenuAction::Recall if !can && has_task => {
-            state.recall = RecallInput::Confirm { manny_id: id, manny_name: name, remote: remote_recall, error: None };
+            state.active_wizard = ActiveWizard::Recall(RecallInput::Confirm { manny_id: id, manny_name: name, remote: remote_recall, error: None });
         }
         MenuAction::Rename => {
             let buf = state.next_name_suggestion();
-            state.rename_manny = RenameMannyInput::Typing { manny_id: id, manny_name: name, buf, error: None };
+            state.active_wizard = ActiveWizard::RenameManny(RenameMannyInput::Typing { manny_id: id, manny_name: name, buf, error: None });
         }
         // Guard mismatch (state changed since the menu was built): no-op.
         _ => {}

--- a/src/input/containers.rs
+++ b/src/input/containers.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_rename_container, fetch_update_container_rules};
-use crate::app::{ApiMessage, AppState, ContainerRulesInput, LogEvent, RenameContainerInput};
+use crate::app::{ActiveWizard, ApiMessage, AppState, ContainerRulesInput, LogEvent, RenameContainerInput};
 
 use super::geometry::list_nav;
 
@@ -43,25 +43,25 @@ pub(super) fn handle_rename_container_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if !matches!(state.rename_container, RenameContainerInput::Typing { .. }) {
+    if !matches!(state.active_wizard, ActiveWizard::RenameContainer(RenameContainerInput::Typing { .. })) {
         return;
     }
     match code {
-        KeyCode::Esc => state.rename_container = RenameContainerInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Tab => {
             let s = state.next_name_suggestion();
-            if let RenameContainerInput::Typing { buf, .. } = &mut state.rename_container {
+            if let ActiveWizard::RenameContainer(RenameContainerInput::Typing { buf, .. }) = &mut state.active_wizard {
                 *buf = s;
             }
         }
         KeyCode::Backspace => {
-            if let RenameContainerInput::Typing { buf, .. } = &mut state.rename_container {
+            if let ActiveWizard::RenameContainer(RenameContainerInput::Typing { buf, .. }) = &mut state.active_wizard {
                 buf.pop();
             }
         }
         KeyCode::Enter => {
             let (id, label) = {
-                let RenameContainerInput::Typing { container_id, buf, .. } = &state.rename_container
+                let ActiveWizard::RenameContainer(RenameContainerInput::Typing { container_id, buf, .. }) = &state.active_wizard
                 else {
                     return;
                 };
@@ -76,7 +76,7 @@ pub(super) fn handle_rename_container_event(
             state.log_event(LogEvent::rename_container(&new_label, state.active_probe_id));
         }
         KeyCode::Char(c) => {
-            if let RenameContainerInput::Typing { buf, error, .. } = &mut state.rename_container {
+            if let ActiveWizard::RenameContainer(RenameContainerInput::Typing { buf, error, .. }) = &mut state.active_wizard {
                 if buf.chars().count() < 80 {
                     buf.push(c);
                     *error = None;
@@ -93,16 +93,16 @@ pub(super) fn handle_container_rules_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let ContainerRulesInput::Editing { selection, types, .. } = &state.container_rules else {
+    let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { selection, types, .. }) = &state.active_wizard else {
         return;
     };
     let sel = *selection;
     let count = types.len();
     match code {
-        KeyCode::Esc => state.container_rules = ContainerRulesInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
             if let Some(ns) = list_nav(code, sel, count) {
-                if let ContainerRulesInput::Editing { selection, .. } = &mut state.container_rules {
+                if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { selection, .. }) = &mut state.active_wizard {
                     *selection = ns;
                 }
             }
@@ -115,9 +115,9 @@ pub(super) fn handle_container_rules_event(
         }
         KeyCode::Delete | KeyCode::Backspace => {
             // Clear the selected type back to "none".
-            if let ContainerRulesInput::Editing {
+            if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
                 types, priority, exclusion, strict_exclusion, selection, ..
-            } = &mut state.container_rules
+            }) = &mut state.active_wizard
             {
                 if let Some(ty) = types.get(*selection).cloned() {
                     priority.retain(|t| t != &ty);
@@ -128,9 +128,9 @@ pub(super) fn handle_container_rules_event(
         }
         KeyCode::Enter => {
             let (id, p, e, s, label) = {
-                let ContainerRulesInput::Editing {
+                let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
                     container_id, priority, exclusion, strict_exclusion, container_label, ..
-                } = &state.container_rules
+                }) = &state.active_wizard
                 else {
                     return;
                 };
@@ -150,9 +150,9 @@ pub(super) fn handle_container_rules_event(
 }
 
 fn cycle_selected(state: &mut AppState, backward: bool) {
-    if let ContainerRulesInput::Editing {
+    if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
         types, priority, exclusion, strict_exclusion, selection, ..
-    } = &mut state.container_rules
+    }) = &mut state.active_wizard
     {
         if let Some(ty) = types.get(*selection).cloned() {
             cycle_assignment(&ty, priority, exclusion, strict_exclusion, backward);

--- a/src/input/craft.rs
+++ b/src/input/craft.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_atomic_printer_craft, fetch_craft};
-use crate::app::{ApiMessage, AppState, Fabricator, FabricationInput, LogEvent};
+use crate::app::{ActiveWizard, ApiMessage, AppState, Fabricator, FabricationInput, LogEvent};
 use super::geometry::list_nav;
 
 /// Drive the unified fabrication wizard. `PickRecipe` browses the sectioned
@@ -16,20 +16,20 @@ pub(super) fn handle_fabrication_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match state.fabrication {
-        FabricationInput::PickRecipe { selection, .. } => {
+    match state.active_wizard {
+        ActiveWizard::Fabrication(FabricationInput::PickRecipe { selection, .. }) => {
             let count = state.fabrication_recipes().len();
             if count == 0 {
                 if code == KeyCode::Esc {
-                    state.fabrication = FabricationInput::Inactive;
+                    state.close_wizard();
                 }
                 return;
             }
             match code {
-                KeyCode::Esc => state.fabrication = FabricationInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let FabricationInput::PickRecipe { ref mut selection, .. } = state.fabrication {
+                        if let ActiveWizard::Fabrication(FabricationInput::PickRecipe { ref mut selection, .. }) = state.active_wizard {
                             *selection = new_sel;
                         }
                     }
@@ -38,19 +38,19 @@ pub(super) fn handle_fabrication_event(
                 _ => {}
             }
         }
-        FabricationInput::PickBuilder { selection, ref mannies, .. } => {
+        ActiveWizard::Fabrication(FabricationInput::PickBuilder { selection, ref mannies, .. }) => {
             let count = mannies.len();
             match code {
-                KeyCode::Esc => state.fabrication = FabricationInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let FabricationInput::PickBuilder { ref mut selection, .. } = state.fabrication {
+                        if let ActiveWizard::Fabrication(FabricationInput::PickBuilder { ref mut selection, .. }) = state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let picked = if let FabricationInput::PickBuilder { ref mannies, selection, ref recipe_id, ref recipe_name, .. } = state.fabrication {
+                    let picked = if let ActiveWizard::Fabrication(FabricationInput::PickBuilder { ref mannies, selection, ref recipe_id, ref recipe_name, .. }) = state.active_wizard {
                         mannies.get(selection).map(|(id, _)| (id.clone(), recipe_id.clone(), recipe_name.clone()))
                     } else {
                         None
@@ -63,7 +63,7 @@ pub(super) fn handle_fabrication_event(
                 _ => {}
             }
         }
-        FabricationInput::Inactive => {}
+        _ => {}
     }
 }
 
@@ -89,7 +89,7 @@ fn commit_recipe(
             }
         }
         Fabricator::Manny => {
-            let prefilled = if let FabricationInput::PickRecipe { ref prefilled_manny, .. } = state.fabrication {
+            let prefilled = if let ActiveWizard::Fabrication(FabricationInput::PickRecipe { ref prefilled_manny, .. }) = state.active_wizard {
                 prefilled_manny.clone()
             } else {
                 None
@@ -108,13 +108,13 @@ fn commit_recipe(
                     state.log_event(LogEvent::craft(&recipe_name, false, state.active_probe_id));
                 }
                 _ => {
-                    state.fabrication = FabricationInput::PickBuilder {
+                    state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickBuilder {
                         recipe_id,
                         recipe_name,
                         mannies,
                         selection: 0,
                         error: None,
-                    };
+                    });
                 }
             }
         }

--- a/src/input/fleet.rs
+++ b/src/input/fleet.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_rename_probe, fetch_transfer_deuterium};
 use crate::app::{
-    ApiMessage, AppState, LogEvent, ProbeSwitchInput, RenameProbeInput, TransferDeuteriumInput,
+    ActiveWizard, ApiMessage, AppState, LogEvent, ProbeSwitchInput, RenameProbeInput, TransferDeuteriumInput,
 };
 
 use super::geometry::list_nav;
@@ -51,31 +51,31 @@ pub(super) fn handle_transfer_deuterium_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     // Step 1 — destination picker.
-    if let TransferDeuteriumInput::PickTarget { targets, selection, .. } = &state.transfer_deuterium {
+    if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget { targets, selection, .. }) = &state.active_wizard {
         let (count, sel) = (targets.len(), *selection);
         match code {
-            KeyCode::Esc => state.transfer_deuterium = TransferDeuteriumInput::Inactive,
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                if let (Some(ns), TransferDeuteriumInput::PickTarget { selection, .. }) =
-                    (list_nav(code, sel, count), &mut state.transfer_deuterium)
+                if let (Some(ns), ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget { selection, .. })) =
+                    (list_nav(code, sel, count), &mut state.active_wizard)
                 {
                     *selection = ns;
                 }
             }
             KeyCode::Enter => {
-                if let TransferDeuteriumInput::PickTarget {
+                if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget {
                     manny_id, manny_name, targets, selection,
-                } = &state.transfer_deuterium
+                }) = &state.active_wizard
                 {
                     if let Some((target_id, target_name)) = targets.get(*selection).cloned() {
-                        state.transfer_deuterium = TransferDeuteriumInput::EnterAmount {
+                        state.active_wizard = ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount {
                             manny_id: manny_id.clone(),
                             manny_name: manny_name.clone(),
                             target_id,
                             target_name,
                             buf: String::new(),
                             error: None,
-                        };
+                        });
                     }
                 }
             }
@@ -86,22 +86,22 @@ pub(super) fn handle_transfer_deuterium_event(
 
     // Step 2 — amount entry. Each arm takes its own borrow so reassigning the
     // wizard state never overlaps the mutable buffer borrow.
-    if !matches!(state.transfer_deuterium, TransferDeuteriumInput::EnterAmount { .. }) {
+    if !matches!(state.active_wizard, ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { .. })) {
         return;
     }
     match code {
-        KeyCode::Esc => state.transfer_deuterium = TransferDeuteriumInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Backspace => {
-            if let TransferDeuteriumInput::EnterAmount { buf, error, .. } =
-                &mut state.transfer_deuterium
+            if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { buf, error, .. }) =
+                &mut state.active_wizard
             {
                 buf.pop();
                 *error = None;
             }
         }
         KeyCode::Char(c) if c.is_ascii_digit() || c == '.' => {
-            if let TransferDeuteriumInput::EnterAmount { buf, error, .. } =
-                &mut state.transfer_deuterium
+            if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { buf, error, .. }) =
+                &mut state.active_wizard
             {
                 if c == '.' && buf.contains('.') {
                     return;
@@ -111,9 +111,9 @@ pub(super) fn handle_transfer_deuterium_event(
             }
         }
         KeyCode::Enter => {
-            let TransferDeuteriumInput::EnterAmount {
+            let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount {
                 manny_id, target_id, target_name, buf, ..
-            } = &state.transfer_deuterium else { return };
+            }) = &state.active_wizard else { return };
             match buf.trim().parse::<f64>() {
                 Ok(amount) if amount > 0.0 => {
                     let (mid, tid, tname) = (manny_id.clone(), *target_id, target_name.clone());
@@ -142,26 +142,26 @@ pub(super) fn handle_rename_probe_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc => state.rename_probe = RenameProbeInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Tab => {
             let s = state.next_name_suggestion();
-            if let RenameProbeInput::Typing { buf, .. } = &mut state.rename_probe {
+            if let ActiveWizard::RenameProbe(RenameProbeInput::Typing { buf, .. }) = &mut state.active_wizard {
                 *buf = s;
             }
         }
         KeyCode::Backspace => {
-            if let RenameProbeInput::Typing { buf, .. } = &mut state.rename_probe {
+            if let ActiveWizard::RenameProbe(RenameProbeInput::Typing { buf, .. }) = &mut state.active_wizard {
                 buf.pop();
             }
         }
         KeyCode::Char(c) => {
-            if let RenameProbeInput::Typing { buf, .. } = &mut state.rename_probe {
+            if let ActiveWizard::RenameProbe(RenameProbeInput::Typing { buf, .. }) = &mut state.active_wizard {
                 buf.push(c);
             }
         }
         KeyCode::Enter => {
-            let order = match &state.rename_probe {
-                RenameProbeInput::Typing { probe_id, buf, .. } if !buf.trim().is_empty() => {
+            let order = match &state.active_wizard {
+                ActiveWizard::RenameProbe(RenameProbeInput::Typing { probe_id, buf, .. }) if !buf.trim().is_empty() => {
                     Some((*probe_id, buf.trim().to_string()))
                 }
                 _ => None,

--- a/src/input/improve.rs
+++ b/src/input/improve.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_improve_probe;
-use crate::app::{ApiMessage, AppState, ImproveInput, LogEvent};
+use crate::app::{ActiveWizard, ApiMessage, AppState, ImproveInput, LogEvent};
 use super::geometry::list_nav;
 
 /// Drive the probe-improvement wizard: pick an improvement, then resolve which
@@ -14,14 +14,14 @@ pub(super) fn handle_improve_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match state.improve {
-        ImproveInput::PickImprovement { selection, .. } => {
+    match state.active_wizard {
+        ActiveWizard::Improve(ImproveInput::PickImprovement { selection, .. }) => {
             let count = state.probe_improvements.len();
             match code {
-                KeyCode::Esc => state.improve = ImproveInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ImproveInput::PickImprovement { ref mut selection, .. } = state.improve {
+                        if let ActiveWizard::Improve(ImproveInput::PickImprovement { ref mut selection, .. }) = state.active_wizard {
                             *selection = new_sel;
                         }
                     }
@@ -30,19 +30,19 @@ pub(super) fn handle_improve_event(
                 _ => {}
             }
         }
-        ImproveInput::PickBuilder { selection, ref mannies, .. } => {
+        ActiveWizard::Improve(ImproveInput::PickBuilder { selection, ref mannies, .. }) => {
             let count = mannies.len();
             match code {
-                KeyCode::Esc => state.improve = ImproveInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ImproveInput::PickBuilder { ref mut selection, .. } = state.improve {
+                        if let ActiveWizard::Improve(ImproveInput::PickBuilder { ref mut selection, .. }) = state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let picked = if let ImproveInput::PickBuilder { ref mannies, selection, ref improvement_id, ref improvement_name, .. } = state.improve {
+                    let picked = if let ActiveWizard::Improve(ImproveInput::PickBuilder { ref mannies, selection, ref improvement_id, ref improvement_name, .. }) = state.active_wizard {
                         mannies.get(selection).map(|(id, _)| (id.clone(), improvement_id.clone(), improvement_name.clone()))
                     } else {
                         None
@@ -55,7 +55,7 @@ pub(super) fn handle_improve_event(
                 _ => {}
             }
         }
-        ImproveInput::Inactive => {}
+        _ => {}
     }
 }
 
@@ -89,13 +89,13 @@ fn commit_improvement(
             state.log_event(LogEvent::improve(&name, state.active_probe_id));
         }
         _ => {
-            state.improve = ImproveInput::PickBuilder {
+            state.active_wizard = ActiveWizard::Improve(ImproveInput::PickBuilder {
                 improvement_id: id,
                 improvement_name: name,
                 mannies,
                 selection: 0,
                 error: None,
-            };
+            });
         }
     }
 }

--- a/src/input/jettison.rs
+++ b/src/input/jettison.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_jettison;
 use crate::app::{
-    ApiMessage, AppState, JettisonInput,
+    ActiveWizard, ApiMessage, AppState, JettisonInput,
 };
 pub(super) fn handle_jettison_event(
     code: KeyCode,
@@ -12,13 +12,13 @@ pub(super) fn handle_jettison_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.jettison {
-        JettisonInput::ConfirmManny { .. } => {
+    match &state.active_wizard {
+        ActiveWizard::Jettison(JettisonInput::ConfirmManny { .. }) => {
             match code {
-                KeyCode::Esc => state.jettison = JettisonInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Enter => {
                     let item_id = {
-                        let JettisonInput::ConfirmManny { ref item_id, .. } = state.jettison else { return };
+                        let ActiveWizard::Jettison(JettisonInput::ConfirmManny { ref item_id, .. }) = state.active_wizard else { return };
                         item_id.clone()
                     };
                     fetch_jettison(item_id, None, client.clone(), tx.clone());
@@ -26,12 +26,12 @@ pub(super) fn handle_jettison_event(
                 _ => {}
             }
         }
-        JettisonInput::ConfirmRelay { .. } => {
+        ActiveWizard::Jettison(JettisonInput::ConfirmRelay { .. }) => {
             match code {
-                KeyCode::Esc => state.jettison = JettisonInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Enter => {
                     let item_id = {
-                        let JettisonInput::ConfirmRelay { ref item_id, .. } = state.jettison else { return };
+                        let ActiveWizard::Jettison(JettisonInput::ConfirmRelay { ref item_id, .. }) = state.active_wizard else { return };
                         item_id.clone()
                     };
                     fetch_jettison(item_id, None, client.clone(), tx.clone());
@@ -39,9 +39,9 @@ pub(super) fn handle_jettison_event(
                 _ => {}
             }
         }
-        JettisonInput::EnterAmount { .. } => {
+        ActiveWizard::Jettison(JettisonInput::EnterAmount { .. }) => {
             match code {
-                KeyCode::Esc => state.jettison = JettisonInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Backspace => state.jettison_backspace(),
                 KeyCode::Char('m') | KeyCode::Char('M') => state.jettison_fill_max(),
                 KeyCode::Char(c) => state.jettison_type_char(c),
@@ -49,7 +49,7 @@ pub(super) fn handle_jettison_event(
                 // irreversible drop, rather than firing straight away.
                 KeyCode::Enter => {
                     let next = {
-                        let JettisonInput::EnterAmount { ref item_id, ref item_name, ref buf, .. } = state.jettison else { return };
+                        let ActiveWizard::Jettison(JettisonInput::EnterAmount { ref item_id, ref item_name, ref buf, .. }) = state.active_wizard else { return };
                         let amount = if buf.is_empty() {
                             None
                         } else {
@@ -64,17 +64,17 @@ pub(super) fn handle_jettison_event(
                             error: None,
                         }
                     };
-                    state.jettison = next;
+                    state.active_wizard = ActiveWizard::Jettison(next);
                 }
                 _ => {}
             }
         }
-        JettisonInput::Confirm { .. } => {
+        ActiveWizard::Jettison(JettisonInput::Confirm { .. }) => {
             match code {
-                KeyCode::Esc => state.jettison = JettisonInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Enter => {
                     let (item_id, amount) = {
-                        let JettisonInput::Confirm { ref item_id, amount, .. } = state.jettison else { return };
+                        let ActiveWizard::Jettison(JettisonInput::Confirm { ref item_id, amount, .. }) = state.active_wizard else { return };
                         (item_id.clone(), amount)
                     };
                     fetch_jettison(item_id, amount, client.clone(), tx.clone());
@@ -82,6 +82,6 @@ pub(super) fn handle_jettison_event(
                 _ => {}
             }
         }
-        JettisonInput::Inactive => {}
+        _ => {}
     }
 }

--- a/src/input/messages.rs
+++ b/src/input/messages.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_mark_message_read, fetch_send_message};
-use crate::app::{ApiMessage, AppState, LogEvent, MessagesInput};
+use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, MessagesInput};
 
 use super::geometry::list_nav;
 
@@ -13,21 +13,21 @@ pub(super) fn handle_messages_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.messages_input {
-        MessagesInput::Browsing { sent_tab, selection } => {
+    match &state.active_wizard {
+        ActiveWizard::Messages(MessagesInput::Browsing { sent_tab, selection }) => {
             let sent_tab = *sent_tab;
             let selection = *selection;
             let count = if sent_tab { state.sent_messages.len() } else { state.messages.len() };
             match code {
                 KeyCode::Esc | KeyCode::Char('Y') | KeyCode::Char('q') => {
-                    state.messages_input = MessagesInput::Inactive;
+                    state.close_wizard();
                 }
                 KeyCode::Tab | KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l') => {
-                    state.messages_input = MessagesInput::Browsing { sent_tab: !sent_tab, selection: 0 };
+                    state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: !sent_tab, selection: 0 });
                 }
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        state.messages_input = MessagesInput::Browsing { sent_tab, selection: new_sel };
+                        state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab, selection: new_sel });
                     }
                 }
                 KeyCode::Enter => {
@@ -42,7 +42,7 @@ pub(super) fn handle_messages_event(
                         })
                     };
                     if let Some(id) = id {
-                        state.messages_input = MessagesInput::Reading { id, sent_tab };
+                        state.active_wizard = ActiveWizard::Messages(MessagesInput::Reading { id, sent_tab });
                     }
                 }
                 KeyCode::Char('c') => {
@@ -50,59 +50,59 @@ pub(super) fn handle_messages_event(
                     if recipients.is_empty() {
                         state.error = Some("no reachable recipient in this sector".into());
                     } else {
-                        state.messages_input = MessagesInput::PickRecipient { recipients, selection: 0 };
+                        state.active_wizard = ActiveWizard::Messages(MessagesInput::PickRecipient { recipients, selection: 0 });
                     }
                 }
                 _ => {}
             }
         }
-        MessagesInput::Reading { sent_tab, .. } => {
+        ActiveWizard::Messages(MessagesInput::Reading { sent_tab, .. }) => {
             let sent_tab = *sent_tab;
             if matches!(code, KeyCode::Esc | KeyCode::Char('h') | KeyCode::Left | KeyCode::Char('q')) {
-                state.messages_input = MessagesInput::Browsing { sent_tab, selection: 0 };
+                state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab, selection: 0 });
             }
         }
-        MessagesInput::PickRecipient { recipients, selection } => {
+        ActiveWizard::Messages(MessagesInput::PickRecipient { recipients, selection }) => {
             let sel = *selection;
             let count = recipients.len();
             match code {
-                KeyCode::Esc => state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 },
+                KeyCode::Esc => state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 }),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let MessagesInput::PickRecipient { ref mut selection, .. } = state.messages_input {
+                        if let ActiveWizard::Messages(MessagesInput::PickRecipient { ref mut selection, .. }) = state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let MessagesInput::PickRecipient { ref recipients, selection } = state.messages_input else { return };
+                    let ActiveWizard::Messages(MessagesInput::PickRecipient { ref recipients, selection }) = state.active_wizard else { return };
                     let (kind, id, name) = recipients[selection].clone();
-                    state.messages_input = MessagesInput::Compose {
+                    state.active_wizard = ActiveWizard::Messages(MessagesInput::Compose {
                         recipient_type: kind,
                         recipient_id: id,
                         recipient_name: name,
                         body_buf: String::new(),
                         error: None,
-                    };
+                    });
                 }
                 _ => {}
             }
         }
-        MessagesInput::Compose { .. } => match code {
-            KeyCode::Esc => state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 },
+        ActiveWizard::Messages(MessagesInput::Compose { .. }) => match code {
+            KeyCode::Esc => state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 }),
             KeyCode::Backspace => {
-                if let MessagesInput::Compose { ref mut body_buf, .. } = state.messages_input {
+                if let ActiveWizard::Messages(MessagesInput::Compose { ref mut body_buf, .. }) = state.active_wizard {
                     body_buf.pop();
                 }
             }
             KeyCode::Char(c) => {
-                if let MessagesInput::Compose { ref mut body_buf, .. } = state.messages_input {
+                if let ActiveWizard::Messages(MessagesInput::Compose { ref mut body_buf, .. }) = state.active_wizard {
                     body_buf.push(c);
                 }
             }
             KeyCode::Enter => {
                 let (kind, id, body, recipient_name) = {
-                    let MessagesInput::Compose { ref recipient_type, ref recipient_id, ref body_buf, ref recipient_name, .. } = state.messages_input else { return };
+                    let ActiveWizard::Messages(MessagesInput::Compose { ref recipient_type, ref recipient_id, ref body_buf, ref recipient_name, .. }) = state.active_wizard else { return };
                     if body_buf.trim().is_empty() { return }
                     (recipient_type.clone(), recipient_id.clone(), body_buf.clone(), recipient_name.clone())
                 };
@@ -111,6 +111,6 @@ pub(super) fn handle_messages_event(
             }
             _ => {}
         },
-        MessagesInput::Inactive => {}
+        _ => {}
     }
 }

--- a/src/input/mine.rs
+++ b/src/input/mine.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_mine;
 use crate::app::{
-    ApiMessage, AppState, LogEvent, MineInput, RemoteMineInput, RESOURCE_TYPES,
+    ActiveWizard, ApiMessage, AppState, LogEvent, MineInput, RemoteMineInput, RESOURCE_TYPES,
 };
 use super::geometry::list_nav;
 
@@ -63,23 +63,23 @@ pub(super) fn handle_mine_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.mine {
-        MineInput::PickAsteroid { selection, candidates, .. } => {
+    match &state.active_wizard {
+        ActiveWizard::Mine(MineInput::PickAsteroid { selection, candidates, .. }) => {
             let sel = *selection;
             let count = candidates.len();
             match code {
-                KeyCode::Esc => state.mine = MineInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let MineInput::PickAsteroid { ref mut selection, .. } = state.mine {
+                        if let ActiveWizard::Mine(MineInput::PickAsteroid { selection, .. }) = &mut state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (manny_id, manny_name, object_id, object_name) = {
-                        let MineInput::PickAsteroid { ref manny_id, ref manny_name, ref candidates, selection } = state.mine else { return };
-                        let (id, name) = candidates[selection].clone();
+                        let ActiveWizard::Mine(MineInput::PickAsteroid { manny_id, manny_name, candidates, selection }) = &state.active_wizard else { return };
+                        let (id, name) = candidates[*selection].clone();
                         (manny_id.clone(), manny_name.clone(), id, name)
                     };
                     // Preselect the resources the target actually holds; fall
@@ -89,26 +89,26 @@ pub(super) fn handle_mine_event(
                         .map(|(flags, _)| flags)
                         .filter(|f| f.iter().any(|&x| x))
                         .unwrap_or([false, true, false, false]);
-                    state.mine = MineInput::Configure {
+                    state.active_wizard = ActiveWizard::Mine(MineInput::Configure {
                         manny_id, manny_name, object_id, object_name,
                         resources,
                         amount_buf: "0.30".into(),
                         amount_mode: false,
                         target_container: None,
                         error: None,
-                    };
+                    });
                 }
                 _ => {}
             }
         }
-        MineInput::Configure { amount_mode, object_id, resources, .. } => {
+        ActiveWizard::Mine(MineInput::Configure { amount_mode, object_id, resources, .. }) => {
             let am = *amount_mode;
             let obj_id = object_id.clone();
             let res = *resources;
             match code {
-                KeyCode::Esc => state.mine = MineInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Tab => {
-                    if let MineInput::Configure { ref mut amount_mode, ref mut error, .. } = state.mine {
+                    if let ActiveWizard::Mine(MineInput::Configure { amount_mode, error, .. }) = &mut state.active_wizard {
                         *amount_mode = !am;
                         *error = None;
                     }
@@ -121,7 +121,7 @@ pub(super) fn handle_mine_event(
                         .map(|(flags, _)| flags[idx])
                         .unwrap_or(true);
                     if present {
-                        if let MineInput::Configure { ref mut resources, ref mut error, .. } = state.mine {
+                        if let ActiveWizard::Mine(MineInput::Configure { resources, error, .. }) = &mut state.active_wizard {
                             resources[idx] = !resources[idx];
                             *error = None;
                         }
@@ -129,13 +129,13 @@ pub(super) fn handle_mine_event(
                 }
                 KeyCode::Char('m') | KeyCode::Char('M') if am => {
                     let max = state.mine_reserve_max(&obj_id, res);
-                    if let MineInput::Configure { ref mut amount_buf, ref mut error, .. } = state.mine {
+                    if let ActiveWizard::Mine(MineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard {
                         *amount_buf = format!("{:.4}", max);
                         *error = None;
                     }
                 }
                 KeyCode::Char(c) if am && (c.is_ascii_digit() || c == '.') => {
-                    if let MineInput::Configure { ref mut amount_buf, ref mut error, .. } = state.mine {
+                    if let ActiveWizard::Mine(MineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard {
                         if !(c == '.' && amount_buf.contains('.')) {
                             amount_buf.push(c);
                             *error = None;
@@ -143,20 +143,20 @@ pub(super) fn handle_mine_event(
                     }
                 }
                 KeyCode::Backspace if am => {
-                    if let MineInput::Configure { ref mut amount_buf, .. } = state.mine {
+                    if let ActiveWizard::Mine(MineInput::Configure { amount_buf, .. }) = &mut state.active_wizard {
                         amount_buf.pop();
                     }
                 }
                 KeyCode::Char('c') => {
                     let containers = state.collect_detached_containers();
-                    if let MineInput::Configure { ref mut target_container, ref mut error, .. } = state.mine {
+                    if let ActiveWizard::Mine(MineInput::Configure { target_container, error, .. }) = &mut state.active_wizard {
                         *target_container = next_target_container(target_container.as_ref(), &containers);
                         *error = None;
                     }
                 }
                 KeyCode::Enter => {
                     let (manny_id, object_id, selected_resources, amount, container_id, destination) = {
-                        let MineInput::Configure { ref manny_id, ref object_id, resources, ref amount_buf, ref target_container, .. } = state.mine else { return };
+                        let ActiveWizard::Mine(MineInput::Configure { manny_id, object_id, resources, amount_buf, target_container, .. }) = &state.active_wizard else { return };
                         let selected: Vec<String> = RESOURCE_TYPES.iter().enumerate()
                             .filter(|(i, _)| resources[*i])
                             .map(|(_, &t)| t.to_string())
@@ -177,7 +177,7 @@ pub(super) fn handle_mine_event(
                 _ => {}
             }
         }
-        MineInput::Inactive => {}
+        _ => {}
     }
 }
 
@@ -187,32 +187,34 @@ pub(super) fn handle_remote_mine_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.remote_mine {
-        RemoteMineInput::Loading { .. } => {
+    match &state.active_wizard {
+        ActiveWizard::RemoteMine(RemoteMineInput::Loading { .. }) => {
             if code == KeyCode::Esc {
-                state.remote_mine = RemoteMineInput::Inactive;
+                state.close_wizard();
             }
         }
-        RemoteMineInput::PickAsteroid { selection, candidates, .. } => {
+        ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { selection, candidates, .. }) => {
             let sel = *selection;
             let count = candidates.len();
             match code {
-                KeyCode::Esc => state.remote_mine = RemoteMineInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let RemoteMineInput::PickAsteroid { ref mut selection, .. } = state.remote_mine {
+                        if let ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { selection, .. }) = &mut state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let RemoteMineInput::PickAsteroid {
-                        ref manny_id, ref manny_name, x, y, z, ref candidates, selection,
-                    } = state.remote_mine else { return };
-                    let (object_id, object_name) = candidates[selection].clone();
-                    state.remote_mine = RemoteMineInput::Configure {
-                        manny_id: manny_id.clone(),
-                        manny_name: manny_name.clone(),
+                    let ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid {
+                        manny_id, manny_name, x, y, z, candidates, selection,
+                    }) = &state.active_wizard else { return };
+                    let (object_id, object_name) = candidates[*selection].clone();
+                    let (manny_id, manny_name, x, y, z) =
+                        (manny_id.clone(), manny_name.clone(), *x, *y, *z);
+                    state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::Configure {
+                        manny_id,
+                        manny_name,
                         x, y, z,
                         object_id,
                         object_name,
@@ -220,30 +222,30 @@ pub(super) fn handle_remote_mine_event(
                         amount_buf: "0.30".into(),
                         amount_mode: false,
                         error: None,
-                    };
+                    });
                 }
                 _ => {}
             }
         }
-        RemoteMineInput::Configure { amount_mode, .. } => {
+        ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_mode, .. }) => {
             let am = *amount_mode;
             match code {
-                KeyCode::Esc => state.remote_mine = RemoteMineInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Tab => {
-                    if let RemoteMineInput::Configure { ref mut amount_mode, ref mut error, .. } = state.remote_mine {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_mode, error, .. }) = &mut state.active_wizard {
                         *amount_mode = !am;
                         *error = None;
                     }
                 }
                 KeyCode::Char(c @ '1'..='4') if !am => {
                     let idx = (c as u8 - b'1') as usize;
-                    if let RemoteMineInput::Configure { ref mut resources, ref mut error, .. } = state.remote_mine {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { resources, error, .. }) = &mut state.active_wizard {
                         resources[idx] = !resources[idx];
                         *error = None;
                     }
                 }
                 KeyCode::Char(c) if am && (c.is_ascii_digit() || c == '.') => {
-                    if let RemoteMineInput::Configure { ref mut amount_buf, ref mut error, .. } = state.remote_mine {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard {
                         if !(c == '.' && amount_buf.contains('.')) {
                             amount_buf.push(c);
                             *error = None;
@@ -251,19 +253,19 @@ pub(super) fn handle_remote_mine_event(
                     }
                 }
                 KeyCode::Backspace if am => {
-                    if let RemoteMineInput::Configure { ref mut amount_buf, .. } = state.remote_mine {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_buf, .. }) = &mut state.active_wizard {
                         amount_buf.pop();
                     }
                 }
                 KeyCode::Enter => {
                     let (manny_id, object_id, resources, amount, coords) = {
-                        let RemoteMineInput::Configure {
-                            ref manny_id, ref object_id, resources, ref amount_buf, x, y, z, ..
-                        } = state.remote_mine else { return };
+                        let ActiveWizard::RemoteMine(RemoteMineInput::Configure {
+                            manny_id, object_id, resources, amount_buf, x, y, z, ..
+                        }) = &state.active_wizard else { return };
                         if !resources.iter().any(|&r| r) { return }
                         let Ok(amount) = amount_buf.parse::<f64>() else { return };
                         if amount <= 0.0 { return }
-                        (manny_id.clone(), object_id.clone(), resources, amount, (x, y, z))
+                        (manny_id.clone(), object_id.clone(), *resources, amount, (*x, *y, *z))
                     };
                     let containers = state
                         .sector_observation_at(coords.0, coords.1, coords.2)
@@ -275,7 +277,7 @@ pub(super) fn handle_remote_mine_event(
                         );
                         return;
                     }
-                    state.remote_mine = RemoteMineInput::PickContainer {
+                    state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::PickContainer {
                         manny_id,
                         object_id,
                         resources,
@@ -283,33 +285,33 @@ pub(super) fn handle_remote_mine_event(
                         containers,
                         selection: 0,
                         error: None,
-                    };
+                    });
                 }
                 _ => {}
             }
         }
-        RemoteMineInput::PickContainer { selection, containers, .. } => {
+        ActiveWizard::RemoteMine(RemoteMineInput::PickContainer { selection, containers, .. }) => {
             let sel = *selection;
             let count = containers.len();
             match code {
-                KeyCode::Esc => state.remote_mine = RemoteMineInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let RemoteMineInput::PickContainer { ref mut selection, .. } = state.remote_mine {
+                        if let ActiveWizard::RemoteMine(RemoteMineInput::PickContainer { selection, .. }) = &mut state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (manny_id, object_id, selected_resources, amount, container_id, destination) = {
-                        let RemoteMineInput::PickContainer {
-                            ref manny_id, ref object_id, resources, amount, ref containers, selection, ..
-                        } = state.remote_mine else { return };
+                        let ActiveWizard::RemoteMine(RemoteMineInput::PickContainer {
+                            manny_id, object_id, resources, amount, containers, selection, ..
+                        }) = &state.active_wizard else { return };
                         let selected: Vec<String> = RESOURCE_TYPES.iter().enumerate()
                             .filter(|(i, _)| resources[*i])
                             .map(|(_, &t)| t.to_string())
                             .collect();
-                        (manny_id.clone(), object_id.clone(), selected, amount, containers[selection].0.clone(), containers[selection].1.clone())
+                        (manny_id.clone(), object_id.clone(), selected, *amount, containers[*selection].0.clone(), containers[*selection].1.clone())
                     };
                     let resources_label = selected_resources.join(", ");
                     fetch_mine(manny_id, object_id, selected_resources, amount, Some(container_id), client.clone(), tx.clone());
@@ -318,6 +320,6 @@ pub(super) fn handle_remote_mine_event(
                 _ => {}
             }
         }
-        RemoteMineInput::Inactive => {}
+        _ => {}
     }
 }

--- a/src/input/missions.rs
+++ b/src/input/missions.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::tasks::fetch_abandon_mission;
 use crate::api::types::MissionStatus;
-use crate::app::{ApiMessage, AppState, LogEvent, MissionsInput};
+use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, MissionsInput};
 use crate::api::client::ApiClient;
 
 use super::geometry::list_nav;
@@ -14,27 +14,27 @@ pub(super) fn handle_missions_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match state.missions_input {
-        MissionsInput::Browsing { selection } => {
+    match state.active_wizard {
+        ActiveWizard::Missions(MissionsInput::Browsing { selection }) => {
             let count = state.missions.len();
             match code {
                 KeyCode::Esc | KeyCode::Char('O') | KeyCode::Char('q') => {
-                    state.missions_input = MissionsInput::Inactive;
+                    state.close_wizard();
                 }
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        state.missions_input = MissionsInput::Browsing { selection: new_sel };
+                        state.active_wizard = ActiveWizard::Missions(MissionsInput::Browsing { selection: new_sel });
                     }
                 }
                 KeyCode::Char('a') => {
                     if let Some(m) = state.missions.get(selection) {
                         if m.status == MissionStatus::Active {
-                            state.missions_input = MissionsInput::ConfirmAbandon {
+                            state.active_wizard = ActiveWizard::Missions(MissionsInput::ConfirmAbandon {
                                 mission_id: m.id.clone(),
                                 mission_title: m.title.clone(),
                                 selection,
                                 error: None,
-                            };
+                            });
                         } else {
                             state.error = Some("only active missions can be abandoned".into());
                         }
@@ -43,13 +43,13 @@ pub(super) fn handle_missions_event(
                 _ => {}
             }
         }
-        MissionsInput::ConfirmAbandon { selection, .. } => match code {
+        ActiveWizard::Missions(MissionsInput::ConfirmAbandon { selection, .. }) => match code {
             KeyCode::Esc | KeyCode::Char('n') => {
-                state.missions_input = MissionsInput::Browsing { selection };
+                state.active_wizard = ActiveWizard::Missions(MissionsInput::Browsing { selection });
             }
             KeyCode::Enter | KeyCode::Char('y') => {
                 let (mission_id, mission_title) = {
-                    let MissionsInput::ConfirmAbandon { ref mission_id, ref mission_title, .. } = state.missions_input
+                    let ActiveWizard::Missions(MissionsInput::ConfirmAbandon { ref mission_id, ref mission_title, .. }) = state.active_wizard
                     else {
                         return;
                     };
@@ -60,6 +60,6 @@ pub(super) fn handle_missions_event(
             }
             _ => {}
         },
-        MissionsInput::Inactive => {}
+        _ => {}
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,13 +4,8 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_sector;
 use crate::app::{
-    AlertsInput, ApiMessage, AppState, AssembleProbeInput, ContainerRulesInput,
-    FabricationInput, DeployInput, DetachInput, DropCargoInput,
-    DropStorageContainerInput, InspectInput, JettisonInput, MindSnapshotInput, MineInput,
-    MessagesInput, MissionsInput, ObjectActionInput, RecallInput, RecoverInput, RefuelInput,
-    RemoteMineInput, RenameContainerInput, RenameMannyInput, RepairInput, SalvageInput, ScanMode,
-    GotoVisitedInput, ImproveInput, InputMode, ProbeSwitchInput, RenameProbeInput, ScutNetworkInput,
-    ScutRelayInput, StorageMoveInput, TransferDeuteriumInput, TravelInput, WaypointsInput,
+    ActiveWizard, ApiMessage, AppState, ScanMode,
+    GotoVisitedInput, InputMode, ProbeSwitchInput,
 };
 mod alerts;
 mod assemble;
@@ -75,37 +70,37 @@ type WizardHandler = fn(KeyCode, &mut AppState, &ApiClient, &mpsc::Sender<ApiMes
 /// (which ignores client/tx) is wrapped to match.
 #[allow(clippy::type_complexity)]
 const WIZARD_INPUTS: &[(WizardGuard, WizardHandler)] = &[
-    (|s| !matches!(s.assemble_probe, AssembleProbeInput::Inactive), handle_assemble_probe_event),
-    (|s| !matches!(s.rename_probe, RenameProbeInput::Inactive), handle_rename_probe_event),
-    (|s| !matches!(s.jettison, JettisonInput::Inactive), handle_jettison_event),
-    (|s| !matches!(s.fabrication, FabricationInput::Inactive), handle_fabrication_event),
-    (|s| !matches!(s.improve, ImproveInput::Inactive), handle_improve_event),
-    (|s| !matches!(s.salvage, SalvageInput::Inactive), handle_salvage_event),
-    (|s| !matches!(s.recall, RecallInput::Inactive), handle_recall_event),
-    (|s| !matches!(s.refuel, RefuelInput::Inactive), handle_refuel_event),
-    (|s| !matches!(s.transfer_deuterium, TransferDeuteriumInput::Inactive), handle_transfer_deuterium_event),
-    (|s| !matches!(s.mind_snapshot, MindSnapshotInput::Inactive), handle_mind_snapshot_event),
-    (|s| !matches!(s.scut_relay, ScutRelayInput::Inactive), handle_scut_relay_event),
-    (|s| !matches!(s.scut_network, ScutNetworkInput::Inactive), handle_scut_network_event),
-    (|s| !matches!(s.missions_input, MissionsInput::Inactive), handle_missions_event),
-    (|s| !matches!(s.messages_input, MessagesInput::Inactive), handle_messages_event),
-    (|s| !matches!(s.rename_manny, RenameMannyInput::Inactive), handle_rename_manny_event),
-    (|s| !matches!(s.deploy, DeployInput::Inactive), handle_deploy_event),
-    (|s| !matches!(s.inspect, InspectInput::Inactive), handle_inspect_event),
-    (|s| !matches!(s.recover, RecoverInput::Inactive), handle_recover_event),
-    (|s| !matches!(s.detach, DetachInput::Inactive), handle_detach_event),
-    (|s| !matches!(s.alerts_input, AlertsInput::Inactive), handle_alerts_event),
-    (|s| !matches!(s.rename_container, RenameContainerInput::Inactive), handle_rename_container_event),
-    (|s| !matches!(s.container_rules, ContainerRulesInput::Inactive), handle_container_rules_event),
-    (|s| !matches!(s.storage_move, StorageMoveInput::Inactive), handle_storage_move_event),
-    (|s| !matches!(s.drop_cargo, DropCargoInput::Inactive), handle_drop_cargo_event),
-    (|s| !matches!(s.drop_container, DropStorageContainerInput::Inactive), handle_drop_container_event),
-    (|s| !matches!(s.object_action, ObjectActionInput::Inactive), handle_object_action_event),
-    (|s| !matches!(s.waypoints, WaypointsInput::Inactive), |c, s, _, _| handle_waypoints_event(c, s)),
-    (|s| !matches!(s.travel, TravelInput::Inactive), handle_travel_event),
-    (|s| !matches!(s.repair, RepairInput::Inactive), handle_repair_event),
-    (|s| !matches!(s.mine, MineInput::Inactive), handle_mine_event),
-    (|s| !matches!(s.remote_mine, RemoteMineInput::Inactive), handle_remote_mine_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::AssembleProbe(_)), handle_assemble_probe_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::RenameProbe(_)), handle_rename_probe_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Jettison(_)), handle_jettison_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Fabrication(_)), handle_fabrication_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Improve(_)), handle_improve_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Salvage(_)), handle_salvage_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Recall(_)), handle_recall_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Refuel(_)), handle_refuel_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::TransferDeuterium(_)), handle_transfer_deuterium_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::MindSnapshot(_)), handle_mind_snapshot_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::ScutRelay(_)), handle_scut_relay_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::ScutNetwork(_)), handle_scut_network_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Missions(_)), handle_missions_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Messages(_)), handle_messages_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::RenameManny(_)), handle_rename_manny_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Deploy(_)), handle_deploy_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Inspect(_)), handle_inspect_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Recover(_)), handle_recover_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Detach(_)), handle_detach_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Alerts(_)), handle_alerts_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::RenameContainer(_)), handle_rename_container_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::ContainerRules(_)), handle_container_rules_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::StorageMove(_)), handle_storage_move_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::DropCargo(_)), handle_drop_cargo_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::DropContainer(_)), handle_drop_container_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::ObjectAction(_)), handle_object_action_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Waypoints(_)), |c, s, _, _| handle_waypoints_event(c, s)),
+    (|s| matches!(s.active_wizard, ActiveWizard::Travel(_)), handle_travel_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Repair(_)), handle_repair_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::Mine(_)), handle_mine_event),
+    (|s| matches!(s.active_wizard, ActiveWizard::RemoteMine(_)), handle_remote_mine_event),
 ];
 
 /// Route a key to the first active wizard. Returns `true` if one consumed it.
@@ -264,7 +259,7 @@ mod tests {
     //! an open wizard captures keys before the cockpit grid, and Esc closes it.
     //! These pin behavior ahead of the wizard-registry refactor.
     use super::*;
-    use crate::app::Pane;
+    use crate::app::{AlertsInput, Pane, TravelInput};
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
     fn dummy_client() -> ApiClient {
@@ -310,55 +305,67 @@ mod tests {
         });
         press(&mut state, KeyCode::Char('1'));
         assert!(matches!(state.mode, InputMode::Normal), "digit fired and closed the menu");
-        assert!(!matches!(state.travel, TravelInput::Inactive), "the item's wizard launched");
+        assert!(matches!(state.active_wizard, ActiveWizard::Travel(_)), "the item's wizard launched");
     }
 
     #[tokio::test]
     async fn open_wizard_captures_keys_before_cockpit() {
         let mut state = AppState::default();
-        state.travel = TravelInput::Typing(String::new());
+        state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
         press(&mut state, KeyCode::Char('e'));
         assert_eq!(state.active_pane, Pane::Probe, "wizard swallows the key; cockpit must not switch pane");
-        assert!(!matches!(state.travel, TravelInput::Inactive), "the wizard stays open");
+        assert!(matches!(state.active_wizard, ActiveWizard::Travel(_)), "the wizard stays open");
     }
 
     #[tokio::test]
     async fn esc_closes_the_active_wizard() {
         let mut state = AppState::default();
-        state.travel = TravelInput::Typing("12".into());
+        state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("12".into()));
         press(&mut state, KeyCode::Esc);
-        assert!(matches!(state.travel, TravelInput::Inactive), "Esc closes the travel wizard");
+        assert!(matches!(state.active_wizard, ActiveWizard::None), "Esc closes the travel wizard");
+    }
+
+    #[tokio::test]
+    async fn opening_a_second_wizard_replaces_the_first() {
+        // The structural guarantee: `active_wizard` is a single field, so a new
+        // wizard cannot coexist with a previous one — it replaces it. No two
+        // wizards can be open at once (that state is now unrepresentable).
+        let mut state = AppState::default();
+        state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
+        state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing { selection: 0, show_warnings: false });
+        assert!(matches!(state.active_wizard, ActiveWizard::Alerts(_)), "the second wizard is now active");
+        assert!(!matches!(state.active_wizard, ActiveWizard::Travel(_)), "the first was replaced, not kept alongside");
     }
 
     #[tokio::test]
     async fn tabbed_wizard_also_captures_keys_and_closes_on_esc() {
         let mut state = AppState::default();
-        state.alerts_input = AlertsInput::Browsing { selection: 0, show_warnings: false };
+        state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing { selection: 0, show_warnings: false });
         // A pane key must not reach the cockpit while the alerts overlay is open.
         press(&mut state, KeyCode::Char('b'));
         assert_eq!(state.active_pane, Pane::Probe, "alerts overlay swallows the pane key");
-        assert!(!matches!(state.alerts_input, AlertsInput::Inactive));
+        assert!(matches!(state.active_wizard, ActiveWizard::Alerts(_)));
         press(&mut state, KeyCode::Esc);
-        assert!(matches!(state.alerts_input, AlertsInput::Inactive), "Esc closes the alerts overlay");
+        assert!(matches!(state.active_wizard, ActiveWizard::None), "Esc closes the alerts overlay");
     }
 
     #[tokio::test]
     async fn pick_list_j_moves_selection_and_esc_closes() {
         use crate::app::SalvageInput;
         let mut state = AppState::default();
-        state.salvage = SalvageInput::PickTarget {
+        state.active_wizard = ActiveWizard::Salvage(SalvageInput::PickTarget {
             manny_id: "m1".into(),
             manny_name: "M".into(),
             candidates: vec![("a".into(), "A".into()), ("b".into(), "B".into())],
             selection: 0,
-        };
+        });
         press(&mut state, KeyCode::Char('j'));
-        match &state.salvage {
-            SalvageInput::PickTarget { selection, .. } => assert_eq!(*selection, 1, "j moves the cursor"),
+        match &state.active_wizard {
+            ActiveWizard::Salvage(SalvageInput::PickTarget { selection, .. }) => assert_eq!(*selection, 1, "j moves the cursor"),
             _ => panic!("should still be picking"),
         }
         press(&mut state, KeyCode::Esc);
-        assert!(matches!(state.salvage, SalvageInput::Inactive), "Esc closes the picker");
+        assert!(matches!(state.active_wizard, ActiveWizard::None), "Esc closes the picker");
     }
 
     fn idle_onboard_manny(id: &str) -> crate::api::types::Manny {
@@ -383,10 +390,10 @@ mod tests {
         let mut state = AppState::default();
         state.recipes = vec![manny_recipe("solar_panel")];
         state.mannies = Some(vec![idle_onboard_manny("m1"), idle_onboard_manny("m2")]);
-        state.fabrication = FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None };
+        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None });
         press(&mut state, KeyCode::Enter);
-        match &state.fabrication {
-            FabricationInput::PickBuilder { recipe_id, mannies, .. } => {
+        match &state.active_wizard {
+            ActiveWizard::Fabrication(FabricationInput::PickBuilder { recipe_id, mannies, .. }) => {
                 assert_eq!(recipe_id, "solar_panel");
                 assert_eq!(mannies.len(), 2, "both idle mannies offered as builders");
             }
@@ -400,10 +407,10 @@ mod tests {
         let mut state = AppState::default();
         state.recipes = vec![manny_recipe("solar_panel")];
         state.mannies = Some(vec![]);
-        state.fabrication = FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None };
+        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None });
         press(&mut state, KeyCode::Enter);
-        match &state.fabrication {
-            FabricationInput::PickRecipe { error, .. } => {
+        match &state.active_wizard {
+            ActiveWizard::Fabrication(FabricationInput::PickRecipe { error, .. }) => {
                 assert!(error.as_deref().unwrap_or("").contains("no idle Manny"), "surfaces the no-manny error");
             }
             _ => panic!("stays on the recipe step with an error"),
@@ -424,8 +431,8 @@ mod tests {
         }"#).unwrap()];
         press(&mut state, KeyCode::Enter); // open the Probe context menu
         press(&mut state, KeyCode::Enter); // fire the first enabled item (Inspect SCUT network…)
-        match &state.scut_network {
-            ScutNetworkInput::Picking { networks, .. } => assert_eq!(networks.len(), 2, "both networks offered"),
+        match &state.active_wizard {
+            ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks, .. }) => assert_eq!(networks.len(), 2, "both networks offered"),
             _ => panic!("two networks should open the picker"),
         }
     }
@@ -443,7 +450,7 @@ mod tests {
         }"#).unwrap()];
         press(&mut state, KeyCode::Enter);
         press(&mut state, KeyCode::Enter);
-        assert!(matches!(state.scut_network, ScutNetworkInput::Viewing { .. }), "a single network views directly");
+        assert!(matches!(state.active_wizard, ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })), "a single network views directly");
     }
 
     #[tokio::test]
@@ -466,7 +473,7 @@ mod tests {
         state.active_pane = Pane::Comms;
         state.pane_nav[Pane::Comms.index()].cursor = 0; // Messages row
         press(&mut state, KeyCode::Enter);
-        assert!(matches!(state.messages_input, MessagesInput::Browsing { .. }), "Messages opens its overlay");
+        assert!(matches!(state.active_wizard, ActiveWizard::Messages(MessagesInput::Browsing { .. })), "Messages opens its overlay");
     }
 
     #[tokio::test]
@@ -481,7 +488,7 @@ mod tests {
         press(&mut state, KeyCode::Enter); // open the Probe menu (Improve is the first enabled item)
         press(&mut state, KeyCode::Enter); // fire it
         assert!(
-            matches!(state.improve, ImproveInput::PickImprovement { .. }),
+            matches!(state.active_wizard, ActiveWizard::Improve(ImproveInput::PickImprovement { .. })),
             "an orderable improvement opens the picker"
         );
     }

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -8,8 +8,8 @@ use crate::api::tasks::{
     fetch_recover, fetch_rename_manny, fetch_salvage,
 };
 use crate::app::{
-    ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput,
-    InspectInput, LogEvent, MindSnapshotInput, RecallInput, RefuelInput,
+    ActiveWizard, ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput,
+    DropStorageContainerInput, InspectInput, LogEvent, RecallInput, RefuelInput,
     RecoverInput, RenameMannyInput, SalvageInput, DETACH_MODES,
 };
 use super::geometry::list_move;
@@ -19,31 +19,31 @@ pub(super) fn handle_salvage_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if let SalvageInput::PickTarget { selection, candidates, .. } = &mut state.salvage {
+    if let ActiveWizard::Salvage(SalvageInput::PickTarget { selection, candidates, .. }) = &mut state.active_wizard {
         if list_move(code, selection, candidates.len()) {
             return;
         }
     }
-    match &state.salvage {
-        SalvageInput::PickTarget { .. } => match code {
-            KeyCode::Esc => state.salvage = SalvageInput::Inactive,
+    match &state.active_wizard {
+        ActiveWizard::Salvage(SalvageInput::PickTarget { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, manny_name, object_id, object_name) = {
-                    let SalvageInput::PickTarget { ref manny_id, ref manny_name, ref candidates, selection } = state.salvage else { return };
-                    let (id, name) = candidates[selection].clone();
+                    let ActiveWizard::Salvage(SalvageInput::PickTarget { manny_id, manny_name, candidates, selection }) = &state.active_wizard else { return };
+                    let (id, name) = candidates[*selection].clone();
                     (manny_id.clone(), manny_name.clone(), id, name)
                 };
-                state.salvage = SalvageInput::Confirm {
+                state.active_wizard = ActiveWizard::Salvage(SalvageInput::Confirm {
                     manny_id, manny_name, object_id, object_name, error: None,
-                };
+                });
             }
             _ => {}
         },
-        SalvageInput::Confirm { .. } => match code {
-            KeyCode::Esc => state.salvage = SalvageInput::Inactive,
+        ActiveWizard::Salvage(SalvageInput::Confirm { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, object_id, object_name) = {
-                    let SalvageInput::Confirm { ref manny_id, ref object_id, ref object_name, .. } = state.salvage else { return };
+                    let ActiveWizard::Salvage(SalvageInput::Confirm { manny_id, object_id, object_name, .. }) = &state.active_wizard else { return };
                     (manny_id.clone(), object_id.clone(), object_name.clone())
                 };
                 fetch_salvage(manny_id, object_id, client.clone(), tx.clone());
@@ -51,7 +51,7 @@ pub(super) fn handle_salvage_event(
             }
             _ => {}
         },
-        SalvageInput::Inactive => {}
+        _ => {}
     }
 }
 
@@ -62,11 +62,11 @@ pub(super) fn handle_recall_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc => state.recall = RecallInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Enter => {
             let (manny_id, manny_name, remote) = {
-                let RecallInput::Confirm { ref manny_id, ref manny_name, remote, .. } = state.recall else { return };
-                (manny_id.clone(), manny_name.clone(), remote)
+                let ActiveWizard::Recall(RecallInput::Confirm { manny_id, manny_name, remote, .. }) = &state.active_wizard else { return };
+                (manny_id.clone(), manny_name.clone(), *remote)
             };
             fetch_recall(manny_id, client.clone(), tx.clone());
             state.log_event(LogEvent::recall(&manny_name, remote, state.active_probe_id));
@@ -82,10 +82,10 @@ pub(super) fn handle_refuel_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc | KeyCode::Char('n') => state.refuel = RefuelInput::Inactive,
+        KeyCode::Esc | KeyCode::Char('n') => state.close_wizard(),
         KeyCode::Enter | KeyCode::Char('y') => {
             let manny_id = {
-                let RefuelInput::Confirm { ref manny_id, .. } = state.refuel else { return };
+                let ActiveWizard::Refuel(RefuelInput::Confirm { manny_id, .. }) = &state.active_wizard else { return };
                 manny_id.clone()
             };
             fetch_refill_deuterium(manny_id, client.clone(), tx.clone());
@@ -102,7 +102,7 @@ pub(super) fn handle_mind_snapshot_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc | KeyCode::Char('n') => state.mind_snapshot = MindSnapshotInput::Inactive,
+        KeyCode::Esc | KeyCode::Char('n') => state.close_wizard(),
         KeyCode::Enter | KeyCode::Char('y') => {
             fetch_reassign_mind_snapshot(client.clone(), tx.clone());
             state.log_event(LogEvent::mind_snapshot(state.active_probe_id));
@@ -117,50 +117,50 @@ pub(super) fn handle_drop_container_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &mut state.drop_container {
-        DropStorageContainerInput::PickContainer { selection, containers, .. } => {
+    match &mut state.active_wizard {
+        ActiveWizard::DropContainer(DropStorageContainerInput::PickContainer { selection, containers, .. }) => {
             if list_move(code, selection, containers.len()) {
                 return;
             }
         }
-        DropStorageContainerInput::PickPlanet { selection, planets, .. } => {
+        ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet { selection, planets, .. }) => {
             if list_move(code, selection, planets.len()) {
                 return;
             }
         }
-        DropStorageContainerInput::Inactive => {}
+        _ => {}
     }
-    match &state.drop_container {
-        DropStorageContainerInput::PickContainer { .. } => match code {
-            KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
+    match &state.active_wizard {
+        ActiveWizard::DropContainer(DropStorageContainerInput::PickContainer { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, manny_name, container_id, container_name) = {
-                    let DropStorageContainerInput::PickContainer {
+                    let ActiveWizard::DropContainer(DropStorageContainerInput::PickContainer {
                         manny_id, manny_name, containers, selection,
-                    } = &state.drop_container else { return };
+                    }) = &state.active_wizard else { return };
                     let (id, name) = containers[*selection].clone();
                     (manny_id.clone(), manny_name.clone(), id, name)
                 };
                 let planets = state.collect_planet_candidates();
                 if planets.is_empty() {
-                    state.drop_container = DropStorageContainerInput::Inactive;
+                    state.close_wizard();
                     state.error = Some("no planet in current sector — scan first".into());
                     return;
                 }
-                state.drop_container = DropStorageContainerInput::PickPlanet {
+                state.active_wizard = ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet {
                     manny_id, manny_name, container_id, container_name,
                     planets, selection: 0, error: None,
-                };
+                });
             }
             _ => {}
         },
-        DropStorageContainerInput::PickPlanet { .. } => match code {
-            KeyCode::Esc => state.drop_container = DropStorageContainerInput::Inactive,
+        ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, container_id, planet_id, container_name, planet_name) = {
-                    let DropStorageContainerInput::PickPlanet {
+                    let ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet {
                         manny_id, container_id, container_name, planets, selection, ..
-                    } = &state.drop_container else { return };
+                    }) = &state.active_wizard else { return };
                     (
                         manny_id.clone(),
                         container_id.clone(),
@@ -174,7 +174,7 @@ pub(super) fn handle_drop_container_event(
             }
             _ => {}
         },
-        DropStorageContainerInput::Inactive => {}
+        _ => {}
     }
 }
 
@@ -185,10 +185,10 @@ pub(super) fn handle_drop_cargo_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc | KeyCode::Char('n') => state.drop_cargo = DropCargoInput::Inactive,
+        KeyCode::Esc | KeyCode::Char('n') => state.close_wizard(),
         KeyCode::Enter | KeyCode::Char('y') => {
             let manny_id = {
-                let DropCargoInput::Confirm { ref manny_id, .. } = state.drop_cargo else { return };
+                let ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_id, .. }) = &state.active_wizard else { return };
                 manny_id.clone()
             };
             fetch_drop_manny_cargo(manny_id, client.clone(), tx.clone());
@@ -204,61 +204,61 @@ pub(super) fn handle_deploy_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &mut state.deploy {
-        DeployInput::PickManny { selection, mannies } => {
+    match &mut state.active_wizard {
+        ActiveWizard::Deploy(DeployInput::PickManny { selection, mannies }) => {
             if list_move(code, selection, mannies.len()) {
                 return;
             }
         }
-        DeployInput::PickObject { selection, candidates, .. } => {
+        ActiveWizard::Deploy(DeployInput::PickObject { selection, candidates, .. }) => {
             if list_move(code, selection, candidates.len()) {
                 return;
             }
         }
         _ => {}
     }
-    match &state.deploy {
-        DeployInput::PickManny { .. } => match code {
-            KeyCode::Esc => state.deploy = DeployInput::Inactive,
+    match &state.active_wizard {
+        ActiveWizard::Deploy(DeployInput::PickManny { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let manny_id = {
-                    let DeployInput::PickManny { ref mannies, selection } = state.deploy else { return };
-                    mannies[selection].0.clone()
+                    let ActiveWizard::Deploy(DeployInput::PickManny { mannies, selection }) = &state.active_wizard else { return };
+                    mannies[*selection].0.clone()
                 };
                 let candidates = state.collect_deploy_candidates();
                 if candidates.is_empty() {
-                    state.deploy = DeployInput::Inactive;
+                    state.close_wizard();
                     state.error = Some("no targets in current sector".into());
                 } else if candidates.len() == 1 {
                     let (object_id, object_name) = candidates.into_iter().next().unwrap();
-                    state.deploy = DeployInput::EnterName { manny_id, object_id, object_name, name_buf: String::new(), error: None };
+                    state.active_wizard = ActiveWizard::Deploy(DeployInput::EnterName { manny_id, object_id, object_name, name_buf: String::new(), error: None });
                 } else {
-                    state.deploy = DeployInput::PickObject { manny_id, candidates, selection: 0 };
+                    state.active_wizard = ActiveWizard::Deploy(DeployInput::PickObject { manny_id, candidates, selection: 0 });
                 }
             }
             _ => {}
         },
-        DeployInput::PickObject { .. } => match code {
-            KeyCode::Esc => state.deploy = DeployInput::Inactive,
+        ActiveWizard::Deploy(DeployInput::PickObject { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, object_id, object_name) = {
-                    let DeployInput::PickObject { ref manny_id, ref candidates, selection } = state.deploy else { return };
-                    let (id, name) = candidates[selection].clone();
+                    let ActiveWizard::Deploy(DeployInput::PickObject { manny_id, candidates, selection }) = &state.active_wizard else { return };
+                    let (id, name) = candidates[*selection].clone();
                     (manny_id.clone(), id, name)
                 };
-                state.deploy = DeployInput::EnterName {
+                state.active_wizard = ActiveWizard::Deploy(DeployInput::EnterName {
                     manny_id, object_id, object_name, name_buf: String::new(), error: None,
-                };
+                });
             }
             _ => {}
         },
-        DeployInput::EnterName { .. } => match code {
-            KeyCode::Esc => state.deploy = DeployInput::Inactive,
+        ActiveWizard::Deploy(DeployInput::EnterName { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Backspace => state.deploy_backspace(),
             KeyCode::Char(c) => state.deploy_type_char(c),
             KeyCode::Enter => {
                 let (manny_id, object_id, name) = {
-                    let DeployInput::EnterName { ref manny_id, ref object_id, ref name_buf, .. } = state.deploy else { return };
+                    let ActiveWizard::Deploy(DeployInput::EnterName { manny_id, object_id, name_buf, .. }) = &state.active_wizard else { return };
                     if name_buf.is_empty() { return }
                     (manny_id.clone(), object_id.clone(), name_buf.clone())
                 };
@@ -268,7 +268,7 @@ pub(super) fn handle_deploy_event(
             }
             _ => {}
         },
-        DeployInput::Inactive => {}
+        _ => {}
     }
 }
 
@@ -279,10 +279,10 @@ pub(super) fn handle_rename_manny_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc => state.rename_manny = RenameMannyInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Tab => {
             let s = state.next_name_suggestion();
-            if let RenameMannyInput::Typing { buf, .. } = &mut state.rename_manny {
+            if let ActiveWizard::RenameManny(RenameMannyInput::Typing { buf, .. }) = &mut state.active_wizard {
                 *buf = s;
             }
         }
@@ -290,7 +290,7 @@ pub(super) fn handle_rename_manny_event(
         KeyCode::Char(c) => state.rename_manny_type_char(c),
         KeyCode::Enter => {
             let (manny_id, name, old_name) = {
-                let RenameMannyInput::Typing { ref manny_id, ref buf, ref manny_name, .. } = state.rename_manny else { return };
+                let ActiveWizard::RenameManny(RenameMannyInput::Typing { manny_id, buf, manny_name, .. }) = &state.active_wizard else { return };
                 if buf.is_empty() { return }
                 (manny_id.clone(), buf.clone(), manny_name.clone())
             };
@@ -308,17 +308,17 @@ pub(super) fn handle_inspect_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if let InspectInput::PickTarget { selection, candidates, .. } = &mut state.inspect {
+    if let ActiveWizard::Inspect(InspectInput::PickTarget { selection, candidates, .. }) = &mut state.active_wizard {
         if list_move(code, selection, candidates.len()) {
             return;
         }
     }
     match code {
-        KeyCode::Esc => state.inspect = InspectInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Enter => {
             let (manny_id, object_id, object_name) = {
-                let InspectInput::PickTarget { ref manny_id, ref candidates, selection, .. } = state.inspect else { return };
-                (manny_id.clone(), candidates[selection].0.clone(), candidates[selection].1.clone())
+                let ActiveWizard::Inspect(InspectInput::PickTarget { manny_id, candidates, selection, .. }) = &state.active_wizard else { return };
+                (manny_id.clone(), candidates[*selection].0.clone(), candidates[*selection].1.clone())
             };
             fetch_inspect(manny_id, object_id, client.clone(), tx.clone());
             state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
@@ -333,17 +333,17 @@ pub(super) fn handle_recover_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if let RecoverInput::PickContainer { selection, candidates, .. } = &mut state.recover {
+    if let ActiveWizard::Recover(RecoverInput::PickContainer { selection, candidates, .. }) = &mut state.active_wizard {
         if list_move(code, selection, candidates.len()) {
             return;
         }
     }
     match code {
-        KeyCode::Esc => state.recover = RecoverInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Enter => {
             let (manny_id, object_id, container_name) = {
-                let RecoverInput::PickContainer { ref manny_id, ref candidates, selection, .. } = state.recover else { return };
-                (manny_id.clone(), candidates[selection].0.clone(), candidates[selection].1.clone())
+                let ActiveWizard::Recover(RecoverInput::PickContainer { manny_id, candidates, selection, .. }) = &state.active_wizard else { return };
+                (manny_id.clone(), candidates[*selection].0.clone(), candidates[*selection].1.clone())
             };
             fetch_recover(manny_id, object_id, client.clone(), tx.clone());
             state.log_event(LogEvent::recover(&container_name, state.active_probe_id));
@@ -358,43 +358,43 @@ pub(super) fn handle_detach_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &mut state.detach {
-        DetachInput::PickContainer { selection, containers, .. } => {
+    match &mut state.active_wizard {
+        ActiveWizard::Detach(DetachInput::PickContainer { selection, containers, .. }) => {
             if list_move(code, selection, containers.len()) {
                 return;
             }
         }
-        DetachInput::PickMode { selection, .. } => {
+        ActiveWizard::Detach(DetachInput::PickMode { selection, .. }) => {
             if list_move(code, selection, DETACH_MODES.len()) {
                 return;
             }
         }
-        DetachInput::PickAsteroid { selection, asteroids, .. } => {
+        ActiveWizard::Detach(DetachInput::PickAsteroid { selection, asteroids, .. }) => {
             if list_move(code, selection, asteroids.len()) {
                 return;
             }
         }
-        DetachInput::Inactive => {}
+        _ => {}
     }
-    match &state.detach {
-        DetachInput::PickContainer { .. } => match code {
-            KeyCode::Esc => state.detach = DetachInput::Inactive,
+    match &state.active_wizard {
+        ActiveWizard::Detach(DetachInput::PickContainer { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, manny_name, container_id, container_name) = {
-                    let DetachInput::PickContainer { ref manny_id, ref manny_name, ref containers, selection } = state.detach else { return };
-                    let (id, name) = containers[selection].clone();
+                    let ActiveWizard::Detach(DetachInput::PickContainer { manny_id, manny_name, containers, selection }) = &state.active_wizard else { return };
+                    let (id, name) = containers[*selection].clone();
                     (manny_id.clone(), manny_name.clone(), id, name)
                 };
-                state.detach = DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection: 0, error: None };
+                state.active_wizard = ActiveWizard::Detach(DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection: 0, error: None });
             }
             _ => {}
         },
-        DetachInput::PickMode { .. } => match code {
-            KeyCode::Esc => state.detach = DetachInput::Inactive,
+        ActiveWizard::Detach(DetachInput::PickMode { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, manny_name, container_id, container_name, sel) = {
-                    let DetachInput::PickMode { ref manny_id, ref manny_name, ref container_id, ref container_name, selection, .. } = state.detach else { return };
-                    (manny_id.clone(), manny_name.clone(), container_id.clone(), container_name.clone(), selection)
+                    let ActiveWizard::Detach(DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection, .. }) = &state.active_wizard else { return };
+                    (manny_id.clone(), manny_name.clone(), container_id.clone(), container_name.clone(), *selection)
                 };
                 let mode = DETACH_MODES[sel].0;
                 if mode == "hidden_on_asteroid" {
@@ -402,7 +402,7 @@ pub(super) fn handle_detach_event(
                     if asteroids.is_empty() {
                         state.set_detach_error("no asteroids in current sector — scan first".into());
                     } else {
-                        state.detach = DetachInput::PickAsteroid { manny_id, manny_name, container_id, container_name, asteroids, selection: 0, error: None };
+                        state.active_wizard = ActiveWizard::Detach(DetachInput::PickAsteroid { manny_id, manny_name, container_id, container_name, asteroids, selection: 0, error: None });
                     }
                 } else {
                     fetch_detach(manny_id, container_id, "drifting".into(), None, client.clone(), tx.clone());
@@ -411,18 +411,18 @@ pub(super) fn handle_detach_event(
             }
             _ => {}
         },
-        DetachInput::PickAsteroid { .. } => match code {
-            KeyCode::Esc => state.detach = DetachInput::Inactive,
+        ActiveWizard::Detach(DetachInput::PickAsteroid { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, container_id, object_id, container_name) = {
-                    let DetachInput::PickAsteroid { ref manny_id, ref container_id, ref container_name, ref asteroids, selection, .. } = state.detach else { return };
-                    (manny_id.clone(), container_id.clone(), asteroids[selection].0.clone(), container_name.clone())
+                    let ActiveWizard::Detach(DetachInput::PickAsteroid { manny_id, container_id, container_name, asteroids, selection, .. }) = &state.active_wizard else { return };
+                    (manny_id.clone(), container_id.clone(), asteroids[*selection].0.clone(), container_name.clone())
                 };
                 fetch_detach(manny_id, container_id, "hidden_on_asteroid".into(), Some(object_id), client.clone(), tx.clone());
                 state.log_event(LogEvent::detach_container(&container_name, true, state.active_probe_id));
             }
             _ => {}
         },
-        DetachInput::Inactive => {}
+        _ => {}
     }
 }

--- a/src/input/repair.rs
+++ b/src/input/repair.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_repair;
 use crate::app::{
-    ApiMessage, AppState, LogEvent, RepairInput,
+    ActiveWizard, ApiMessage, AppState, LogEvent, RepairInput,
 };
 pub(super) fn handle_repair_event(
     code: KeyCode,
@@ -13,13 +13,13 @@ pub(super) fn handle_repair_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match code {
-        KeyCode::Esc => state.repair = RepairInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Backspace => state.repair_backspace(),
         KeyCode::Char('m') | KeyCode::Char('M') => state.repair_fill_max(),
         KeyCode::Char(c) => state.repair_type_char(c),
         KeyCode::Enter => {
             let (manny_id, pct) = {
-                let RepairInput::Typing { ref manny_id, ref buf, .. } = state.repair else { return };
+                let ActiveWizard::Repair(RepairInput::Typing { manny_id, buf, .. }) = &state.active_wizard else { return };
                 let Ok(pct) = buf.parse::<f64>() else { return };
                 if pct <= 0.0 { return }
                 (manny_id.clone(), pct)

--- a/src/input/scanner.rs
+++ b/src/input/scanner.rs
@@ -9,7 +9,7 @@ use crate::api::tasks::{
     fetch_turn_on_relay,
 };
 use crate::app::{
-    ApiMessage, AppState, DeployInput, LogEvent, MineInput, ObjectAction, ObjectActionInput, SalvageInput,
+    ActiveWizard, ApiMessage, AppState, DeployInput, LogEvent, MineInput, ObjectAction, ObjectActionInput, SalvageInput,
     ScutNetworkInput, ScutRelayInput, WaypointsInput,
 };
 use super::geometry::list_nav;
@@ -24,11 +24,13 @@ pub(super) fn dispatch_object_action(
 ) {
     let (object_id, object_name) = object;
     let (manny_id, manny_name) = manny;
-    state.object_action = ObjectActionInput::Inactive;
+    // Close the object-action picker; each arm either fires immediately or
+    // opens the next wizard (which replaces it in `active_wizard`).
+    state.close_wizard();
     state.scanner_obj_selection = None;
     match action {
         ObjectAction::Mine => {
-            state.mine = MineInput::Configure {
+            state.active_wizard = ActiveWizard::Mine(MineInput::Configure {
                 manny_id,
                 manny_name,
                 object_id,
@@ -38,44 +40,44 @@ pub(super) fn dispatch_object_action(
                 amount_mode: false,
                 target_container: None,
                 error: None,
-            };
+            });
         }
         ObjectAction::Inspect => {
             fetch_inspect(manny_id, object_id, client.clone(), tx.clone());
             state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
         }
         ObjectAction::Salvage => {
-            state.salvage = SalvageInput::Confirm {
+            state.active_wizard = ActiveWizard::Salvage(SalvageInput::Confirm {
                 manny_id,
                 manny_name,
                 object_id,
                 object_name,
                 error: None,
-            };
+            });
         }
         ObjectAction::Recover => {
             fetch_recover(manny_id, object_id, client.clone(), tx.clone());
             state.log_event(LogEvent::recover(&object_name, state.active_probe_id));
         }
         ObjectAction::DeployWaypoint => {
-            state.deploy = DeployInput::EnterName {
+            state.active_wizard = ActiveWizard::Deploy(DeployInput::EnterName {
                 manny_id,
                 object_id,
                 object_name,
                 name_buf: String::new(),
                 error: None,
-            };
+            });
         }
         ObjectAction::TurnOnRelay => match object_id.parse::<i64>() {
             Ok(relay_id) => {
-                state.scut_relay = ScutRelayInput::EnterNetworkName {
+                state.active_wizard = ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName {
                     manny_id,
                     manny_name,
                     relay_id,
                     relay_name: object_name,
                     buf: String::new(),
                     error: None,
-                };
+                });
             }
             Err(_) => {
                 state.error = Some("relay has an unexpected id format".into());
@@ -90,28 +92,28 @@ pub(super) fn handle_scut_relay_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let ScutRelayInput::EnterNetworkName { .. } = state.scut_relay else { return };
+    let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { .. }) = &state.active_wizard else { return };
     match code {
-        KeyCode::Esc => state.scut_relay = ScutRelayInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Backspace => {
-            if let ScutRelayInput::EnterNetworkName { ref mut buf, .. } = state.scut_relay {
+            if let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { buf, .. }) = &mut state.active_wizard {
                 buf.pop();
             }
         }
         KeyCode::Char(c) => {
-            if let ScutRelayInput::EnterNetworkName { ref mut buf, .. } = state.scut_relay {
+            if let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { buf, .. }) = &mut state.active_wizard {
                 buf.push(c);
             }
         }
         KeyCode::Enter => {
             let (manny_id, relay_id, name) = {
-                let ScutRelayInput::EnterNetworkName { ref manny_id, relay_id, ref buf, .. } =
-                    state.scut_relay
+                let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { manny_id, relay_id, buf, .. }) =
+                    &state.active_wizard
                 else {
                     return;
                 };
                 let name = if buf.trim().is_empty() { None } else { Some(buf.trim().to_string()) };
-                (manny_id.clone(), relay_id, name)
+                (manny_id.clone(), *relay_id, name)
             };
             let network = name.clone();
             fetch_turn_on_relay(manny_id, relay_id, name, client.clone(), tx.clone());
@@ -127,56 +129,60 @@ pub(super) fn handle_scut_network_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match state.scut_network {
-        ScutNetworkInput::Picking { ref networks, selection } => {
+    match &state.active_wizard {
+        ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks, selection }) => {
             let count = networks.len();
+            let selection = *selection;
             match code {
-                KeyCode::Esc => state.scut_network = ScutNetworkInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ScutNetworkInput::Picking { ref mut selection, .. } = state.scut_network {
+                        if let ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { selection, .. }) = &mut state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let id = networks[selection].0;
-                    state.scut_network = ScutNetworkInput::Viewing { error: None };
+                    let id = {
+                        let ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks, .. }) = &state.active_wizard else { return };
+                        networks[selection].0
+                    };
+                    state.active_wizard = ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { error: None });
                     state.scut_network_view = None;
                     fetch_scut_network(id, client.clone(), tx.clone());
                 }
                 _ => {}
             }
         }
-        ScutNetworkInput::Viewing { .. } => {
-            if code == KeyCode::Esc {
-                state.scut_network = ScutNetworkInput::Inactive;
+        ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })
+            if code == KeyCode::Esc => {
+                state.close_wizard();
                 state.scut_network_view = None;
             }
-        }
-        ScutNetworkInput::Inactive => {}
+        _ => {}
     }
 }
 
 pub(super) fn handle_waypoints_event(code: KeyCode, state: &mut AppState) {
-    let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
+    let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, selection }) = &state.active_wizard else { return };
     let count = entries.len();
+    let selection = *selection;
     match code {
-        KeyCode::Esc | KeyCode::Char('w') => state.waypoints = WaypointsInput::Inactive,
+        KeyCode::Esc | KeyCode::Char('w') => state.close_wizard(),
         KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
             if let Some(new_sel) = list_nav(code, selection, count) {
-                if let WaypointsInput::Browsing { ref mut selection, .. } = state.waypoints {
+                if let ActiveWizard::Waypoints(WaypointsInput::Browsing { selection, .. }) = &mut state.active_wizard {
                     *selection = new_sel;
                 }
             }
         }
         KeyCode::Enter => {
             let (x, y, z) = {
-                let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
+                let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, .. }) = &state.active_wizard else { return };
                 let e = &entries[selection];
                 (e.x, e.y, e.z)
             };
-            state.waypoints = WaypointsInput::Inactive;
+            state.close_wizard();
             state.travel_go_sector(x, y, z);
         }
         _ => {}
@@ -189,28 +195,28 @@ pub(super) fn handle_object_action_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.object_action {
-        ObjectActionInput::PickAction { selection, actions, .. } => {
+    match &state.active_wizard {
+        ActiveWizard::ObjectAction(ObjectActionInput::PickAction { selection, actions, .. }) => {
             let sel = *selection;
             let count = actions.len();
             match code {
-                KeyCode::Esc => state.object_action = ObjectActionInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ObjectActionInput::PickAction { ref mut selection, .. } = state.object_action {
+                        if let ActiveWizard::ObjectAction(ObjectActionInput::PickAction { selection, .. }) = &mut state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (object_id, object_name, action) = {
-                        let ObjectActionInput::PickAction { ref object_id, ref object_name, ref actions, selection } = state.object_action else { return };
-                        (object_id.clone(), object_name.clone(), actions[selection])
+                        let ActiveWizard::ObjectAction(ObjectActionInput::PickAction { object_id, object_name, actions, selection }) = &state.active_wizard else { return };
+                        (object_id.clone(), object_name.clone(), actions[*selection])
                     };
                     let mannies = state.collect_idle_onboard_mannies();
                     match mannies.len() {
                         0 => {
-                            state.object_action = ObjectActionInput::Inactive;
+                            state.close_wizard();
                             state.error = Some("no idle Manny on board".into());
                         }
                         1 => {
@@ -218,41 +224,41 @@ pub(super) fn handle_object_action_event(
                             dispatch_object_action(state, client, tx, action, (object_id, object_name), manny);
                         }
                         _ => {
-                            state.object_action = ObjectActionInput::PickManny {
+                            state.active_wizard = ActiveWizard::ObjectAction(ObjectActionInput::PickManny {
                                 object_id,
                                 object_name,
                                 action,
                                 mannies,
                                 selection: 0,
-                            };
+                            });
                         }
                     }
                 }
                 _ => {}
             }
         }
-        ObjectActionInput::PickManny { selection, mannies, .. } => {
+        ActiveWizard::ObjectAction(ObjectActionInput::PickManny { selection, mannies, .. }) => {
             let sel = *selection;
             let count = mannies.len();
             match code {
-                KeyCode::Esc => state.object_action = ObjectActionInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ObjectActionInput::PickManny { ref mut selection, .. } = state.object_action {
+                        if let ActiveWizard::ObjectAction(ObjectActionInput::PickManny { selection, .. }) = &mut state.active_wizard {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (object, action, manny) = {
-                        let ObjectActionInput::PickManny { ref object_id, ref object_name, action, ref mannies, selection } = state.object_action else { return };
-                        ((object_id.clone(), object_name.clone()), action, mannies[selection].clone())
+                        let ActiveWizard::ObjectAction(ObjectActionInput::PickManny { object_id, object_name, action, mannies, selection }) = &state.active_wizard else { return };
+                        ((object_id.clone(), object_name.clone()), *action, mannies[*selection].clone())
                     };
                     dispatch_object_action(state, client, tx, action, object, manny);
                 }
                 _ => {}
             }
         }
-        ObjectActionInput::Inactive => {}
+        _ => {}
     }
 }

--- a/src/input/storage_move.rs
+++ b/src/input/storage_move.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_storage_move, StorageMoveArgs};
-use crate::app::{ApiMessage, AppState, LogEvent, StorageMoveInput, MOVE_RESOURCE_TYPES};
+use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, StorageMoveInput, MOVE_RESOURCE_TYPES};
 
 use super::geometry::list_nav;
 
@@ -20,48 +20,48 @@ pub(super) fn handle_storage_move_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.storage_move {
-        StorageMoveInput::PickManny { selection, mannies } => {
+    match &state.active_wizard {
+        ActiveWizard::StorageMove(StorageMoveInput::PickManny { selection, mannies }) => {
             let (sel, count) = (*selection, mannies.len());
             match code {
-                KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(ns) = list_nav(code, sel, count) {
-                        if let StorageMoveInput::PickManny { selection, .. } = &mut state.storage_move {
+                        if let ActiveWizard::StorageMove(StorageMoveInput::PickManny { selection, .. }) = &mut state.active_wizard {
                             *selection = ns;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (id, name) = {
-                        let StorageMoveInput::PickManny { mannies, selection } = &state.storage_move
+                        let ActiveWizard::StorageMove(StorageMoveInput::PickManny { mannies, selection }) = &state.active_wizard
                         else { return };
                         mannies[*selection].clone()
                     };
-                    state.storage_move = StorageMoveInput::PickKind {
+                    state.active_wizard = ActiveWizard::StorageMove(StorageMoveInput::PickKind {
                         actor_manny_id: id,
                         actor_manny_name: name,
                         selection: 0,
-                    };
+                    });
                 }
                 _ => {}
             }
         }
-        StorageMoveInput::PickKind { selection, .. } => {
+        ActiveWizard::StorageMove(StorageMoveInput::PickKind { selection, .. }) => {
             let sel = *selection;
             match code {
-                KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(ns) = list_nav(code, sel, 2) {
-                        if let StorageMoveInput::PickKind { selection, .. } = &mut state.storage_move {
+                        if let ActiveWizard::StorageMove(StorageMoveInput::PickKind { selection, .. }) = &mut state.active_wizard {
                             *selection = ns;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (id, name) = {
-                        let StorageMoveInput::PickKind { actor_manny_id, actor_manny_name, .. } =
-                            &state.storage_move else { return };
+                        let ActiveWizard::StorageMove(StorageMoveInput::PickKind { actor_manny_id, actor_manny_name, .. }) =
+                            &state.active_wizard else { return };
                         (actor_manny_id.clone(), actor_manny_name.clone())
                     };
                     if sel == 0 {
@@ -73,20 +73,20 @@ pub(super) fn handle_storage_move_event(
                 _ => {}
             }
         }
-        StorageMoveInput::ConfigureResource { .. } => handle_resource(code, state, client, tx),
-        StorageMoveInput::ConfigureItem { .. } => handle_item(code, state, client, tx),
-        StorageMoveInput::Inactive => {}
+        ActiveWizard::StorageMove(StorageMoveInput::ConfigureResource { .. }) => handle_resource(code, state, client, tx),
+        ActiveWizard::StorageMove(StorageMoveInput::ConfigureItem { .. }) => handle_item(code, state, client, tx),
+        _ => {}
     }
 }
 
 fn enter_resource(state: &mut AppState, actor_manny_id: String, actor_manny_name: String) {
     let containers = state.collect_move_containers();
     if containers.len() < 2 {
-        state.storage_move = StorageMoveInput::Inactive;
+        state.close_wizard();
         state.error = Some("need at least two containers to move resources".into());
         return;
     }
-    state.storage_move = StorageMoveInput::ConfigureResource {
+    state.active_wizard = ActiveWizard::StorageMove(StorageMoveInput::ConfigureResource {
         actor_manny_id,
         actor_manny_name,
         containers,
@@ -96,13 +96,13 @@ fn enter_resource(state: &mut AppState, actor_manny_id: String, actor_manny_name
         amount_buf: "0.10".into(),
         field: 0,
         error: None,
-    };
+    });
 }
 
 fn enter_item(state: &mut AppState, actor_manny_id: String, actor_manny_name: String) {
     let containers = state.collect_move_containers();
     if containers.is_empty() {
-        state.storage_move = StorageMoveInput::Inactive;
+        state.close_wizard();
         state.error = Some("no containers available".into());
         return;
     }
@@ -112,11 +112,11 @@ fn enter_item(state: &mut AppState, actor_manny_id: String, actor_manny_name: St
         .map(|(id, label)| (id, label, false))
         .collect();
     if items.is_empty() {
-        state.storage_move = StorageMoveInput::Inactive;
+        state.close_wizard();
         state.error = Some("no movable items in inventory".into());
         return;
     }
-    state.storage_move = StorageMoveInput::ConfigureItem {
+    state.active_wizard = ActiveWizard::StorageMove(StorageMoveInput::ConfigureItem {
         actor_manny_id,
         actor_manny_name,
         containers,
@@ -125,7 +125,7 @@ fn enter_item(state: &mut AppState, actor_manny_id: String, actor_manny_name: St
         item_cursor: 0,
         field: 0,
         error: None,
-    };
+    });
 }
 
 fn handle_resource(
@@ -134,15 +134,15 @@ fn handle_resource(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let StorageMoveInput::ConfigureResource {
+    let ActiveWizard::StorageMove(StorageMoveInput::ConfigureResource {
         actor_manny_id, containers, resource_idx, from_sel, to_sel, amount_buf, field, ..
-    } = &mut state.storage_move
+    }) = &mut state.active_wizard
     else {
         return;
     };
     let clen = containers.len();
     match code {
-        KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Up | KeyCode::BackTab => *field = wrap_prev(*field as usize, 4) as u8,
         KeyCode::Down | KeyCode::Tab => *field = wrap_next(*field as usize, 4) as u8,
         KeyCode::Left | KeyCode::Char('h') => match field {
@@ -208,16 +208,16 @@ fn handle_item(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let StorageMoveInput::ConfigureItem {
+    let ActiveWizard::StorageMove(StorageMoveInput::ConfigureItem {
         actor_manny_id, containers, items, to_sel, item_cursor, field, ..
-    } = &mut state.storage_move
+    }) = &mut state.active_wizard
     else {
         return;
     };
     let clen = containers.len();
     let ilen = items.len();
     match code {
-        KeyCode::Esc => state.storage_move = StorageMoveInput::Inactive,
+        KeyCode::Esc => state.close_wizard(),
         KeyCode::Tab => *field = if *field == 0 { 1 } else { 0 },
         KeyCode::Up | KeyCode::Char('k') if *field == 0 => *item_cursor = wrap_prev(*item_cursor, ilen),
         KeyCode::Down | KeyCode::Char('j') if *field == 0 => *item_cursor = wrap_next(*item_cursor, ilen),

--- a/src/input/travel.rs
+++ b/src/input/travel.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_move;
 use crate::app::{
-    ApiMessage, AppState, LogEvent, TravelInput,
+    ActiveWizard, ApiMessage, AppState, LogEvent, TravelInput,
 };
 pub(super) fn handle_travel_event(
     code: KeyCode,
@@ -12,18 +12,18 @@ pub(super) fn handle_travel_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    match &state.travel {
-        TravelInput::Typing(_) => match code {
-            KeyCode::Esc => state.travel = TravelInput::Inactive,
+    match &state.active_wizard {
+        ActiveWizard::Travel(TravelInput::Typing(_)) => match code {
+            KeyCode::Esc => state.close_wizard(),
             KeyCode::Backspace => state.travel_backspace(),
             KeyCode::Enter => state.travel_submit(),
             KeyCode::Char(c) => state.travel_type_char(c),
             _ => {}
         },
-        TravelInput::Confirming { x, y, z, error, .. } => {
+        ActiveWizard::Travel(TravelInput::Confirming { x, y, z, error, .. }) => {
             let (x, y, z, has_error) = (*x, *y, *z, error.is_some());
             match code {
-                KeyCode::Esc => state.travel = TravelInput::Inactive,
+                KeyCode::Esc => state.close_wizard(),
                 KeyCode::Enter if !has_error => {
                     fetch_move(x, y, z, client.clone(), tx.clone());
                     state.log_event(LogEvent::travel(x, y, z, state.active_probe_id));
@@ -31,6 +31,6 @@ pub(super) fn handle_travel_event(
                 _ => {}
             }
         }
-        TravelInput::Inactive => {}
+        _ => {}
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,16 +15,12 @@ use neumann_cockpit::api::tasks::{
     fetch_missions, fetch_sent_messages,
 };
 use neumann_cockpit::app::{
-    ApiMessage, AppState, AssembleProbeInput, ColorMode, ContainerRulesInput, FabricationInput,
-    ImproveInput,
-    DeployInput,
-    DetachInput, DropCargoInput, DropStorageContainerInput, InspectInput, JettisonInput,
-    MessagesInput, MindSnapshotInput, MineInput, MissionsInput, RecallInput, RecoverInput,
-    RefuelInput,
+    ActiveWizard,
+    ApiMessage, AppState, ColorMode,
+    MessagesInput, MissionsInput,
     Refetch,
     RemoteMineInput,
-    RenameContainerInput, RenameMannyInput, RenameProbeInput, RepairInput, SalvageInput,
-    ScutNetworkInput, ScutRelayInput, StorageMoveInput, TransferDeuteriumInput,
+    ScutNetworkInput,
 };
 use neumann_cockpit::input::handle_event;
 use neumann_cockpit::preflight;
@@ -190,7 +186,7 @@ async fn run(
                     }
                     ApiMessage::ProbeRenamed(list, name) => {
                         state.update_fleet(list);
-                        state.rename_probe = RenameProbeInput::Inactive;
+                        state.close_wizard();
                         // Refresh so the Probe pane identity picks up the new name.
                         state.finish_action(format!("probe renamed to {name}"), Refetch::All);
                     }
@@ -212,10 +208,10 @@ async fn run(
                         }
                     }
                     ApiMessage::ScanError(e) => {
-                        if matches!(state.remote_mine, RemoteMineInput::Loading { .. }) {
+                        if matches!(state.active_wizard, ActiveWizard::RemoteMine(RemoteMineInput::Loading { .. })) {
                             // The remote-mine sector fetch failed — don't leave the
                             // wizard hung on "fetching…". Abort and surface why.
-                            state.remote_mine = RemoteMineInput::Inactive;
+                            state.close_wizard();
                             state.set_error(e);
                         } else if state.scan_batch.is_some() {
                             state.batch_tick();
@@ -229,13 +225,12 @@ async fn run(
                     }
                     ApiMessage::MoveError(e) => state.set_travel_error(e),
                     ApiMessage::RepairStarted => {
-                        state.repair = RepairInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("repair order sent", Refetch::Mannies);
                     }
                     ApiMessage::RepairError(e) => state.set_repair_error(e),
                     ApiMessage::MineStarted => {
-                        state.mine = MineInput::Inactive;
-                        state.remote_mine = RemoteMineInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("mining order sent", Refetch::Mannies);
                     }
                     ApiMessage::MineError(e) => {
@@ -244,63 +239,63 @@ async fn run(
                     }
                     ApiMessage::JettisonDone(inv) => {
                         state.update_inventory(inv);
-                        state.jettison = JettisonInput::Inactive;
+                        state.close_wizard();
                         // Jettison always adds an object to the sector (ejected manny,
                         // drifting item, or deployed SCUT relay) — refresh everything.
                         state.finish_action("jettisoned", Refetch::All);
                     }
                     ApiMessage::JettisonError(e) => state.set_jettison_error(e),
                     ApiMessage::CraftStarted => {
-                        state.fabrication = FabricationInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("craft order sent", Refetch::Mannies);
                     }
                     ApiMessage::CraftError(e) => state.set_fabrication_error(e),
                     ApiMessage::SalvageStarted => {
-                        state.salvage = SalvageInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("salvage order sent", Refetch::Mannies);
                     }
                     ApiMessage::SalvageError(e) => state.set_salvage_error(e),
                     ApiMessage::RecallStarted => {
-                        state.recall = RecallInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("recall order sent", Refetch::Mannies);
                     }
                     ApiMessage::RecallError(e) => state.set_recall_error(e),
                     ApiMessage::DeuteriumRefuelStarted => {
-                        state.refuel = RefuelInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("refuel order sent", Refetch::All);
                     }
                     ApiMessage::DeuteriumRefuelError(e) => state.set_refuel_error(e),
                     ApiMessage::DeuteriumTransferStarted => {
-                        state.transfer_deuterium = TransferDeuteriumInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("deuterium transfer order sent", Refetch::All);
                     }
                     ApiMessage::DeuteriumTransferError(e) => state.set_transfer_deuterium_error(e),
                     ApiMessage::MindSnapshotReassigned(probe) => {
-                        state.mind_snapshot = MindSnapshotInput::Inactive;
+                        state.close_wizard();
                         state.update_probe(probe);
                         state.finish_action("mind snapshot reassigned", Refetch::All);
                     }
                     ApiMessage::MindSnapshotReassignError(e) => state.set_mind_snapshot_error(e),
                     ApiMessage::MissionsFetched(missions) => state.missions = missions,
                     ApiMessage::MissionAbandoned(_) => {
-                        state.missions_input = MissionsInput::Browsing { selection: 0 };
+                        state.active_wizard = ActiveWizard::Missions(MissionsInput::Browsing { selection: 0 });
                         state.finish_action("mission abandoned", Refetch::Missions);
                     }
                     ApiMessage::MissionAbandonError(e) => state.set_mission_abandon_error(e),
                     ApiMessage::ScutRelayTurnedOn => {
-                        state.scut_relay = ScutRelayInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("relay turn-on order sent", Refetch::All);
                     }
                     ApiMessage::ScutRelayTurnOnError(e) => state.set_scut_relay_error(e),
                     ApiMessage::ScutNetworkFetched(network) => {
-                        if matches!(state.scut_network, ScutNetworkInput::Viewing { .. }) {
+                        if matches!(state.active_wizard, ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })) {
                             state.scut_network_view = Some(network);
                         }
                     }
                     ApiMessage::MessagesFetched(m) => state.messages = m,
                     ApiMessage::SentMessagesFetched(m) => state.sent_messages = m,
                     ApiMessage::MessageSent(_) => {
-                        state.messages_input = MessagesInput::Browsing { sent_tab: false, selection: 0 };
+                        state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 });
                         state.finish_action("message sent", Refetch::Messages);
                     }
                     ApiMessage::MessageSendError(e) => state.set_message_send_error(e),
@@ -310,17 +305,17 @@ async fn run(
                         }
                     }
                     ApiMessage::ScutNetworkError(e) => {
-                        if matches!(state.scut_network, ScutNetworkInput::Viewing { .. }) {
-                            state.scut_network = ScutNetworkInput::Viewing { error: Some(e) };
+                        if matches!(state.active_wizard, ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })) {
+                            state.active_wizard = ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { error: Some(e) });
                         }
                     }
                     ApiMessage::DeployStarted => {
-                        state.deploy = DeployInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("waypoint deploy order sent", Refetch::All);
                     }
                     ApiMessage::DeployError(e) => state.set_deploy_error(e),
                     ApiMessage::AtomicPrinterCraftStarted => {
-                        state.fabrication = FabricationInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("atomic printer craft started", Refetch::All);
                     }
                     ApiMessage::AtomicPrinterCraftError(e) => state.set_fabrication_error(e),
@@ -329,22 +324,22 @@ async fn run(
                         state.probe_improvements = improvements;
                     }
                     ApiMessage::ImproveProbeStarted => {
-                        state.improve = ImproveInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("probe improvement started", Refetch::All);
                     }
                     ApiMessage::ImproveProbeError(e) => state.set_improve_error(e),
                     ApiMessage::InspectStarted => {
-                        state.inspect = InspectInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("inspect order sent", Refetch::Mannies);
                     }
                     ApiMessage::InspectError(e) => state.set_inspect_error(e),
                     ApiMessage::RecoverStarted => {
-                        state.recover = RecoverInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("recover order sent", Refetch::All);
                     }
                     ApiMessage::RecoverError(e) => state.set_recover_error(e),
                     ApiMessage::DetachStarted => {
-                        state.detach = DetachInput::Inactive;
+                        state.close_wizard();
                         state.finish_action("detach order sent", Refetch::All);
                     }
                     ApiMessage::DetachError(e) => state.set_detach_error(e),
@@ -372,13 +367,13 @@ async fn run(
                     }
                     ApiMessage::RenameContainerDone(c, inv) => {
                         state.apply_container_update(c, inv);
-                        state.rename_container = RenameContainerInput::Inactive;
+                        state.close_wizard();
                         state.set_toast("container renamed");
                     }
                     ApiMessage::RenameContainerError(e) => state.set_rename_container_error(e),
                     ApiMessage::UpdateContainerRulesDone(c, inv) => {
                         state.apply_container_update(c, inv);
-                        state.container_rules = ContainerRulesInput::Inactive;
+                        state.close_wizard();
                         state.set_toast("routing rules updated");
                     }
                     ApiMessage::UpdateContainerRulesError(e) => state.set_container_rules_error(e),
@@ -389,7 +384,7 @@ async fn run(
                             }
                         }
                         state.update_inventory(inv);
-                        state.storage_move = StorageMoveInput::Inactive;
+                        state.close_wizard();
                         state.set_toast("storage move order sent");
                     }
                     ApiMessage::StorageMoveError(e) => state.set_storage_move_error(e),
@@ -400,7 +395,7 @@ async fn run(
                             }
                         }
                         state.update_inventory(inv);
-                        state.assemble_probe = AssembleProbeInput::Inactive;
+                        state.close_wizard();
                         // The new drone appears in the roster once assembled.
                         state.finish_action("drone assembly started (~3h)", Refetch::All);
                     }
@@ -411,7 +406,7 @@ async fn run(
                                 *m = manny;
                             }
                         }
-                        state.drop_cargo = DropCargoInput::Inactive;
+                        state.close_wizard();
                         // Recoverable objects may reappear in the sector.
                         state.finish_action("cargo dropped", Refetch::All);
                     }
@@ -422,7 +417,7 @@ async fn run(
                                 *m = manny;
                             }
                         }
-                        state.drop_container = DropStorageContainerInput::Inactive;
+                        state.close_wizard();
                         // Container + drop kit leave the inventory.
                         state.finish_action("drop container order sent", Refetch::All);
                     }
@@ -433,7 +428,7 @@ async fn run(
                                 *m = manny;
                             }
                         }
-                        state.rename_manny = RenameMannyInput::Inactive;
+                        state.close_wizard();
                         state.set_toast("manny renamed");
                     }
                     ApiMessage::RenameMannyError(e) => state.set_rename_manny_error(e),

--- a/src/ui/overlays/alerts.rs
+++ b/src/ui/overlays/alerts.rs
@@ -1,6 +1,6 @@
 use crate::ui::theme::{palette, Palette};
 use crate::api::types::{AlertType, ProbeAlert};
-use crate::app::{AlertsInput, AppState};
+use crate::app::{ActiveWizard, AlertsInput, AppState};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -59,9 +59,10 @@ fn alert_row(alert: &ProbeAlert, p: Palette) -> ListItem<'static> {
 
 pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let AlertsInput::Browsing { selection, show_warnings } = state.alerts_input else {
+    let ActiveWizard::Alerts(AlertsInput::Browsing { selection, show_warnings }) = &state.active_wizard else {
         return;
     };
+    let (selection, show_warnings) = (*selection, *show_warnings);
 
     let entries: &[ProbeAlert] = if show_warnings {
         &state.damage_warnings

--- a/src/ui/overlays/assemble.rs
+++ b/src/ui/overlays/assemble.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, AssembleProbeInput};
+use crate::app::{ActiveWizard, AppState, AssembleProbeInput};
 use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -22,8 +22,8 @@ const ASSEMBLY_BILL: &[&str] = &[
 ];
 
 pub(crate) fn render_assemble_probe_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let AssembleProbeInput::PickContainers { manny_name, containers, selected, cursor, error, .. } =
-        &state.assemble_probe
+    let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { manny_name, containers, selected, cursor, error, .. }) =
+        &state.active_wizard
     else {
         return;
     };

--- a/src/ui/overlays/containers.rs
+++ b/src/ui/overlays/containers.rs
@@ -1,5 +1,5 @@
 use crate::ui::theme::palette;
-use crate::app::{AppState, ContainerRulesInput, RenameContainerInput};
+use crate::app::{ActiveWizard, AppState, ContainerRulesInput, RenameContainerInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -12,8 +12,8 @@ use super::{centered_rect, render_footer, FooterKey};
 
 pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let RenameContainerInput::Typing { ref current_label, ref buf, ref error, .. } =
-        state.rename_container
+    let ActiveWizard::RenameContainer(RenameContainerInput::Typing { current_label, buf, error, .. }) =
+        &state.active_wizard
     else {
         return;
     };
@@ -53,19 +53,20 @@ pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, sta
 
 pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ContainerRulesInput::Editing {
-        ref container_label,
-        ref types,
-        ref priority,
-        ref exclusion,
-        ref strict_exclusion,
+    let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
+        container_label,
+        types,
+        priority,
+        exclusion,
+        strict_exclusion,
         selection,
-        ref error,
+        error,
         ..
-    } = state.container_rules
+    }) = &state.active_wizard
     else {
         return;
     };
+    let selection = *selection;
 
     let height = (types.len() as u16 + 8).clamp(10, 24);
     let popup = centered_rect(58, height, area);

--- a/src/ui/overlays/craft.rs
+++ b/src/ui/overlays/craft.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, Fabricator, FabricationInput};
+use crate::app::{ActiveWizard, AppState, Fabricator, FabricationInput};
 use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -12,21 +12,21 @@ use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
 
 /// Render whichever step of the unified fabrication wizard is active.
 pub(crate) fn render_fabrication_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    match state.fabrication {
-        FabricationInput::PickRecipe { selection, ref error, .. } => {
-            render_catalog(frame, area, state, selection, error.as_deref());
+    let ActiveWizard::Fabrication(fabrication) = &state.active_wizard else { return };
+    match fabrication {
+        FabricationInput::PickRecipe { selection, error, .. } => {
+            render_catalog(frame, area, state, *selection, error.as_deref());
         }
-        FabricationInput::PickBuilder { ref recipe_name, ref mannies, selection, ref error, .. } => {
+        FabricationInput::PickBuilder { recipe_name, mannies, selection, error, .. } => {
             let p = palette(state.color_mode);
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let prompt = format!("Build {recipe_name} with:");
             let height = (names.len() as u16 + 6).clamp(8, 20);
             render_pick_list(
                 frame, area, p, " FABRICATION — SELECT BUILDER ", 46, height,
-                Some(&prompt), &names, selection, error.as_deref(), "BUILD",
+                Some(&prompt), &names, *selection, error.as_deref(), "BUILD",
             );
         }
-        FabricationInput::Inactive => {}
     }
 }
 
@@ -212,7 +212,7 @@ fn builder_line(fab: Fabricator, state: &AppState, p: Palette) -> Line<'static> 
         }
         Fabricator::Manny => {
             // A pre-chosen builder (opened from the Mannies pane) wins.
-            if let FabricationInput::PickRecipe { prefilled_manny: Some((_, name)), .. } = &state.fabrication {
+            if let ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: Some((_, name)), .. }) = &state.active_wizard {
                 return Line::from(vec![
                     Span::styled("⚙ builder: ", dim),
                     Span::styled(name.clone(), Style::default().fg(p.text)),

--- a/src/ui/overlays/drop_container.rs
+++ b/src/ui/overlays/drop_container.rs
@@ -1,12 +1,12 @@
 use crate::ui::theme::palette;
-use crate::app::{AppState, DropStorageContainerInput};
+use crate::app::{ActiveWizard, AppState, DropStorageContainerInput};
 use ratatui::{layout::Rect, Frame};
 
 use super::render_pick_list;
 
 pub(crate) fn render_drop_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    match &state.drop_container {
-        DropStorageContainerInput::Inactive => {}
+    let ActiveWizard::DropContainer(drop_container) = &state.active_wizard else { return };
+    match drop_container {
         DropStorageContainerInput::PickContainer { containers, selection, .. } => {
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(18);

--- a/src/ui/overlays/fleet.rs
+++ b/src/ui/overlays/fleet.rs
@@ -6,7 +6,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{AppState, ProbeSwitchInput, RenameProbeInput, TransferDeuteriumInput};
+use crate::app::{ActiveWizard, AppState, ProbeSwitchInput, RenameProbeInput, TransferDeuteriumInput};
 use crate::ui::theme::{palette, probe_status_label};
 
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
@@ -48,7 +48,8 @@ pub(crate) fn render_probe_switch_overlay(frame: &mut Frame, area: Rect, state: 
 /// server-validated, so a mismatch surfaces as an error line in step 2.
 pub(crate) fn render_transfer_deuterium_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.transfer_deuterium {
+    let ActiveWizard::TransferDeuterium(transfer_deuterium) = &state.active_wizard else { return };
+    match transfer_deuterium {
         TransferDeuteriumInput::PickTarget { manny_name, targets, selection, .. } => {
             let labels: Vec<String> =
                 targets.iter().map(|(id, name)| format!("{name}  ·  #{id}")).collect();
@@ -101,13 +102,12 @@ pub(crate) fn render_transfer_deuterium_overlay(frame: &mut Frame, area: Rect, s
                 FooterKey::nav("[Esc]", "cancel"),
             ]);
         }
-        TransferDeuteriumInput::Inactive => {}
     }
 }
 
 /// Text-entry overlay to rename the piloted probe (API v81).
 pub(crate) fn render_rename_probe_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let RenameProbeInput::Typing { current_name, buf, error, .. } = &state.rename_probe else {
+    let ActiveWizard::RenameProbe(RenameProbeInput::Typing { current_name, buf, error, .. }) = &state.active_wizard else {
         return;
     };
     let p = palette(state.color_mode);

--- a/src/ui/overlays/improve.rs
+++ b/src/ui/overlays/improve.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, ImproveInput};
+use crate::app::{ActiveWizard, AppState, ImproveInput};
 use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -12,21 +12,21 @@ use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
 
 /// Render whichever step of the probe-improvement wizard is active.
 pub(crate) fn render_improve_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    match state.improve {
-        ImproveInput::PickImprovement { selection, ref error } => {
-            render_catalog(frame, area, state, selection, error.as_deref());
+    let ActiveWizard::Improve(improve) = &state.active_wizard else { return };
+    match improve {
+        ImproveInput::PickImprovement { selection, error } => {
+            render_catalog(frame, area, state, *selection, error.as_deref());
         }
-        ImproveInput::PickBuilder { ref improvement_name, ref mannies, selection, ref error, .. } => {
+        ImproveInput::PickBuilder { improvement_name, mannies, selection, error, .. } => {
             let p = palette(state.color_mode);
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let prompt = format!("Install {improvement_name} with:");
             let height = (names.len() as u16 + 6).clamp(8, 20);
             render_pick_list(
                 frame, area, p, " IMPROVE PROBE — SELECT BUILDER ", 48, height,
-                Some(&prompt), &names, selection, error.as_deref(), "BUILD",
+                Some(&prompt), &names, *selection, error.as_deref(), "BUILD",
             );
         }
-        ImproveInput::Inactive => {}
     }
 }
 

--- a/src/ui/overlays/jettison.rs
+++ b/src/ui/overlays/jettison.rs
@@ -1,5 +1,5 @@
 use crate::ui::theme::palette;
-use crate::app::{AppState, JettisonInput};
+use crate::app::{ActiveWizard, AppState, JettisonInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
@@ -11,7 +11,8 @@ use ratatui::{
 use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.jettison {
+    let ActiveWizard::Jettison(jettison) = &state.active_wizard else { return };
+    match jettison {
         JettisonInput::ConfirmManny { manny_name, error, .. } => {
             let popup = centered_rect(48, 8, area);
             frame.render_widget(Clear, popup);
@@ -169,7 +170,6 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
             ]);
         }
 
-        JettisonInput::Inactive => {}
     }
 }
 

--- a/src/ui/overlays/messages.rs
+++ b/src/ui/overlays/messages.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use crate::api::types::MessageStatus;
-use crate::app::{AppState, MessagesInput};
+use crate::app::{ActiveWizard, AppState, MessagesInput};
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 fn preview(body: &str) -> String {
@@ -22,7 +22,8 @@ fn preview(body: &str) -> String {
 
 pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.messages_input {
+    let ActiveWizard::Messages(messages_input) = &state.active_wizard else { return };
+    match messages_input {
         MessagesInput::Browsing { sent_tab, selection } => {
             let popup = centered_rect(76, 80, area);
             frame.render_widget(Clear, popup);
@@ -175,6 +176,5 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             ]);
         }
 
-        MessagesInput::Inactive => {}
     }
 }

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, MineInput, RESOURCE_LABELS, RESOURCE_TYPES};
+use crate::app::{ActiveWizard, AppState, MineInput, RESOURCE_LABELS, RESOURCE_TYPES};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
@@ -46,7 +46,8 @@ pub(crate) fn estimate_mine_duration(target_amount: f64, travel_deducted: bool) 
 
 pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.mine {
+    let ActiveWizard::Mine(mine) = &state.active_wizard else { return };
+    match mine {
         MineInput::PickAsteroid { manny_name, candidates, selection, .. } => {
             // Asteroids are usually unnamed, so label each by index + its known
             // resource content (like the Sector pane) instead of a bare name.
@@ -217,7 +218,6 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             render_footer(frame, rows[1], p, &keys);
         }
 
-        MineInput::Inactive => {}
     }
 }
 

--- a/src/ui/overlays/missions.rs
+++ b/src/ui/overlays/missions.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use crate::api::types::{Mission, MissionStatus, MissionStepStatus};
-use crate::app::{AppState, MissionsInput};
+use crate::app::{ActiveWizard, AppState, MissionsInput};
 
 use super::{centered_rect, render_footer, FooterKey};
 
@@ -67,10 +67,10 @@ fn mission_lines(m: &Mission, selected: bool, p: Palette) -> Vec<Line<'static>> 
 
 pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let selection = match state.missions_input {
-        MissionsInput::Browsing { selection } => selection,
-        MissionsInput::ConfirmAbandon { selection, .. } => selection,
-        MissionsInput::Inactive => return,
+    let selection = match &state.active_wizard {
+        ActiveWizard::Missions(MissionsInput::Browsing { selection }) => *selection,
+        ActiveWizard::Missions(MissionsInput::ConfirmAbandon { selection, .. }) => *selection,
+        _ => return,
     };
 
     let popup = centered_rect(78, 80, area);
@@ -108,7 +108,7 @@ pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &App
         FooterKey::nav("[Esc]", "close"),
     ]);
 
-    if let MissionsInput::ConfirmAbandon { ref mission_title, ref error, .. } = state.missions_input {
+    if let ActiveWizard::Missions(MissionsInput::ConfirmAbandon { mission_title, error, .. }) = &state.active_wizard {
         render_abandon_confirm(frame, area, mission_title, error.as_deref(), p);
     }
 }

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -54,13 +54,7 @@ pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
 
 use crate::app::{
-    AlertsInput, AppState, AssembleProbeInput, ContainerRulesInput, FabricationInput, ImproveInput, DeployInput,
-    DetachInput, DropCargoInput, DropStorageContainerInput, GotoVisitedInput, InspectInput,
-    JettisonInput, MessagesInput, MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput,
-    ProbeSwitchInput, RenameProbeInput,
-    RecallInput, RecoverInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput,
-    RepairInput, SalvageInput, ScanMode, ScutNetworkInput, ScutRelayInput, StorageMoveInput,
-    TransferDeuteriumInput, TravelInput, WaypointsInput, RESOURCE_LABELS,
+    ActiveWizard, AppState, GotoVisitedInput, ProbeSwitchInput, ScanMode, RESOURCE_LABELS,
 };
 use crate::api::types::DangerLevel;
 use crate::ui::theme::{palette, Palette};
@@ -83,37 +77,37 @@ type OverlayRender = fn(&mut Frame, Rect, &AppState);
 /// matching the state), so the caller must gate them.
 #[allow(clippy::type_complexity)]
 const WIZARD_OVERLAYS: &[(OverlayGuard, OverlayRender)] = &[
-    (|s| !matches!(s.assemble_probe, AssembleProbeInput::Inactive), render_assemble_probe_overlay),
-    (|s| !matches!(s.rename_probe, RenameProbeInput::Inactive), render_rename_probe_overlay),
-    (|s| !matches!(s.alerts_input, AlertsInput::Inactive), render_alerts_overlay),
-    (|s| !matches!(s.travel, TravelInput::Inactive), render_travel_overlay),
-    (|s| !matches!(s.repair, RepairInput::Inactive), render_repair_overlay),
-    (|s| !matches!(s.mine, MineInput::Inactive), render_mine_overlay),
-    (|s| !matches!(s.remote_mine, RemoteMineInput::Inactive), render_remote_mine_overlay),
-    (|s| !matches!(s.jettison, JettisonInput::Inactive), render_jettison_overlay),
-    (|s| !matches!(s.fabrication, FabricationInput::Inactive), render_fabrication_overlay),
-    (|s| !matches!(s.improve, ImproveInput::Inactive), render_improve_overlay),
-    (|s| !matches!(s.salvage, SalvageInput::Inactive), render_salvage_overlay),
-    (|s| !matches!(s.recall, RecallInput::Inactive), render_recall_overlay),
-    (|s| !matches!(s.refuel, RefuelInput::Inactive), render_refuel_overlay),
-    (|s| !matches!(s.transfer_deuterium, TransferDeuteriumInput::Inactive), render_transfer_deuterium_overlay),
-    (|s| !matches!(s.mind_snapshot, MindSnapshotInput::Inactive), render_mind_snapshot_overlay),
-    (|s| !matches!(s.missions_input, MissionsInput::Inactive), render_missions_overlay),
-    (|s| !matches!(s.messages_input, MessagesInput::Inactive), render_messages_overlay),
-    (|s| !matches!(s.scut_relay, ScutRelayInput::Inactive), render_scut_relay_overlay),
-    (|s| !matches!(s.scut_network, ScutNetworkInput::Inactive), render_scut_network_overlay),
-    (|s| !matches!(s.drop_cargo, DropCargoInput::Inactive), render_drop_cargo_overlay),
-    (|s| !matches!(s.deploy, DeployInput::Inactive), render_deploy_overlay),
-    (|s| !matches!(s.rename_manny, RenameMannyInput::Inactive), render_rename_manny_overlay),
-    (|s| !matches!(s.inspect, InspectInput::Inactive), render_inspect_overlay),
-    (|s| !matches!(s.recover, RecoverInput::Inactive), render_recover_overlay),
-    (|s| !matches!(s.detach, DetachInput::Inactive), render_detach_overlay),
-    (|s| !matches!(s.drop_container, DropStorageContainerInput::Inactive), render_drop_container_overlay),
-    (|s| !matches!(s.object_action, ObjectActionInput::Inactive), render_object_action_overlay),
-    (|s| !matches!(s.waypoints, WaypointsInput::Inactive), render_waypoints_overlay),
-    (|s| !matches!(s.rename_container, RenameContainerInput::Inactive), render_rename_container_overlay),
-    (|s| !matches!(s.container_rules, ContainerRulesInput::Inactive), render_container_rules_overlay),
-    (|s| !matches!(s.storage_move, StorageMoveInput::Inactive), render_storage_move_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::AssembleProbe(_)), render_assemble_probe_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::RenameProbe(_)), render_rename_probe_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Alerts(_)), render_alerts_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Travel(_)), render_travel_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Repair(_)), render_repair_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Mine(_)), render_mine_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::RemoteMine(_)), render_remote_mine_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Jettison(_)), render_jettison_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Fabrication(_)), render_fabrication_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Improve(_)), render_improve_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Salvage(_)), render_salvage_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Recall(_)), render_recall_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Refuel(_)), render_refuel_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::TransferDeuterium(_)), render_transfer_deuterium_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::MindSnapshot(_)), render_mind_snapshot_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Missions(_)), render_missions_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Messages(_)), render_messages_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::ScutRelay(_)), render_scut_relay_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::ScutNetwork(_)), render_scut_network_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::DropCargo(_)), render_drop_cargo_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Deploy(_)), render_deploy_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::RenameManny(_)), render_rename_manny_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Inspect(_)), render_inspect_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Recover(_)), render_recover_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Detach(_)), render_detach_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::DropContainer(_)), render_drop_container_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::ObjectAction(_)), render_object_action_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::Waypoints(_)), render_waypoints_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::RenameContainer(_)), render_rename_container_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::ContainerRules(_)), render_container_rules_overlay),
+    (|s| matches!(s.active_wizard, ActiveWizard::StorageMove(_)), render_storage_move_overlay),
 ];
 
 /// Render whichever wizard overlays are active, on top of the cockpit grid.
@@ -332,7 +326,7 @@ pub(crate) fn render_pick_list(
 #[cfg(test)]
 mod tests {
     use super::{object_pick_label, render_active_overlays, DangerLevel};
-    use crate::app::{AppState, TravelInput};
+    use crate::app::{ActiveWizard, AppState, TravelInput};
     use ratatui::{backend::TestBackend, Terminal};
 
     #[test]
@@ -381,7 +375,7 @@ mod tests {
     #[test]
     fn active_wizard_frame_renders() {
         let mut state = AppState::default();
-        state.travel = TravelInput::Typing(String::new());
+        state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
         assert!(rendered_text(&state).contains("TRAVEL"), "active travel wizard renders its frame");
     }
 
@@ -397,7 +391,7 @@ mod tests {
                 "ingredients":[],"durationSeconds":300,
                 "output":{"type":"steel_plate","name":"Steel plate","containerSpace":0.01,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
         ];
-        state.fabrication = FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None };
+        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None });
         let text = rendered_text(&state);
         assert!(text.contains("FABRICATION"), "unified title renders");
         assert!(text.contains("ATOMIC PRINTER"), "atomic section header renders");

--- a/src/ui/overlays/object_actions.rs
+++ b/src/ui/overlays/object_actions.rs
@@ -1,5 +1,5 @@
 use crate::ui::theme::palette;
-use crate::app::{AppState, ObjectActionInput};
+use crate::app::{ActiveWizard, AppState, ObjectActionInput};
 use ratatui::{
     layout::Rect,
     Frame,
@@ -7,7 +7,8 @@ use ratatui::{
 
 use super::render_pick_list;
 pub(crate) fn render_object_action_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    match &state.object_action {
+    let ActiveWizard::ObjectAction(object_action) = &state.active_wizard else { return };
+    match object_action {
         ObjectActionInput::PickAction { object_name, actions, selection, .. } => {
             let labels: Vec<&str> = actions.iter().map(|a| a.label()).collect();
             let height = (actions.len() as u16 + 6).min(14);
@@ -21,7 +22,6 @@ pub(crate) fn render_object_action_overlay(frame: &mut Frame, area: Rect, state:
             render_pick_list(frame, area, palette(state.color_mode), &format!(" {object_name} "), 46, height,
                 Some(&prompt), &names, *selection, None, "confirm");
         }
-        ObjectActionInput::Inactive => {}
     }
 }
 

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -1,5 +1,5 @@
 use crate::ui::theme::palette;
-use crate::app::{AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, MindSnapshotInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput, ScutRelayInput};
+use crate::app::{ActiveWizard, AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, MindSnapshotInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput, ScutRelayInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -11,7 +11,8 @@ use ratatui::{
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.salvage {
+    let ActiveWizard::Salvage(salvage) = &state.active_wizard else { return };
+    match salvage {
         SalvageInput::PickTarget { manny_name, candidates, selection, .. } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
@@ -53,14 +54,12 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
                 FooterKey::nav("[Esc]", "cancel"),
             ]);
         }
-
-        SalvageInput::Inactive => {}
     }
 }
 
 pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let DropCargoInput::Confirm { ref manny_name, ref error, .. } = state.drop_cargo else { return };
+    let ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_name, error, .. }) = &state.active_wizard else { return };
 
     let popup = centered_rect(54, 8, area);
     frame.render_widget(Clear, popup);
@@ -102,12 +101,12 @@ pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &A
 
 pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let RecallInput::Confirm { ref manny_name, remote, ref error, .. } = state.recall else { return };
+    let ActiveWizard::Recall(RecallInput::Confirm { manny_name, remote, error, .. }) = &state.active_wizard else { return };
 
     let popup = centered_rect(52, 8, area);
     frame.render_widget(Clear, popup);
 
-    let title = if remote {
+    let title = if *remote {
         format!(" ABANDON — {manny_name} ")
     } else {
         format!(" RECALL — {manny_name} ")
@@ -127,10 +126,10 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
-        if remote { "Abandon this Manny's remote task?" } else { "Send recall order?" },
+        if *remote { "Abandon this Manny's remote task?" } else { "Send recall order?" },
         Style::default().fg(p.text),
     )));
-    if remote {
+    if *remote {
         lines.push(Line::from(Span::styled(
             "It will be left forgotten in its sector (no return).",
             Style::default().fg(p.dim),
@@ -145,7 +144,7 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     // Abandon (remote) is irreversible → Danger; a normal recall is a Commit.
-    let recall_key = if remote {
+    let recall_key = if *remote {
         FooterKey::danger("[Enter]", "ABANDON")
     } else {
         FooterKey::commit("[Enter]", "RECALL")
@@ -155,7 +154,7 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
 pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let RefuelInput::Confirm { ref manny_name, ref error, .. } = state.refuel else { return };
+    let ActiveWizard::Refuel(RefuelInput::Confirm { manny_name, error, .. }) = &state.active_wizard else { return };
 
     let popup = centered_rect(50, 7, area);
     frame.render_widget(Clear, popup);
@@ -195,8 +194,8 @@ pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
 pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ScutRelayInput::EnterNetworkName { ref manny_name, ref relay_name, ref buf, ref error, .. } =
-        state.scut_relay
+    let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { manny_name, relay_name, buf, error, .. }) =
+        &state.active_wizard
     else {
         return;
     };
@@ -242,7 +241,7 @@ pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &A
 
 pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let MindSnapshotInput::Confirm { ref error } = state.mind_snapshot else { return };
+    let ActiveWizard::MindSnapshot(MindSnapshotInput::Confirm { error }) = &state.active_wizard else { return };
     let alert = state.probe_terminal_alert();
 
     let popup = centered_rect(60, 10, area);
@@ -296,7 +295,7 @@ pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state:
 
 pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let RenameMannyInput::Typing { ref manny_name, ref buf, ref error, .. } = state.rename_manny else { return };
+    let ActiveWizard::RenameManny(RenameMannyInput::Typing { manny_name, buf, error, .. }) = &state.active_wizard else { return };
 
     let popup = centered_rect(46, 7, area);
     frame.render_widget(Clear, popup);
@@ -339,7 +338,8 @@ pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: 
 
 pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.deploy {
+    let ActiveWizard::Deploy(deploy) = &state.active_wizard else { return };
+    match deploy {
         DeployInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);
@@ -392,36 +392,35 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 FooterKey::nav("[Esc]", "cancel"),
             ]);
         }
-
-        DeployInput::Inactive => {}
     }
 }
 
 pub(crate) fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let InspectInput::PickTarget { ref manny_name, ref candidates, selection, ref error, .. } = state.inspect else { return };
+    let ActiveWizard::Inspect(InspectInput::PickTarget { manny_name, candidates, selection, error, .. }) = &state.active_wizard else { return };
     let labels: Vec<String> = candidates.iter().enumerate()
         .map(|(i, (id, n))| super::probe_object_label(state, i, id, n)).collect();
     let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     render_pick_list(frame, area, p, &format!(" INSPECT — {manny_name} "), 52, height,
-        Some("Select object to inspect:"), &names, selection, error.as_deref(), "INSPECT");
+        Some("Select object to inspect:"), &names, *selection, error.as_deref(), "INSPECT");
 }
 
 pub(crate) fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let RecoverInput::PickContainer { ref manny_name, ref candidates, selection, ref error, .. } = state.recover else { return };
+    let ActiveWizard::Recover(RecoverInput::PickContainer { manny_name, candidates, selection, error, .. }) = &state.active_wizard else { return };
     let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
     render_pick_list(frame, area, p, &format!(" RECOVER — {manny_name} "), 52, height,
-        Some("Select container to recover:"), &names, selection, error.as_deref(), "RECOVER");
+        Some("Select container to recover:"), &names, *selection, error.as_deref(), "RECOVER");
 }
 
 pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.detach {
+    let ActiveWizard::Detach(detach) = &state.active_wizard else { return };
+    match detach {
         DetachInput::PickContainer { manny_name, containers, selection, .. } => {
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(16);
@@ -445,8 +444,6 @@ pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             render_pick_list(frame, area, p, &format!(" DETACH — hide {container_name} "), 52, height,
                 Some(&prompt), &names, *selection, error.as_deref(), "HIDE HERE");
         }
-
-        DetachInput::Inactive => {}
     }
 }
 

--- a/src/ui/overlays/remote_mine.rs
+++ b/src/ui/overlays/remote_mine.rs
@@ -7,12 +7,13 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{AppState, RemoteMineInput, RESOURCE_LABELS};
+use crate::app::{ActiveWizard, AppState, RemoteMineInput, RESOURCE_LABELS};
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.remote_mine {
+    let ActiveWizard::RemoteMine(remote_mine) = &state.active_wizard else { return };
+    match remote_mine {
         RemoteMineInput::Loading { manny_name, x, y, z, .. } => {
             let popup = centered_rect(50, 5, area);
             frame.render_widget(Clear, popup);
@@ -105,6 +106,5 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
             );
         }
 
-        RemoteMineInput::Inactive => {}
     }
 }

--- a/src/ui/overlays/repair.rs
+++ b/src/ui/overlays/repair.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, RepairInput};
+use crate::app::{ActiveWizard, AppState, RepairInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
@@ -11,7 +11,7 @@ use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_footer, FooterKey, KeyTone};
 pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let RepairInput::Typing { ref manny_name, ref buf, ref error, .. } = state.repair else { return };
+    let ActiveWizard::Repair(RepairInput::Typing { manny_name, buf, error, .. }) = &state.active_wizard else { return };
 
     let max_pct = state.repair_max_percent();
     let metals_stock = state.repair_metals_stock();

--- a/src/ui/overlays/scut_network.rs
+++ b/src/ui/overlays/scut_network.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use crate::api::types::{ProbeSector, ScutRelayStatus};
-use crate::app::{AppState, ScutNetworkInput};
+use crate::app::{ActiveWizard, AppState, ScutNetworkInput};
 
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
@@ -21,7 +21,8 @@ fn rel(sector: &ProbeSector) -> String {
 
 pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.scut_network {
+    let ActiveWizard::ScutNetwork(scut_network) = &state.active_wizard else { return };
+    match scut_network {
         ScutNetworkInput::Picking { networks, selection } => {
             let items: Vec<&str> = networks.iter().map(|(_, name)| name.as_str()).collect();
             let height = (items.len() as u16) + 4;
@@ -104,6 +105,5 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
             render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc]", "close")]);
         }
-        ScutNetworkInput::Inactive => {}
     }
 }

--- a/src/ui/overlays/storage_move.rs
+++ b/src/ui/overlays/storage_move.rs
@@ -1,5 +1,5 @@
 use crate::ui::theme::{palette, Palette};
-use crate::app::{AppState, StorageMoveInput, MOVE_RESOURCE_TYPES};
+use crate::app::{ActiveWizard, AppState, StorageMoveInput, MOVE_RESOURCE_TYPES};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -54,8 +54,8 @@ fn field_row(p: Palette, label: &str, value: String, active: bool, editing: bool
 
 pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    match &state.storage_move {
-        StorageMoveInput::Inactive => {}
+    let ActiveWizard::StorageMove(storage_move) = &state.active_wizard else { return };
+    match storage_move {
         StorageMoveInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);

--- a/src/ui/overlays/travel.rs
+++ b/src/ui/overlays/travel.rs
@@ -1,4 +1,4 @@
-use crate::app::{AppState, TravelInput};
+use crate::app::{ActiveWizard, AppState, TravelInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -11,6 +11,7 @@ use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
+    let ActiveWizard::Travel(travel) = &state.active_wizard else { return };
     let popup = centered_rect(46, 11, area);
     frame.render_widget(Clear, popup);
 
@@ -29,9 +30,7 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     let body = rows[0];
     let hint_area = rows[1];
 
-    match &state.travel {
-        TravelInput::Inactive => {}
-
+    match travel {
         TravelInput::Typing(buf) => {
             let mut lines: Vec<Line> = Vec::new();
 

--- a/src/ui/overlays/waypoints.rs
+++ b/src/ui/overlays/waypoints.rs
@@ -1,5 +1,5 @@
 use crate::ui::theme::palette;
-use crate::app::{AppState, WaypointKind, WaypointsInput};
+use crate::app::{ActiveWizard, AppState, WaypointKind, WaypointsInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -11,7 +11,8 @@ use ratatui::{
 use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let WaypointsInput::Browsing { ref entries, selection } = state.waypoints else { return };
+    let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, selection }) = &state.active_wizard else { return };
+    let selection = *selection;
 
     let height = (entries.len() as u16 + 5).min(20);
     let popup = centered_rect(58, height, area);


### PR DESCRIPTION
## What

`AppState` held **31 mutually-exclusive `*Input` wizard fields**; "exactly one wizard active" was only a convention (the `WIZARD_INPUTS` precedence + tests). This replaces them with a single `active_wizard: ActiveWizard` sum type, so a second wizard **cannot coexist** with a first — the illegal state is now unrepresentable at compile time (holds in release too, unlike the `debug_assert` this **supersedes**).

This is **option 2** of #210 (Design B), chosen over the debug_assert to get better foundations for the sequencing work ahead.

## How

- **`src/app/inputs.rs`** — removed the `Inactive` variant (+ `#[default]` + `#[derive(Default)]`) from each of the 31 enums; added `enum ActiveWizard { None, Repair(RepairInput), Travel(TravelInput), … }`.
- **`src/app/mod.rs`** — 31 fields → one `active_wizard`; new `close_wizard()` replaces every `state.<field> = <Input>::Inactive` reset.
- **Registries** — `WIZARD_INPUTS` (input) and `WIZARD_OVERLAYS` (ui) guards now `matches!(s.active_wizard, ActiveWizard::X(_))`.
- **Handlers / overlays / launchers / `main.rs`** — read/write through the enum variant (compiler-guided: every unmigrated site was a type error).

## Scope

The 5 hand-wired overlays stay separate fields — `scan_mode`, `goto_visited`, `probe_switch`, `map`, `help_open`, `inventory_detail_open`. Folding those is **#211**.

## Behaviour

Unchanged. `finish_action` deliberately does **not** close the wizard: most arms close explicitly via `close_wizard()`, but mission-abandon and message-sent return to a browsing state and keep their overlay open — auto-closing would have regressed that.

## Tests

- 282 pass (`cargo test`); `cargo clippy` (lib) clean; build clean.
- All characterization tests adapted and green, plus a new `opening_a_second_wizard_replaces_the_first` proving the structural guarantee.
- 45 files changed, net −58 lines.

Closes #210.