### PR TITLE
chore: adopt rustfmt (config + per-check CI + baseline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,27 +9,43 @@ on:
 permissions:
   contents: read
 
+# One job per check: each shows as its own box in the PR status list, they run
+# in parallel, and one failure never hides another. `--locked` proves CI builds
+# against the committed Cargo.lock.
 jobs:
-  ci:
+  fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          components: rustfmt
+      # No cache: `cargo fmt --check` does not compile.
+      - run: cargo fmt --check
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # `cargo check` is subsumed by clippy, which type-checks too.
+      - run: cargo clippy --locked -- -D warnings
 
-      - name: Cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo test --locked
 
-      # `cargo check` is subsumed by clippy, which type-checks too — dropped.
-      # `--locked` proves CI builds against the committed Cargo.lock.
-      - name: Clippy
-        run: cargo clippy --locked -- -D warnings
-
-      - name: Test
-        run: cargo test --locked
-
-      - name: Build release
-        run: cargo build --release --locked
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo build --release --locked

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+# Formatting is tuned to the codebase's existing hand-formatting: a generous
+# width keeps intentional single-line constructs (e.g. the WIZARD_INPUTS /
+# WIZARD_OVERLAYS registry entries, dense match arms) from being wrapped.
+# Stable rustfmt options only — CI runs stable `cargo fmt`.
+edition = "2021"
+max_width = 120

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,8 +1,7 @@
 use super::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, EndpointId, Manny, Mission, Pagination,
-    Probe, ProbeAlert, ProbeImprovement, ProbeInventory, ProbeListResponse, ProbeMessage,
-    ProbeMovement, ProbeSentMessage, ScutNetwork, SectorObservation, StorageContainer,
-    VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, EndpointId, Manny, Mission, Pagination, Probe, ProbeAlert,
+    ProbeImprovement, ProbeInventory, ProbeListResponse, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork,
+    SectorObservation, StorageContainer, VisitedSector,
 };
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
@@ -45,7 +44,12 @@ impl ApiClient {
             .build()
             .context("Failed to build HTTP client")?;
         let base_url = Url::parse(&base_url).context("Invalid base_url in config")?;
-        Ok(Self { client, base_url, api_key, active_probe_id: None })
+        Ok(Self {
+            client,
+            base_url,
+            api_key,
+            active_probe_id: None,
+        })
     }
 
     /// Return a clone of this client that targets `id` (or the default probe
@@ -53,7 +57,10 @@ impl ApiClient {
     /// internally reference-counted. Used by the cockpit to switch the active
     /// probe without touching the server-side default.
     pub fn with_active_probe(&self, id: Option<u64>) -> Self {
-        Self { active_probe_id: id, ..self.clone() }
+        Self {
+            active_probe_id: id,
+            ..self.clone()
+        }
     }
 
     /// Which probe per-probe calls currently target (`None` = default).
@@ -104,7 +111,9 @@ impl ApiClient {
             anyhow::bail!("{msg}");
         }
 
-        resp.json::<T>().await.with_context(|| format!("Parsing {method} {path}"))
+        resp.json::<T>()
+            .await
+            .with_context(|| format!("Parsing {method} {path}"))
     }
 
     async fn post<T: for<'de> Deserialize<'de>, B: Serialize>(&self, path: &str, body: &B) -> Result<T> {
@@ -139,7 +148,9 @@ impl ApiClient {
     pub async fn get_api_version(&self) -> Result<u32> {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
-        struct Resp { api_version: u32 }
+        struct Resp {
+            api_version: u32,
+        }
         Ok(self.get::<Resp>("/api/version").await?.api_version)
     }
 
@@ -177,7 +188,8 @@ impl ApiClient {
             is_default: Option<bool>,
         }
         let path = format!("/api/probe/{probe_id}");
-        self.patch::<ProbeListResponse, _>(&path, &Body { name, is_default }).await
+        self.patch::<ProbeListResponse, _>(&path, &Body { name, is_default })
+            .await
     }
 
     pub async fn get_mannies(&self) -> Result<Vec<Manny>> {
@@ -198,13 +210,26 @@ impl ApiClient {
 
     pub async fn move_probe(&self, x: i32, y: i32, z: i32) -> Result<ProbeMovement> {
         #[derive(Serialize)]
-        struct Target { x: i32, y: i32, z: i32 }
+        struct Target {
+            x: i32,
+            y: i32,
+            z: i32,
+        }
         #[derive(Serialize)]
-        struct Body { target: Target }
+        struct Body {
+            target: Target,
+        }
         #[derive(Deserialize)]
-        struct Resp { movement: ProbeMovement }
+        struct Resp {
+            movement: ProbeMovement,
+        }
         Ok(self
-            .post::<Resp, _>(&self.probe_path("/move"), &Body { target: Target { x, y, z } })
+            .post::<Resp, _>(
+                &self.probe_path("/move"),
+                &Body {
+                    target: Target { x, y, z },
+                },
+            )
             .await?
             .movement)
     }
@@ -212,9 +237,13 @@ impl ApiClient {
     pub async fn repair_manny(&self, manny_id: &str, integrity_percent: f64) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
-        struct Body { integrity_percent: f64 }
+        struct Body {
+            integrity_percent: f64,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/repair"));
         Ok(self.post::<Resp, _>(&path, &Body { integrity_percent }).await?.manny)
     }
@@ -237,15 +266,20 @@ impl ApiClient {
             target_container_id: Option<String>,
         }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/mine"));
         Ok(self
-            .post::<Resp, _>(&path, &Body {
-                object_id: object_id.to_string(),
-                resources,
-                target_amount,
-                target_container_id,
-            })
+            .post::<Resp, _>(
+                &path,
+                &Body {
+                    object_id: object_id.to_string(),
+                    resources,
+                    target_amount,
+                    target_container_id,
+                },
+            )
             .await?
             .manny)
     }
@@ -254,16 +288,17 @@ impl ApiClient {
     /// additional containers plus fixed components (`POST
     /// /api/probe/mannies/{id}/assemble-probe`, API v81). Returns the updated
     /// Manny and probe inventory (the containers + components are consumed).
-    pub async fn assemble_probe(
-        &self,
-        manny_id: &str,
-        container_ids: &[String],
-    ) -> Result<(Manny, ProbeInventory)> {
+    pub async fn assemble_probe(&self, manny_id: &str, container_ids: &[String]) -> Result<(Manny, ProbeInventory)> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
-        struct Body<'a> { container_ids: &'a [String] }
+        struct Body<'a> {
+            container_ids: &'a [String],
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny, inventory: ProbeInventory }
+        struct Resp {
+            manny: Manny,
+            inventory: ProbeInventory,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/assemble-probe"));
         let r = self.post::<Resp, _>(&path, &Body { container_ids }).await?;
         Ok((r.manny, r.inventory))
@@ -276,31 +311,46 @@ impl ApiClient {
             amount: Option<f64>,
         }
         #[derive(Deserialize)]
-        struct Resp { inventory: ProbeInventory }
+        struct Resp {
+            inventory: ProbeInventory,
+        }
         let path = self.probe_path(&format!("/inventory/{item_id}/jettison"));
         Ok(self.post::<Resp, _>(&path, &Body { amount }).await?.inventory)
     }
 
     pub async fn craft_manny(&self, manny_id: &str, recipe: &str) -> Result<Manny> {
         #[derive(Serialize)]
-        struct Body<'a> { recipe: &'a str }
+        struct Body<'a> {
+            recipe: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/craft"));
         Ok(self.post::<Resp, _>(&path, &Body { recipe }).await?.manny)
     }
 
     pub async fn get_probe_improvements(&self) -> Result<Vec<ProbeImprovement>> {
         #[derive(Deserialize)]
-        struct Resp { improvements: Vec<ProbeImprovement> }
-        Ok(self.get::<Resp>(&self.probe_path("/probe-improvements-available")).await?.improvements)
+        struct Resp {
+            improvements: Vec<ProbeImprovement>,
+        }
+        Ok(self
+            .get::<Resp>(&self.probe_path("/probe-improvements-available"))
+            .await?
+            .improvements)
     }
 
     pub async fn improve_probe(&self, manny_id: &str, improvement: &str) -> Result<Manny> {
         #[derive(Serialize)]
-        struct Body<'a> { improvement: &'a str }
+        struct Body<'a> {
+            improvement: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/improve-probe"));
         Ok(self.post::<Resp, _>(&path, &Body { improvement }).await?.manny)
     }
@@ -317,16 +367,22 @@ impl ApiClient {
     pub async fn salvage_manny(&self, manny_id: &str, object_id: &str) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
-        struct Body<'a> { object_id: &'a str }
+        struct Body<'a> {
+            object_id: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/salvage"));
         Ok(self.post::<Resp, _>(&path, &Body { object_id }).await?.manny)
     }
 
     pub async fn recall_manny(&self, manny_id: &str) -> Result<Manny> {
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/recall"));
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
     }
@@ -342,11 +398,25 @@ impl ApiClient {
     ) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
-        struct Body<'a> { container_id: &'a str, planet_id: &'a str }
+        struct Body<'a> {
+            container_id: &'a str,
+            planet_id: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/drop-storage-container"));
-        Ok(self.post::<Resp, _>(&path, &Body { container_id, planet_id }).await?.manny)
+        Ok(self
+            .post::<Resp, _>(
+                &path,
+                &Body {
+                    container_id,
+                    planet_id,
+                },
+            )
+            .await?
+            .manny)
     }
 
     /// Drop the cargo of a Manny waiting outside for storage space and retry
@@ -354,7 +424,9 @@ impl ApiClient {
     /// is lost; recoverable objects are restored to the current sector.
     pub async fn drop_manny_cargo(&self, manny_id: &str) -> Result<Manny> {
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/drop-manny-cargo"));
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
     }
@@ -364,7 +436,9 @@ impl ApiClient {
     /// deuterium refuel station in the current sector.
     pub async fn refill_deuterium_tank(&self, manny_id: &str) -> Result<Manny> {
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/refill-deuterium-tank"));
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.manny)
     }
@@ -388,10 +462,18 @@ impl ApiClient {
             amount: f64,
         }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/transfer-deuterium-to-probe"));
         Ok(self
-            .post::<Resp, _>(&path, &Body { target_probe_id, amount })
+            .post::<Resp, _>(
+                &path,
+                &Body {
+                    target_probe_id,
+                    amount,
+                },
+            )
             .await?
             .manny)
     }
@@ -409,7 +491,11 @@ impl ApiClient {
     /// List received messages (`GET /api/probe/messages`, newest first).
     pub async fn get_messages(&self) -> Result<(Vec<ProbeMessage>, Pagination)> {
         #[derive(Deserialize)]
-        struct Resp { #[serde(default)] messages: Vec<ProbeMessage>, pagination: Pagination }
+        struct Resp {
+            #[serde(default)]
+            messages: Vec<ProbeMessage>,
+            pagination: Pagination,
+        }
         let r = self.get::<Resp>(&self.probe_path("/messages")).await?;
         Ok((r.messages, r.pagination))
     }
@@ -417,7 +503,11 @@ impl ApiClient {
     /// List sent messages (`GET /api/probe/messages/sent`, newest first).
     pub async fn get_sent_messages(&self) -> Result<(Vec<ProbeSentMessage>, Pagination)> {
         #[derive(Deserialize)]
-        struct Resp { #[serde(default)] messages: Vec<ProbeSentMessage>, pagination: Pagination }
+        struct Resp {
+            #[serde(default)]
+            messages: Vec<ProbeSentMessage>,
+            pagination: Pagination,
+        }
         let r = self.get::<Resp>("/api/probe/messages/sent").await?;
         Ok((r.messages, r.pagination))
     }
@@ -430,18 +520,25 @@ impl ApiClient {
         body: &str,
     ) -> Result<ProbeMessage> {
         #[derive(Deserialize)]
-        struct Resp { message: ProbeMessage }
+        struct Resp {
+            message: ProbeMessage,
+        }
         let payload = serde_json::json!({
             "recipient": { "type": recipient_type, "id": recipient_id },
             "body": body,
         });
-        Ok(self.post::<Resp, _>(&self.probe_path("/messages"), &payload).await?.message)
+        Ok(self
+            .post::<Resp, _>(&self.probe_path("/messages"), &payload)
+            .await?
+            .message)
     }
 
     /// Mark a received message as read (`PATCH /api/probe/messages/{id}/read`).
     pub async fn mark_message_read(&self, message_id: i64) -> Result<ProbeMessage> {
         #[derive(Deserialize)]
-        struct Resp { message: ProbeMessage }
+        struct Resp {
+            message: ProbeMessage,
+        }
         let path = self.probe_path(&format!("/messages/{message_id}/read"));
         Ok(self.patch::<Resp, _>(&path, &serde_json::json!({})).await?.message)
     }
@@ -449,7 +546,9 @@ impl ApiClient {
     /// Abandon an active mission (`POST /api/probe/missions/{id}/abandon`).
     pub async fn abandon_mission(&self, mission_id: &str) -> Result<Mission> {
         #[derive(Deserialize)]
-        struct Resp { mission: Mission }
+        struct Resp {
+            mission: Mission,
+        }
         let path = format!("/api/probe/missions/{mission_id}/abandon");
         Ok(self.post::<Resp, _>(&path, &serde_json::json!({})).await?.mission)
     }
@@ -458,7 +557,9 @@ impl ApiClient {
     /// (`GET /api/probe/scut-network/{id}`).
     pub async fn get_scut_network(&self, network_id: i64) -> Result<ScutNetwork> {
         #[derive(Deserialize)]
-        struct Resp { network: ScutNetwork }
+        struct Resp {
+            network: ScutNetwork,
+        }
         let path = self.probe_path(&format!("/scut-network/{network_id}"));
         Ok(self.get::<Resp>(&path).await?.network)
     }
@@ -467,12 +568,7 @@ impl ApiClient {
     /// (`POST /api/probe/mannies/{id}/turn-on-relay`). Requires a star in the
     /// sector and one integrated_circuit in inventory. `relay_id` is the
     /// relay's integer id (the sector object id parsed as an integer).
-    pub async fn turn_on_relay(
-        &self,
-        manny_id: &str,
-        relay_id: i64,
-        network_name: Option<&str>,
-    ) -> Result<Manny> {
+    pub async fn turn_on_relay(&self, manny_id: &str, relay_id: i64, network_name: Option<&str>) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct Body<'a> {
@@ -481,7 +577,9 @@ impl ApiClient {
             network_name: Option<&'a str>,
         }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/turn-on-relay"));
         Ok(self
             .post::<Resp, _>(&path, &Body { relay_id, network_name })
@@ -495,7 +593,9 @@ impl ApiClient {
     /// frame to 0,0,0 and returns the new probe.
     pub async fn reassign_mind_snapshot(&self) -> Result<Probe> {
         #[derive(Deserialize)]
-        struct Resp { probe: Probe }
+        struct Resp {
+            probe: Probe,
+        }
         Ok(self
             .post::<Resp, _>("/api/probe/mind-snapshot/reassign", &serde_json::json!({}))
             .await?
@@ -504,17 +604,24 @@ impl ApiClient {
 
     pub async fn rename_manny(&self, manny_id: &str, name: &str) -> Result<Manny> {
         #[derive(Serialize)]
-        struct Body<'a> { name: &'a str }
+        struct Body<'a> {
+            name: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}"));
         Ok(self.patch::<Resp, _>(&path, &Body { name }).await?.manny)
     }
 
     pub async fn craft_atomic_printer(&self, recipe: &str) -> Result<()> {
         #[derive(Serialize)]
-        struct Body<'a> { recipe: &'a str }
-        self.post::<serde_json::Value, _>(&self.probe_path("/atomic-printer/craft"), &Body { recipe }).await?;
+        struct Body<'a> {
+            recipe: &'a str,
+        }
+        self.post::<serde_json::Value, _>(&self.probe_path("/atomic-printer/craft"), &Body { recipe })
+            .await?;
         Ok(())
     }
 
@@ -534,9 +641,21 @@ impl ApiClient {
             object_id: Option<&'a str>,
         }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/detach-storage-container"));
-        Ok(self.post::<Resp, _>(&path, &Body { container_id, mode, object_id }).await?.manny)
+        Ok(self
+            .post::<Resp, _>(
+                &path,
+                &Body {
+                    container_id,
+                    mode,
+                    object_id,
+                },
+            )
+            .await?
+            .manny)
     }
 
     /// Inspect a sector object (asteroid, dormant construct, or detached
@@ -544,9 +663,13 @@ impl ApiClient {
     pub async fn inspect_sector_object(&self, manny_id: &str, object_id: &str) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
-        struct Body<'a> { object_id: &'a str }
+        struct Body<'a> {
+            object_id: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/inspect-sector-object"));
         Ok(self.post::<Resp, _>(&path, &Body { object_id }).await?.manny)
     }
@@ -554,9 +677,13 @@ impl ApiClient {
     pub async fn recover_storage_container(&self, manny_id: &str, object_id: &str) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
-        struct Body<'a> { object_id: &'a str }
+        struct Body<'a> {
+            object_id: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/recover-storage-container"));
         Ok(self.post::<Resp, _>(&path, &Body { object_id }).await?.manny)
     }
@@ -564,22 +691,34 @@ impl ApiClient {
     pub async fn get_visited_sectors(&self) -> Result<Vec<VisitedSector>> {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
-        struct Resp { visited_sectors: Vec<VisitedSector> }
-        Ok(self.get::<Resp>(&self.probe_path("/visited-sectors")).await?.visited_sectors)
+        struct Resp {
+            visited_sectors: Vec<VisitedSector>,
+        }
+        Ok(self
+            .get::<Resp>(&self.probe_path("/visited-sectors"))
+            .await?
+            .visited_sectors)
     }
 
     pub async fn get_crafting_recipes(&self) -> Result<Vec<CraftingRecipe>> {
         #[derive(Deserialize)]
-        struct Resp { recipes: Vec<CraftingRecipe> }
+        struct Resp {
+            recipes: Vec<CraftingRecipe>,
+        }
         Ok(self.get::<Resp>("/api/crafting-recipes").await?.recipes)
     }
 
     pub async fn install_bookmark_manny(&self, manny_id: &str, object_id: &str, name: &str) -> Result<Manny> {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
-        struct Body<'a> { object_id: &'a str, name: &'a str }
+        struct Body<'a> {
+            object_id: &'a str,
+            name: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny }
+        struct Resp {
+            manny: Manny,
+        }
         let path = self.probe_path(&format!("/mannies/{manny_id}/install-bookmark"));
         Ok(self.post::<Resp, _>(&path, &Body { object_id, name }).await?.manny)
     }
@@ -601,9 +740,14 @@ impl ApiClient {
     pub async fn ack_damage_warning(&self, id: i64) -> Result<ProbeAlert> {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
-        struct Resp { damage_warning: ProbeAlert }
+        struct Resp {
+            damage_warning: ProbeAlert,
+        }
         let path = self.probe_path(&format!("/damage-warnings/{id}"));
-        Ok(self.patch::<Resp, _>(&path, &serde_json::json!({})).await?.damage_warning)
+        Ok(self
+            .patch::<Resp, _>(&path, &serde_json::json!({}))
+            .await?
+            .damage_warning)
     }
 
     pub async fn get_alerts(&self) -> Result<Vec<ProbeAlert>> {
@@ -618,7 +762,9 @@ impl ApiClient {
     /// Mark an alert as read (`PATCH /api/probe/alerts/{id}`).
     pub async fn ack_alert(&self, id: i64) -> Result<ProbeAlert> {
         #[derive(Deserialize)]
-        struct Resp { alert: ProbeAlert }
+        struct Resp {
+            alert: ProbeAlert,
+        }
         let path = self.probe_path(&format!("/alerts/{id}"));
         Ok(self.patch::<Resp, _>(&path, &serde_json::json!({})).await?.alert)
     }
@@ -654,7 +800,10 @@ impl ApiClient {
             body.insert("itemIds".into(), serde_json::json!(v));
         }
         #[derive(Deserialize)]
-        struct Resp { manny: Manny, inventory: ProbeInventory }
+        struct Resp {
+            manny: Manny,
+            inventory: ProbeInventory,
+        }
         let r = self
             .post::<Resp, _>(&self.probe_path("/storage-moves"), &serde_json::Value::Object(body))
             .await?;
@@ -663,27 +812,36 @@ impl ApiClient {
 
     pub async fn get_storage_containers(&self) -> Result<Vec<StorageContainer>> {
         #[derive(Deserialize)]
-        struct Resp { containers: Vec<StorageContainer> }
-        Ok(self.get::<Resp>(&self.probe_path("/storage-containers")).await?.containers)
+        struct Resp {
+            containers: Vec<StorageContainer>,
+        }
+        Ok(self
+            .get::<Resp>(&self.probe_path("/storage-containers"))
+            .await?
+            .containers)
     }
 
     pub async fn get_storage_container(&self, id: &str) -> Result<(StorageContainer, ContainerInventory)> {
         #[derive(Deserialize)]
-        struct Resp { container: StorageContainer, inventory: ContainerInventory }
+        struct Resp {
+            container: StorageContainer,
+            inventory: ContainerInventory,
+        }
         let path = self.probe_path(&format!("/storage-containers/{id}"));
         let r = self.get::<Resp>(&path).await?;
         Ok((r.container, r.inventory))
     }
 
-    pub async fn rename_storage_container(
-        &self,
-        id: &str,
-        label: &str,
-    ) -> Result<(StorageContainer, ProbeInventory)> {
+    pub async fn rename_storage_container(&self, id: &str, label: &str) -> Result<(StorageContainer, ProbeInventory)> {
         #[derive(Serialize)]
-        struct Body<'a> { label: &'a str }
+        struct Body<'a> {
+            label: &'a str,
+        }
         #[derive(Deserialize)]
-        struct Resp { container: StorageContainer, inventory: ProbeInventory }
+        struct Resp {
+            container: StorageContainer,
+            inventory: ProbeInventory,
+        }
         let path = self.probe_path(&format!("/storage-containers/{id}"));
         let r = self.patch::<Resp, _>(&path, &Body { label }).await?;
         Ok((r.container, r.inventory))
@@ -704,10 +862,20 @@ impl ApiClient {
             strict_exclusion: Vec<String>,
         }
         #[derive(Deserialize)]
-        struct Resp { container: StorageContainer, inventory: ProbeInventory }
+        struct Resp {
+            container: StorageContainer,
+            inventory: ProbeInventory,
+        }
         let path = self.probe_path(&format!("/storage-containers/{id}/rules"));
         let r = self
-            .patch::<Resp, _>(&path, &Body { priority, exclusion, strict_exclusion })
+            .patch::<Resp, _>(
+                &path,
+                &Body {
+                    priority,
+                    exclusion,
+                    strict_exclusion,
+                },
+            )
             .await?;
         Ok((r.container, r.inventory))
     }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -50,7 +50,11 @@ fn spawn_fetch<T, E>(
 }
 
 pub fn fetch_api_version(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    spawn_fetch(tx, async move { client.get_api_version().await }, ApiMessage::VersionFetched);
+    spawn_fetch(
+        tx,
+        async move { client.get_api_version().await },
+        ApiMessage::VersionFetched,
+    );
 }
 
 pub fn fetch_all(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
@@ -66,14 +70,30 @@ pub fn fetch_all(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
 
     // Mannies, sector, visited sectors and the fleet roster are all non-fatal.
     let c = client.clone();
-    spawn_fetch(tx.clone(), async move { c.get_mannies().await }, ApiMessage::ManniesUpdated);
+    spawn_fetch(
+        tx.clone(),
+        async move { c.get_mannies().await },
+        ApiMessage::ManniesUpdated,
+    );
     let c = client.clone();
-    spawn_fetch(tx.clone(), async move { c.get_probe_sector().await }, ApiMessage::SectorUpdated);
+    spawn_fetch(
+        tx.clone(),
+        async move { c.get_probe_sector().await },
+        ApiMessage::SectorUpdated,
+    );
     let c = client.clone();
-    spawn_fetch(tx.clone(), async move { c.get_visited_sectors().await }, ApiMessage::VisitedSectorsFetched);
+    spawn_fetch(
+        tx.clone(),
+        async move { c.get_visited_sectors().await },
+        ApiMessage::VisitedSectorsFetched,
+    );
     // Fleet roster (API v81 multi-probe): drives the probe switcher.
     let c = client.clone();
-    spawn_fetch(tx.clone(), async move { c.get_probes().await }, ApiMessage::FleetFetched);
+    spawn_fetch(
+        tx.clone(),
+        async move { c.get_probes().await },
+        ApiMessage::FleetFetched,
+    );
 
     // Alerts + damage warnings + missions + probe improvements: same non-fatal
     // pattern, each in its own wrapper.
@@ -91,12 +111,7 @@ pub fn fetch_probe_improvements(client: ApiClient, tx: mpsc::Sender<ApiMessage>)
     );
 }
 
-pub fn fetch_improve_probe(
-    manny_id: String,
-    improvement: String,
-    client: ApiClient,
-    tx: mpsc::Sender<ApiMessage>,
-) {
+pub fn fetch_improve_probe(manny_id: String, improvement: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     spawn_action(
         tx,
         async move { client.improve_probe(&manny_id, &improvement).await },
@@ -106,15 +121,17 @@ pub fn fetch_improve_probe(
 }
 
 pub fn fetch_missions(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    spawn_fetch(tx, async move { client.get_missions().await }, ApiMessage::MissionsFetched);
+    spawn_fetch(
+        tx,
+        async move { client.get_missions().await },
+        ApiMessage::MissionsFetched,
+    );
 }
 
 pub fn fetch_messages(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    spawn_fetch(
-        tx,
-        async move { client.get_messages().await },
-        |(messages, _pag)| ApiMessage::MessagesFetched(messages),
-    );
+    spawn_fetch(tx, async move { client.get_messages().await }, |(messages, _pag)| {
+        ApiMessage::MessagesFetched(messages)
+    });
 }
 
 pub fn fetch_sent_messages(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
@@ -257,14 +274,22 @@ pub fn fetch_update_container_rules(
 ) {
     spawn_action(
         tx,
-        async move { client.update_container_rules(&id, priority, exclusion, strict_exclusion).await },
+        async move {
+            client
+                .update_container_rules(&id, priority, exclusion, strict_exclusion)
+                .await
+        },
         |(c, inv)| ApiMessage::UpdateContainerRulesDone(c, inv),
         ApiMessage::UpdateContainerRulesError,
     );
 }
 
 pub fn fetch_mannies(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    spawn_fetch(tx, async move { client.get_mannies().await }, ApiMessage::ManniesUpdated);
+    spawn_fetch(
+        tx,
+        async move { client.get_mannies().await },
+        ApiMessage::ManniesUpdated,
+    );
 }
 
 pub fn fetch_move(x: i32, y: i32, z: i32, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
@@ -297,7 +322,9 @@ pub fn fetch_mine(
     spawn_action(
         tx,
         async move {
-            client.mine_manny(&manny_id, &object_id, resources, target_amount, target_container_id).await
+            client
+                .mine_manny(&manny_id, &object_id, resources, target_amount, target_container_id)
+                .await
         },
         |_| ApiMessage::MineStarted,
         ApiMessage::MineError,
@@ -323,7 +350,11 @@ pub fn fetch_craft(manny_id: String, recipe: String, client: ApiClient, tx: mpsc
 }
 
 pub fn fetch_crafting_recipes(client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
-    spawn_fetch(tx, async move { client.get_crafting_recipes().await }, ApiMessage::RecipesFetched);
+    spawn_fetch(
+        tx,
+        async move { client.get_crafting_recipes().await },
+        ApiMessage::RecipesFetched,
+    );
 }
 
 pub fn fetch_atomic_printer_craft(recipe: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
@@ -367,7 +398,13 @@ pub fn fetch_sector(coords: Option<(i32, i32, i32)>, client: ApiClient, tx: mpsc
     );
 }
 
-pub fn fetch_deploy(manny_id: String, object_id: String, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
+pub fn fetch_deploy(
+    manny_id: String,
+    object_id: String,
+    name: String,
+    client: ApiClient,
+    tx: mpsc::Sender<ApiMessage>,
+) {
     spawn_action(
         tx,
         async move { client.install_bookmark_manny(&manny_id, &object_id, &name).await },
@@ -405,7 +442,9 @@ pub fn fetch_detach(
     spawn_action(
         tx,
         async move {
-            client.detach_storage_container(&manny_id, &container_id, &mode, object_id.as_deref()).await
+            client
+                .detach_storage_container(&manny_id, &container_id, &mode, object_id.as_deref())
+                .await
         },
         |_| ApiMessage::DetachStarted,
         ApiMessage::DetachError,
@@ -422,7 +461,9 @@ pub fn fetch_drop_storage_container(
     spawn_action(
         tx,
         async move {
-            client.drop_storage_container_on_planet(&manny_id, &container_id, &planet_id).await
+            client
+                .drop_storage_container_on_planet(&manny_id, &container_id, &planet_id)
+                .await
         },
         ApiMessage::DropStorageContainerStarted,
         ApiMessage::DropStorageContainerError,
@@ -470,7 +511,11 @@ pub fn fetch_transfer_deuterium(
 ) {
     spawn_action(
         tx,
-        async move { client.transfer_deuterium_to_probe(&manny_id, target_probe_id, amount).await },
+        async move {
+            client
+                .transfer_deuterium_to_probe(&manny_id, target_probe_id, amount)
+                .await
+        },
         |_| ApiMessage::DeuteriumTransferStarted,
         ApiMessage::DeuteriumTransferError,
     );
@@ -502,12 +547,7 @@ pub fn fetch_turn_on_relay(
 
 /// Promote a probe to the player's default (`PATCH /api/probe/{id}`). The
 /// server refuses an out-of-reach target with 422, surfaced as `ActionError`.
-pub fn fetch_set_default_probe(
-    probe_id: u64,
-    name: String,
-    client: ApiClient,
-    tx: mpsc::Sender<ApiMessage>,
-) {
+pub fn fetch_set_default_probe(probe_id: u64, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     spawn_action(
         tx,
         async move { client.patch_probe(probe_id, None, Some(true)).await },
@@ -517,12 +557,7 @@ pub fn fetch_set_default_probe(
 }
 
 /// Rename a probe (`PATCH /api/probe/{id}` with `name`, API v81).
-pub fn fetch_rename_probe(
-    probe_id: u64,
-    name: String,
-    client: ApiClient,
-    tx: mpsc::Sender<ApiMessage>,
-) {
+pub fn fetch_rename_probe(probe_id: u64, name: String, client: ApiClient, tx: mpsc::Sender<ApiMessage>) {
     // `name` is needed both in the request and in the success message; clone so
     // the future can borrow one copy while the `on_ok` closure owns the other.
     let label = name.clone();

--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -174,7 +174,10 @@ mod tests {
 
     #[test]
     fn boot_completes_then_auto_continues() {
-        let mut s = AppState { booting: true, ..Default::default() };
+        let mut s = AppState {
+            booting: true,
+            ..Default::default()
+        };
         assert!(!s.boot_complete());
         for _ in 0..BOOT_SEQUENCE_END {
             s.boot_tick();
@@ -191,7 +194,10 @@ mod tests {
 
     #[test]
     fn any_key_leaves_the_boot() {
-        let mut s = AppState { booting: true, ..Default::default() };
+        let mut s = AppState {
+            booting: true,
+            ..Default::default()
+        };
         s.skip_boot();
         assert!(!s.booting);
     }

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -3,8 +3,7 @@ use super::*;
 /// Command verbs recognised by `:` mode. Kept as a table so the input layer can
 /// offer Tab-completion and a `:help`-style listing.
 pub const COMMANDS: [&str; 12] = [
-    "focus", "travel", "goto", "filter", "refresh", "theme", "zoom", "craft", "mine", "probe",
-    "help", "quit",
+    "focus", "travel", "goto", "filter", "refresh", "theme", "zoom", "craft", "mine", "probe", "help", "quit",
 ];
 
 /// One-line argument usage for a verb, shown as inline ghost-text while typing
@@ -72,7 +71,11 @@ fn fleet_probe_id(state: &AppState, args: &[&str]) -> Option<u64> {
         return Some(p.id);
     }
     let ql = q.to_lowercase();
-    state.fleet.iter().find(|p| p.name.to_lowercase().contains(&ql)).map(|p| p.id)
+    state
+        .fleet
+        .iter()
+        .find(|p| p.name.to_lowercase().contains(&ql))
+        .map(|p| p.id)
 }
 
 fn color_from_name(name: &str) -> Option<ColorMode> {
@@ -113,7 +116,10 @@ impl AppState {
     fn arg_candidates(&self, verb: &str) -> Vec<String> {
         match verb {
             "focus" => Pane::ALL.iter().map(|p| p.label().to_lowercase()).collect(),
-            "filter" => ["all", "objects", "minable", "danger"].iter().map(|s| s.to_string()).collect(),
+            "filter" => ["all", "objects", "minable", "danger"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
             "theme" => [
                 ColorMode::MonoGreen,
                 ColorMode::MonoAmber,
@@ -144,8 +150,11 @@ impl AppState {
             // Still on the first token → complete the verb.
             None => {
                 let stem = head[lead..].to_lowercase();
-                let cands: Vec<String> =
-                    COMMANDS.iter().filter(|c| c.starts_with(&stem)).map(|c| c.to_string()).collect();
+                let cands: Vec<String> = COMMANDS
+                    .iter()
+                    .filter(|c| c.starts_with(&stem))
+                    .map(|c| c.to_string())
+                    .collect();
                 (!cands.is_empty()).then_some((lead, cands))
             }
             // Verb typed → complete its (single) argument. The token spans the
@@ -160,8 +169,10 @@ impl AppState {
                 let region = &head[after_verb..];
                 let ts = after_verb + (region.len() - region.trim_start().len());
                 let stem = input[ts..cbyte].to_lowercase();
-                let cands: Vec<String> =
-                    all.into_iter().filter(|c| c.to_lowercase().starts_with(&stem)).collect();
+                let cands: Vec<String> = all
+                    .into_iter()
+                    .filter(|c| c.to_lowercase().starts_with(&stem))
+                    .collect();
                 (!cands.is_empty()).then_some((ts, cands))
             }
         }
@@ -271,7 +282,10 @@ impl AppState {
             return Some(m.clone());
         }
         let q = query.to_lowercase();
-        mannies.iter().find(|(_, name)| name.to_lowercase().contains(&q)).cloned()
+        mannies
+            .iter()
+            .find(|(_, name)| name.to_lowercase().contains(&q))
+            .cloned()
     }
 
     /// `:craft <recipe>` — resolve the recipe by name (case-insensitive exact,
@@ -357,7 +371,12 @@ impl AppState {
                 });
             }
             _ => {
-                self.active_wizard = ActiveWizard::Mine(MineInput::PickAsteroid { manny_id, manny_name, candidates, selection: 0 });
+                self.active_wizard = ActiveWizard::Mine(MineInput::PickAsteroid {
+                    manny_id,
+                    manny_name,
+                    candidates,
+                    selection: 0,
+                });
             }
         }
     }
@@ -369,8 +388,7 @@ impl AppState {
         // Split into the positional head (resources + amount) and the by/at/to
         // keyword buckets. Keyword values run to the next keyword, so names may
         // contain spaces.
-        let (mut positional, mut by, mut at, mut to) =
-            (Vec::new(), Vec::new(), Vec::new(), Vec::new());
+        let (mut positional, mut by, mut at, mut to) = (Vec::new(), Vec::new(), Vec::new(), Vec::new());
         let mut bucket = 0u8; // 0 positional · 1 by · 2 at · 3 to
         for &tok in args {
             match tok {

--- a/src/app/containers.rs
+++ b/src/app/containers.rs
@@ -27,7 +27,12 @@ impl AppState {
     pub fn has_atmospheric_drop_kit(&self) -> bool {
         self.probe
             .as_ref()
-            .map(|p| p.inventory.items.iter().any(|it| it.item_type == "atmospheric_drop_kit"))
+            .map(|p| {
+                p.inventory
+                    .items
+                    .iter()
+                    .any(|it| it.item_type == "atmospheric_drop_kit")
+            })
             .unwrap_or(false)
     }
 

--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -16,16 +16,16 @@ const PANE_JUMP_CAP: usize = 4096;
 /// QWERTY). `Probe` is the centre — the `f` home key with the tactile bump.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Pane {
-    Scanner,   // e
-    Map,       // r
-    Comms,     // t
-    Sector,    // d
+    Scanner, // e
+    Map,     // r
+    Comms,   // t
+    Sector,  // d
     #[default]
-    Probe,     // f — centre of the square
-    Missions,  // g
+    Probe, // f — centre of the square
+    Missions, // g
     Inventory, // c
-    Storage,   // v
-    Mannies,   // b
+    Storage, // v
+    Mannies, // b
 }
 
 impl Pane {
@@ -148,8 +148,7 @@ impl CommsCategory {
     }
 
     /// Root-row order in the Comms pane.
-    pub const ALL: [CommsCategory; 3] =
-        [CommsCategory::Messages, CommsCategory::Alerts, CommsCategory::Warnings];
+    pub const ALL: [CommsCategory; 3] = [CommsCategory::Messages, CommsCategory::Alerts, CommsCategory::Warnings];
 }
 
 /// The two sub-views of the Missions pane, selectable at its root: the active
@@ -185,15 +184,8 @@ impl super::AppState {
     /// around (fallback to the grid keys for `Tab`/`Shift+Tab`).
     pub fn cycle_pane(&mut self, forward: bool) {
         let n = Pane::ALL.len();
-        let cur = Pane::ALL
-            .iter()
-            .position(|p| *p == self.active_pane)
-            .unwrap_or(0);
-        let next = if forward {
-            (cur + 1) % n
-        } else {
-            (cur + n - 1) % n
-        };
+        let cur = Pane::ALL.iter().position(|p| *p == self.active_pane).unwrap_or(0);
+        let next = if forward { (cur + 1) % n } else { (cur + n - 1) % n };
         self.active_pane = Pane::ALL[next];
     }
 
@@ -217,11 +209,9 @@ impl super::AppState {
             Pane::Missions => match drill {
                 None => MissionsCategory::ALL.len(),
                 Some(DrillLevel::MissionsCat(MissionsCategory::ShipsLog)) => self.ship_log_entries().len(),
-                Some(DrillLevel::Mission(id)) => self
-                    .missions
-                    .iter()
-                    .find(|m| &m.id == id)
-                    .map_or(0, |m| m.steps.len()),
+                Some(DrillLevel::Mission(id)) => {
+                    self.missions.iter().find(|m| &m.id == id).map_or(0, |m| m.steps.len())
+                }
                 _ => self.missions.len(),
             },
             // Drilled into a container, the cursor is frozen (contents are
@@ -378,10 +368,13 @@ impl super::AppState {
     /// The Missions category currently drilled into, if any — found anywhere in
     /// the stack, so it holds while drilled deeper into a mission's steps.
     pub fn missions_category(&self) -> Option<MissionsCategory> {
-        self.pane_nav[Pane::Missions.index()].drill.iter().find_map(|l| match l {
-            DrillLevel::MissionsCat(c) => Some(*c),
-            _ => None,
-        })
+        self.pane_nav[Pane::Missions.index()]
+            .drill
+            .iter()
+            .find_map(|l| match l {
+                DrillLevel::MissionsCat(c) => Some(*c),
+                _ => None,
+            })
     }
 
     /// Enter a Missions category from the root (missions list / ship's log).
@@ -588,10 +581,7 @@ mod tests {
         // Root exposes the two categories.
         assert_eq!(s.pane_item_count(Pane::Missions), MissionsCategory::ALL.len());
         // The Ship's log category lists the journal entries.
-        s.journal = vec![
-            LogEvent::action("test", "a", None),
-            LogEvent::action("test", "b", None),
-        ];
+        s.journal = vec![LogEvent::action("test", "a", None), LogEvent::action("test", "b", None)];
         s.missions_enter_category(MissionsCategory::ShipsLog);
         assert_eq!(s.missions_category(), Some(MissionsCategory::ShipsLog));
         assert_eq!(s.pane_item_count(Pane::Missions), 2);

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -110,10 +110,7 @@ pub enum ObjectActionInput {
 pub enum AlertsInput {
     /// `show_warnings` selects the Warnings tab; otherwise the Alerts tab.
     /// The entries themselves live in `AppState::alerts` / `damage_warnings`.
-    Browsing {
-        selection: usize,
-        show_warnings: bool,
-    },
+    Browsing { selection: usize, show_warnings: bool },
 }
 
 pub enum RenameContainerInput {
@@ -484,10 +481,7 @@ pub enum JettisonInput {
         error: Option<String>,
     },
     /// Confirmation for deploying a scut_relay item as an inactive relay.
-    ConfirmRelay {
-        item_id: String,
-        error: Option<String>,
-    },
+    ConfirmRelay { item_id: String, error: Option<String> },
     EnterAmount {
         item_id: String,
         item_name: String,

--- a/src/app/inventory.rs
+++ b/src/app/inventory.rs
@@ -1,5 +1,5 @@
-use crate::api::types::{CraftingRecipe, CraftingRecipeIngredient, ProbeInventory};
 use super::*;
+use crate::api::types::{CraftingRecipe, CraftingRecipeIngredient, ProbeInventory};
 
 /// Active items (manny, atomic printer) are listed individually in the
 /// inventory panel; passive items are grouped by type.
@@ -26,7 +26,8 @@ impl AppState {
     }
 
     pub fn mine_max_amount(&self) -> f64 {
-        self.probe.as_ref()
+        self.probe
+            .as_ref()
             .map(|p| (p.inventory.free_capacity * 10000.0).round() / 10000.0)
             .unwrap_or(0.30)
             .max(0.0)
@@ -48,7 +49,9 @@ impl AppState {
         for item in inv.items.iter().filter(|i| !is_active_item(&i.item_type)) {
             if !seen.contains(&item.item_type.as_str()) {
                 seen.push(&item.item_type);
-                out.push(InventoryRow::PassiveGroup { item_type: item.item_type.clone() });
+                out.push(InventoryRow::PassiveGroup {
+                    item_type: item.item_type.clone(),
+                });
             }
         }
         out
@@ -68,19 +71,21 @@ impl AppState {
     pub fn inventory_prev(&mut self) {
         let count = self.inventory_rows().len();
         if count > 0 {
-            self.inventory_selection = self
-                .inventory_selection
-                .checked_sub(1)
-                .unwrap_or(count - 1);
+            self.inventory_selection = self.inventory_selection.checked_sub(1).unwrap_or(count - 1);
         }
     }
 
     /// Build the jettison wizard state for the currently selected inventory row.
     pub fn jettison_for_selected(&self) -> Result<JettisonInput, String> {
-        let Some(probe) = &self.probe else { return Err("no probe data".into()) };
+        let Some(probe) = &self.probe else {
+            return Err("no probe data".into());
+        };
         match self.selected_inventory_row() {
             Some(InventoryRow::Stock { id }) => {
-                let stock = probe.inventory.resource_stocks.iter()
+                let stock = probe
+                    .inventory
+                    .resource_stocks
+                    .iter()
                     .find(|s| s.id == id)
                     .ok_or_else(|| "stock not found".to_string())?;
                 if stock.amount <= 0.0 {
@@ -95,13 +100,18 @@ impl AppState {
                 })
             }
             Some(InventoryRow::ActiveItem { id }) => {
-                let item = probe.inventory.items.iter()
+                let item = probe
+                    .inventory
+                    .items
+                    .iter()
                     .find(|i| i.id == id)
                     .ok_or_else(|| "item not found".to_string())?;
                 if item.item_type != "manny" {
                     return Err("only resource stocks and mannies can be jettisoned".into());
                 }
-                let in_probe = item.location.as_ref()
+                let in_probe = item
+                    .location
+                    .as_ref()
                     .map(|l| l.location_type == crate::api::types::MannyLocationType::Probe)
                     .unwrap_or(false);
                 if !in_probe {
@@ -117,7 +127,10 @@ impl AppState {
                 })
             }
             Some(InventoryRow::PassiveGroup { item_type }) if item_type == "scut_relay" => {
-                let item = probe.inventory.items.iter()
+                let item = probe
+                    .inventory
+                    .items
+                    .iter()
                     .find(|i| i.item_type == "scut_relay")
                     .ok_or_else(|| "no SCUT relay in inventory".to_string())?;
                 Ok(JettisonInput::ConfirmRelay {
@@ -154,14 +167,18 @@ impl AppState {
     }
 
     pub fn jettison_fill_max(&mut self) {
-        if let ActiveWizard::Jettison(JettisonInput::EnterAmount { buf, max_amount, error, .. }) = &mut self.active_wizard {
+        if let ActiveWizard::Jettison(JettisonInput::EnterAmount {
+            buf, max_amount, error, ..
+        }) = &mut self.active_wizard
+        {
             *buf = format!("{max_amount:.4}");
             *error = None;
         }
     }
 
     pub fn has_atomic_printer(&self) -> bool {
-        self.probe.as_ref()
+        self.probe
+            .as_ref()
             .map(|p| p.inventory.items.iter().any(|i| i.item_type == "atomic_3d_printer"))
             .unwrap_or(false)
     }
@@ -178,13 +195,15 @@ impl AppState {
     }
 
     pub fn atomic_printer_recipes(&self) -> Vec<&CraftingRecipe> {
-        self.recipes.iter()
+        self.recipes
+            .iter()
             .filter(|r| r.craftable_by.iter().any(|c| c == "atomic_3d_printer"))
             .collect()
     }
 
     pub fn manny_craft_recipes(&self) -> Vec<&CraftingRecipe> {
-        self.recipes.iter()
+        self.recipes
+            .iter()
             .filter(|r| r.craftable_by.iter().any(|c| c == "manny"))
             .collect()
     }
@@ -194,7 +213,9 @@ impl AppState {
     /// selection order of the fabrication wizard. A recipe craftable by both
     /// fabricators appears once per section (either route is valid).
     pub fn fabrication_recipes(&self) -> Vec<(Fabricator, &CraftingRecipe)> {
-        self.atomic_printer_recipes().into_iter().map(|r| (Fabricator::AtomicPrinter, r))
+        self.atomic_printer_recipes()
+            .into_iter()
+            .map(|r| (Fabricator::AtomicPrinter, r))
             .chain(self.manny_craft_recipes().into_iter().map(|r| (Fabricator::Manny, r)))
             .collect()
     }
@@ -204,7 +225,12 @@ impl AppState {
     pub fn recipe_ingredient_have(&self, ing: &CraftingRecipeIngredient) -> f64 {
         let Some(probe) = &self.probe else { return 0.0 };
         if ing.unit == "item" {
-            probe.inventory.items.iter().filter(|it| it.item_type == ing.ingredient_type).count() as f64
+            probe
+                .inventory
+                .items
+                .iter()
+                .filter(|it| it.item_type == ing.ingredient_type)
+                .count() as f64
         } else if ing.ingredient_type == "deuterium" {
             // Deuterium lives in the fuel tank, not in resource_stocks. The tank
             // level is a percentage (0..max_deuterium) where 100% of a size-1 tank
@@ -223,12 +249,17 @@ impl AppState {
 
     /// Whether every ingredient of a recipe is currently on hand.
     pub fn recipe_affordable(&self, recipe: &CraftingRecipe) -> bool {
-        recipe.ingredients.iter().all(|ing| self.recipe_ingredient_have(ing) >= ing.quantity)
+        recipe
+            .ingredients
+            .iter()
+            .all(|ing| self.recipe_ingredient_have(ing) >= ing.quantity)
     }
 
     /// Whether every ingredient of a probe improvement is currently on hand.
     pub fn improvement_affordable(&self, imp: &crate::api::types::ProbeImprovement) -> bool {
-        imp.ingredients.iter().all(|ing| self.recipe_ingredient_have(ing) >= ing.quantity)
+        imp.ingredients
+            .iter()
+            .all(|ing| self.recipe_ingredient_have(ing) >= ing.quantity)
     }
 
     /// Whether at least one probe improvement is installable right now (unlocked
@@ -238,7 +269,11 @@ impl AppState {
     }
 
     pub fn inventory_waypoint_bookmark_id(&self) -> Option<String> {
-        self.probe.as_ref()?.inventory.items.iter()
+        self.probe
+            .as_ref()?
+            .inventory
+            .items
+            .iter()
             .find(|i| i.item_type == "waypoint_bookmark")
             .map(|i| i.id.clone())
     }

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -90,7 +90,11 @@ impl LogEvent {
 
     /// "Detached container «container», {set adrift | hidden on an asteroid}."
     pub fn detach_container(container: &str, hidden_on_asteroid: bool, probe_id: Option<u64>) -> Self {
-        let placement = if hidden_on_asteroid { "hidden on an asteroid" } else { "set adrift" };
+        let placement = if hidden_on_asteroid {
+            "hidden on an asteroid"
+        } else {
+            "set adrift"
+        };
         Self::action(
             kind::CONTAINER,
             format!("Detached container «{container}», {placement}."),
@@ -100,11 +104,7 @@ impl LogEvent {
 
     /// "Installed waypoint «name»."
     pub fn deploy_waypoint(name: &str, probe_id: Option<u64>) -> Self {
-        Self::action(
-            kind::WAYPOINT,
-            format!("Installed waypoint «{name}»."),
-            probe_id,
-        )
+        Self::action(kind::WAYPOINT, format!("Installed waypoint «{name}»."), probe_id)
     }
 
     pub fn repair(pct: f64, probe_id: Option<u64>) -> Self {
@@ -113,7 +113,11 @@ impl LogEvent {
 
     /// Fabrication order, on the atomic printer or at the manny bay.
     pub fn craft(recipe: &str, atomic_printer: bool, probe_id: Option<u64>) -> Self {
-        let bay = if atomic_printer { "on the atomic printer" } else { "at the manny bay" };
+        let bay = if atomic_printer {
+            "on the atomic printer"
+        } else {
+            "at the manny bay"
+        };
         Self::action(kind::CRAFT, format!("Queued «{recipe}» {bay}."), probe_id)
     }
 
@@ -131,7 +135,11 @@ impl LogEvent {
     }
 
     pub fn recover(container: &str, probe_id: Option<u64>) -> Self {
-        Self::action(kind::RECOVER, format!("Sent a manny to recover container «{container}»."), probe_id)
+        Self::action(
+            kind::RECOVER,
+            format!("Sent a manny to recover container «{container}»."),
+            probe_id,
+        )
     }
 
     pub fn rename_manny(old: &str, new: &str, probe_id: Option<u64>) -> Self {
@@ -159,7 +167,11 @@ impl LogEvent {
     }
 
     pub fn refuel(probe_id: Option<u64>) -> Self {
-        Self::action(kind::REFUEL, "Sent a manny to refill the deuterium tank.".to_string(), probe_id)
+        Self::action(
+            kind::REFUEL,
+            "Sent a manny to refill the deuterium tank.".to_string(),
+            probe_id,
+        )
     }
 
     /// "Dispatched a manny to ferry {amount}% deuterium to «target»."
@@ -172,15 +184,27 @@ impl LogEvent {
     }
 
     pub fn assemble_probe(probe_id: Option<u64>) -> Self {
-        Self::action(kind::ASSEMBLE, "Began assembling a new drone (~3h).".to_string(), probe_id)
+        Self::action(
+            kind::ASSEMBLE,
+            "Began assembling a new drone (~3h).".to_string(),
+            probe_id,
+        )
     }
 
     pub fn drop_cargo(probe_id: Option<u64>) -> Self {
-        Self::action(kind::DROP_CARGO, "Dumped a manny's onboard cargo.".to_string(), probe_id)
+        Self::action(
+            kind::DROP_CARGO,
+            "Dumped a manny's onboard cargo.".to_string(),
+            probe_id,
+        )
     }
 
     pub fn mind_snapshot(probe_id: Option<u64>) -> Self {
-        Self::action(kind::MIND_SNAPSHOT, "Reassigned the mind snapshot to a fresh probe.".to_string(), probe_id)
+        Self::action(
+            kind::MIND_SNAPSHOT,
+            "Reassigned the mind snapshot to a fresh probe.".to_string(),
+            probe_id,
+        )
     }
 
     pub fn mission_abandon(title: &str, probe_id: Option<u64>) -> Self {
@@ -200,7 +224,11 @@ impl LogEvent {
     }
 
     pub fn container_rules(container: &str, probe_id: Option<u64>) -> Self {
-        Self::action(kind::RULES, format!("Updated routing rules for «{container}»."), probe_id)
+        Self::action(
+            kind::RULES,
+            format!("Updated routing rules for «{container}»."),
+            probe_id,
+        )
     }
 }
 

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -1,5 +1,5 @@
-use crate::api::types::{Manny, MannyTaskVisibility, SectorObject, SectorObjectType};
 use super::*;
+use crate::api::types::{Manny, MannyTaskVisibility, SectorObject, SectorObjectType};
 
 impl AppState {
     pub fn manny_next(&mut self) {
@@ -13,16 +13,14 @@ impl AppState {
     pub fn manny_prev(&mut self) {
         if let Some(mannies) = &self.mannies {
             if !mannies.is_empty() {
-                self.mannies_selection = self
-                    .mannies_selection
-                    .checked_sub(1)
-                    .unwrap_or(mannies.len() - 1);
+                self.mannies_selection = self.mannies_selection.checked_sub(1).unwrap_or(mannies.len() - 1);
             }
         }
     }
 
     pub fn repair_max_percent(&self) -> f64 {
-        self.probe.as_ref()
+        self.probe
+            .as_ref()
             .and_then(|p| p.systems.as_ref())
             .and_then(|s| s.integrity_percent)
             .map(|i| (100.0_f64 - i).max(0.0))
@@ -30,9 +28,12 @@ impl AppState {
     }
 
     pub fn repair_metals_stock(&self) -> f64 {
-        self.probe.as_ref()
+        self.probe
+            .as_ref()
             .map(|p| {
-                p.inventory.resource_stocks.iter()
+                p.inventory
+                    .resource_stocks
+                    .iter()
                     .find(|s| s.stock_type == "metals")
                     .map(|s| s.amount)
                     .unwrap_or(0.0)
@@ -127,7 +128,9 @@ impl AppState {
     }
 
     pub fn set_transfer_deuterium_error(&mut self, msg: String) {
-        if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { error, .. }) = &mut self.active_wizard {
+        if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { error, .. }) =
+            &mut self.active_wizard
+        {
             *error = Some(msg);
         }
     }
@@ -157,7 +160,8 @@ impl AppState {
     }
 
     pub fn unread_message_count(&self) -> usize {
-        self.messages.iter()
+        self.messages
+            .iter()
             .filter(|m| m.status == crate::api::types::MessageStatus::Unread)
             .count()
     }
@@ -167,7 +171,9 @@ impl AppState {
     pub fn collect_message_recipients(&self) -> Vec<(String, crate::api::types::EndpointId, String)> {
         use crate::api::types::EndpointId;
         let mut out = Vec::new();
-        let Some(sector) = self.probe_current_sector_scan() else { return out };
+        let Some(sector) = self.probe_current_sector_scan() else {
+            return out;
+        };
         if let Some(probes) = sector.probes.as_ref() {
             for p in probes {
                 out.push(("probe".to_string(), EndpointId::Probe(p.id), p.name.clone()));
@@ -196,22 +202,24 @@ impl AppState {
         self.probe_current_sector_scan()
             .and_then(|s| s.objects.as_ref())
             .is_some_and(|objects| {
-                objects.iter().any(|o| {
-                    matches!(o.object_type, SectorObjectType::DeuteriumRefuelStation)
-                })
+                objects
+                    .iter()
+                    .any(|o| matches!(o.object_type, SectorObjectType::DeuteriumRefuelStation))
             })
     }
 
     pub fn collect_mineable_candidates(&self) -> Vec<(String, String)> {
-        let Some(sector) = self.probe_current_sector_scan() else { return Vec::new() };
-        let Some(objects) = sector.objects.as_ref() else { return Vec::new() };
+        let Some(sector) = self.probe_current_sector_scan() else {
+            return Vec::new();
+        };
+        let Some(objects) = sector.objects.as_ref() else {
+            return Vec::new();
+        };
         let mut out: Vec<(String, String)> = Vec::new();
         for o in objects {
             // Asteroids nested under a parent object (e.g. a solar system).
             for t in o.minable_targets.iter().flatten() {
-                if matches!(t.object_type, SectorObjectType::Asteroid)
-                    && !out.iter().any(|(id, _)| id == &t.id)
-                {
+                if matches!(t.object_type, SectorObjectType::Asteroid) && !out.iter().any(|(id, _)| id == &t.id) {
                     out.push((t.id.clone(), t.name.clone().unwrap_or_else(|| "unnamed".into())));
                 }
             }
@@ -239,7 +247,9 @@ impl AppState {
     /// Objects a Manny can inspect in the probe's current sector (API v65):
     /// asteroids plus top-level dormant constructs and detached containers.
     pub fn collect_inspectable_candidates(&self) -> Vec<(String, String)> {
-        let Some(sector) = self.probe_current_sector_scan() else { return Vec::new() };
+        let Some(sector) = self.probe_current_sector_scan() else {
+            return Vec::new();
+        };
         let mut out = self.collect_asteroid_candidates_in(sector);
         if let Some(objects) = sector.objects.as_ref() {
             for o in objects {
@@ -267,13 +277,19 @@ impl AppState {
         Some(sector)
             .and_then(|s| s.objects.as_ref())
             .map(|objects| {
-                objects.iter()
+                objects
+                    .iter()
                     .flat_map(|o| {
                         let direct = if matches!(o.object_type, SectorObjectType::Asteroid) {
-                            o.id.as_ref().map(|id| vec![(id.clone(), o.name.clone().unwrap_or_else(|| "unnamed".into()))])
+                            o.id.as_ref()
+                                .map(|id| vec![(id.clone(), o.name.clone().unwrap_or_else(|| "unnamed".into()))])
                                 .unwrap_or_default()
-                        } else { vec![] };
-                        let nested: Vec<(String, String)> = o.bookmark_targets.iter()
+                        } else {
+                            vec![]
+                        };
+                        let nested: Vec<(String, String)> = o
+                            .bookmark_targets
+                            .iter()
                             .filter(|t| matches!(t.object_type, SectorObjectType::Asteroid))
                             .map(|t| (t.id.clone(), t.name.clone().unwrap_or_else(|| "unnamed".into())))
                             .collect();
@@ -288,7 +304,8 @@ impl AppState {
         self.probe_current_sector_scan()
             .and_then(|s| s.objects.as_ref())
             .map(|objects| {
-                objects.iter()
+                objects
+                    .iter()
                     .filter(|o| matches!(o.object_type, SectorObjectType::Manny))
                     .map(|o| {
                         let id = o.id.clone().unwrap_or_default();
@@ -341,12 +358,12 @@ impl AppState {
     }
 
     pub fn collect_idle_onboard_mannies(&self) -> Vec<(String, String)> {
-        self.mannies.as_ref()
+        self.mannies
+            .as_ref()
             .map(|ms| {
                 ms.iter()
                     .filter(|m| {
-                        m.location.location_type == crate::api::types::MannyLocationType::Probe
-                            && m.can_receive_orders
+                        m.location.location_type == crate::api::types::MannyLocationType::Probe && m.can_receive_orders
                     })
                     .map(|m| (m.id.clone(), m.name.clone()))
                     .collect()
@@ -361,8 +378,7 @@ impl AppState {
             ms.iter()
                 .enumerate()
                 .filter(|(_, m)| {
-                    m.location.location_type == crate::api::types::MannyLocationType::Probe
-                        && m.can_receive_orders
+                    m.location.location_type == crate::api::types::MannyLocationType::Probe && m.can_receive_orders
                 })
                 .map(|(i, _)| i)
                 .collect()
@@ -391,11 +407,15 @@ impl AppState {
         self.probe_current_sector_scan()
             .and_then(|s| s.objects.as_ref())
             .map(|objects| {
-                objects.iter()
+                objects
+                    .iter()
                     .filter(|o| o.id.is_some())
                     .map(|o: &SectorObject| {
                         let id = o.id.clone().unwrap();
-                        let name = o.name.clone().unwrap_or_else(|| format!("{:?}", o.object_type).to_lowercase());
+                        let name = o
+                            .name
+                            .clone()
+                            .unwrap_or_else(|| format!("{:?}", o.object_type).to_lowercase());
                         (id, name)
                     })
                     .collect()
@@ -432,9 +452,12 @@ impl AppState {
     }
 
     pub fn collect_detachable_containers(&self) -> Vec<(String, String)> {
-        self.probe.as_ref()
+        self.probe
+            .as_ref()
             .map(|p| {
-                p.inventory.containers.iter()
+                p.inventory
+                    .containers
+                    .iter()
                     .filter(|c| c.kind != "probe")
                     .map(|c| (c.id.clone(), c.label.clone()))
                     .collect()
@@ -446,9 +469,12 @@ impl AppState {
     /// (API v81 `assemble-probe` consumes two of them). Excludes the probe's
     /// own container and any that still hold cargo.
     pub fn collect_empty_containers(&self) -> Vec<(String, String)> {
-        self.probe.as_ref()
+        self.probe
+            .as_ref()
             .map(|p| {
-                p.inventory.containers.iter()
+                p.inventory
+                    .containers
+                    .iter()
                     .filter(|c| c.kind != "probe" && c.used_capacity == 0.0)
                     .map(|c| (c.id.clone(), c.label.clone()))
                     .collect()
@@ -470,7 +496,8 @@ impl AppState {
         Some(sector)
             .and_then(|s| s.objects.as_ref())
             .map(|objects| {
-                objects.iter()
+                objects
+                    .iter()
                     .filter(|o| matches!(o.object_type, SectorObjectType::DetachedContainer))
                     .map(|o| {
                         let id = o.id.clone().unwrap_or_default();
@@ -486,11 +513,13 @@ impl AppState {
     /// to asteroid selection (or abort with an error if it has no asteroids).
     pub fn remote_mine_sector_loaded(&mut self, x: i32, y: i32, z: i32) {
         let (manny_id, manny_name) = match &self.active_wizard {
-            ActiveWizard::RemoteMine(RemoteMineInput::Loading { manny_id, manny_name, x: lx, y: ly, z: lz })
-                if (*lx, *ly, *lz) == (x, y, z) =>
-            {
-                (manny_id.clone(), manny_name.clone())
-            }
+            ActiveWizard::RemoteMine(RemoteMineInput::Loading {
+                manny_id,
+                manny_name,
+                x: lx,
+                y: ly,
+                z: lz,
+            }) if (*lx, *ly, *lz) == (x, y, z) => (manny_id.clone(), manny_name.clone()),
             _ => return,
         };
         let candidates = match self.sector_observation_at(x, y, z) {
@@ -533,11 +562,7 @@ impl AppState {
 
     /// Relative sector coords of a Manny from its location payload.
     pub fn manny_sector_coords(&self, manny: &Manny) -> Option<(i32, i32, i32)> {
-        let v = manny
-            .location
-            .sector
-            .as_ref()?
-            .get("relative")?;
+        let v = manny.location.sector.as_ref()?.get("relative")?;
         Some((
             v.get("x")?.as_f64()? as i32,
             v.get("y")?.as_f64()? as i32,

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,7 +1,7 @@
 use crate::api::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert,
-    ProbeImprovement, ProbeInventory, ProbeListResponse, ProbeMessage, ProbeMovement,
-    ProbeSentMessage, ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert, ProbeImprovement,
+    ProbeInventory, ProbeListResponse, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork, SectorObservation,
+    StorageContainer, VisitedSector,
 };
 
 pub enum ApiMessage {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,10 +12,10 @@ mod map;
 mod message;
 mod mode;
 mod scan;
-mod travel;
-mod waypoints;
 #[cfg(test)]
 mod tests;
+mod travel;
+mod waypoints;
 
 pub use boot::{BOOT_CHARS_PER_FRAME, BOOT_LINE_STRIDE};
 pub use color::*;
@@ -31,9 +31,9 @@ pub use scan::*;
 pub use waypoints::*;
 
 use crate::api::types::{
-    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe,
-    ProbeAlert, ProbeImprovement, ProbeInventory, ProbeMessage, ProbeSentMessage, ProbeSummary,
-    ScutNetwork, SectorObservation, StorageContainer, VisitedSector,
+    ContainerInventory, CraftingRecipe, DamageWarningRule, Manny, Mission, Probe, ProbeAlert, ProbeImprovement,
+    ProbeInventory, ProbeMessage, ProbeSentMessage, ProbeSummary, ScutNetwork, SectorObservation, StorageContainer,
+    VisitedSector,
 };
 use chrono::{DateTime, Local, Utc};
 use tokio::time::Instant;
@@ -287,8 +287,7 @@ impl AppState {
 
     pub fn set_storage_move_error(&mut self, msg: String) {
         if let ActiveWizard::StorageMove(
-            StorageMoveInput::ConfigureResource { error, .. }
-            | StorageMoveInput::ConfigureItem { error, .. },
+            StorageMoveInput::ConfigureResource { error, .. } | StorageMoveInput::ConfigureItem { error, .. },
         ) = &mut self.active_wizard
         {
             *error = Some(msg);
@@ -308,7 +307,9 @@ impl AppState {
     }
 
     pub fn set_drop_container_error(&mut self, msg: String) {
-        if let ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet { error, .. }) = &mut self.active_wizard {
+        if let ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet { error, .. }) =
+            &mut self.active_wizard
+        {
             *error = Some(msg);
         }
     }
@@ -442,9 +443,7 @@ impl AppState {
     pub fn next_refresh_instant(&self) -> Instant {
         match self.movement_arrival {
             Some(arrival) => {
-                let remaining = (arrival - Utc::now())
-                    .to_std()
-                    .unwrap_or(std::time::Duration::ZERO);
+                let remaining = (arrival - Utc::now()).to_std().unwrap_or(std::time::Duration::ZERO);
                 Instant::now() + remaining
             }
             None => Instant::now() + std::time::Duration::from_secs(86400),
@@ -452,7 +451,6 @@ impl AppState {
     }
 
     pub fn seconds_until_refresh(&self) -> Option<i64> {
-        self.movement_arrival
-            .map(|a| (a - Utc::now()).num_seconds().max(0))
+        self.movement_arrival.map(|a| (a - Utc::now()).num_seconds().max(0))
     }
 }

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -178,7 +178,11 @@ impl super::AppState {
                 }
             },
         ];
-        ContextMenu { title: "MAP".into(), items, cursor: 0 }
+        ContextMenu {
+            title: "MAP".into(),
+            items,
+            cursor: 0,
+        }
     }
 
     fn scanner_context_menu(&self) -> ContextMenu {
@@ -229,7 +233,11 @@ impl super::AppState {
             },
         ];
         let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
-        ContextMenu { title: "SCANNER".into(), items, cursor }
+        ContextMenu {
+            title: "SCANNER".into(),
+            items,
+            cursor,
+        }
     }
 
     fn storage_context_menu(&self) -> Option<ContextMenu> {
@@ -273,8 +281,7 @@ impl super::AppState {
                     action: MenuAction::SetDefaultProbe,
                     label: "Set as default probe".into(),
                     enabled: active.is_reachable,
-                    disabled_reason: (!active.is_reachable)
-                        .then(|| "out of SCUT range".to_string()),
+                    disabled_reason: (!active.is_reachable).then(|| "out of SCUT range".to_string()),
                 });
             }
         }
@@ -311,7 +318,11 @@ impl super::AppState {
             });
         }
         let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
-        Some(ContextMenu { title: "PROBE".into(), items, cursor })
+        Some(ContextMenu {
+            title: "PROBE".into(),
+            items,
+            cursor,
+        })
     }
 
     fn inventory_context_menu(&self) -> ContextMenu {
@@ -356,7 +367,11 @@ impl super::AppState {
             });
         }
         let cursor = items.iter().position(|i| i.enabled).unwrap_or(0);
-        ContextMenu { title: "INVENTORY".into(), items, cursor }
+        ContextMenu {
+            title: "INVENTORY".into(),
+            items,
+            cursor,
+        }
     }
 
     fn mannies_context_menu(&self) -> Option<ContextMenu> {

--- a/src/app/scan.rs
+++ b/src/app/scan.rs
@@ -1,6 +1,6 @@
+use super::*;
 use crate::api::types::{DangerLevel, ScutRelayStatus, SectorObjectType, SectorObservation};
 use chrono::Utc;
-use super::*;
 
 /// Reserves (presence flags + amounts, indexed as [`RESOURCE_TYPES`]) paired
 /// with the danger level for a sector object — the inputs a pick-row label needs.
@@ -40,9 +40,11 @@ pub fn sector_matches_filter(s: &SectorObservation, f: ScanFilter) -> bool {
     match f {
         ScanFilter::All => true,
         ScanFilter::Objects => s.objects.as_ref().is_some_and(|o| !o.is_empty()),
-        ScanFilter::Minable => s.objects.iter().flatten().any(|o| {
-            o.minable_targets.as_ref().is_some_and(|t| !t.is_empty())
-        }),
+        ScanFilter::Minable => s
+            .objects
+            .iter()
+            .flatten()
+            .any(|o| o.minable_targets.as_ref().is_some_and(|t| !t.is_empty())),
         ScanFilter::Danger => {
             let observed = s.objects.iter().flatten().any(|o| {
                 matches!(o.object_type, crate::api::types::SectorObjectType::BlackHole)
@@ -191,9 +193,7 @@ impl AppState {
     fn danger_in(sector: &SectorObservation, object_id: &str) -> Option<DangerLevel> {
         let objs = sector.objects.as_ref()?;
         for o in objs {
-            if o.id.as_deref() == Some(object_id)
-                || o.minable_targets.iter().flatten().any(|t| t.id == object_id)
-            {
+            if o.id.as_deref() == Some(object_id) || o.minable_targets.iter().flatten().any(|t| t.id == object_id) {
                 return o.danger_level.clone();
             }
         }
@@ -267,32 +267,41 @@ impl AppState {
         };
         for o in objects {
             if let Some(id) = &o.id {
-                push(&mut out, ScannerObjectEntry {
-                    id: id.clone(),
-                    name: o.name.clone().unwrap_or_default(),
-                    object_type: o.object_type.clone(),
-                    provenance: ObjectProvenance::TopLevel,
-                    attached: false,
-                });
+                push(
+                    &mut out,
+                    ScannerObjectEntry {
+                        id: id.clone(),
+                        name: o.name.clone().unwrap_or_default(),
+                        object_type: o.object_type.clone(),
+                        provenance: ObjectProvenance::TopLevel,
+                        attached: false,
+                    },
+                );
             }
             for t in o.minable_targets.iter().flatten() {
-                push(&mut out, ScannerObjectEntry {
-                    id: t.id.clone(),
-                    name: t.name.clone().unwrap_or_default(),
-                    object_type: t.object_type.clone(),
-                    provenance: ObjectProvenance::MinableTarget,
-                    attached: false,
-                });
-            }
-            for t in &o.bookmark_targets {
-                if matches!(t.object_type, SectorObjectType::Asteroid) {
-                    push(&mut out, ScannerObjectEntry {
+                push(
+                    &mut out,
+                    ScannerObjectEntry {
                         id: t.id.clone(),
                         name: t.name.clone().unwrap_or_default(),
                         object_type: t.object_type.clone(),
-                        provenance: ObjectProvenance::BookmarkTarget,
+                        provenance: ObjectProvenance::MinableTarget,
                         attached: false,
-                    });
+                    },
+                );
+            }
+            for t in &o.bookmark_targets {
+                if matches!(t.object_type, SectorObjectType::Asteroid) {
+                    push(
+                        &mut out,
+                        ScannerObjectEntry {
+                            id: t.id.clone(),
+                            name: t.name.clone().unwrap_or_default(),
+                            object_type: t.object_type.clone(),
+                            provenance: ObjectProvenance::BookmarkTarget,
+                            attached: false,
+                        },
+                    );
                 }
             }
         }
@@ -324,14 +333,12 @@ impl AppState {
                 .and_then(|o| o.target_object_id.clone())
         };
         let is_container = |id: &str| -> bool {
-            objects.iter().any(|o| {
-                o.id.as_deref() == Some(id)
-                    && matches!(o.object_type, SectorObjectType::DetachedContainer)
-            })
+            objects
+                .iter()
+                .any(|o| o.id.as_deref() == Some(id) && matches!(o.object_type, SectorObjectType::DetachedContainer))
         };
         let mut hosts: Vec<ScannerObjectEntry> = Vec::new();
-        let mut hosted: std::collections::HashMap<String, Vec<ScannerObjectEntry>> =
-            std::collections::HashMap::new();
+        let mut hosted: std::collections::HashMap<String, Vec<ScannerObjectEntry>> = std::collections::HashMap::new();
         let mut drifting: Vec<ScannerObjectEntry> = Vec::new();
         for mut e in out.into_iter() {
             match host_of(&e.id) {
@@ -395,9 +402,7 @@ impl AppState {
             }
             _ => {}
         }
-        if entry.provenance == ObjectProvenance::TopLevel
-            && self.inventory_waypoint_bookmark_id().is_some()
-        {
+        if entry.provenance == ObjectProvenance::TopLevel && self.inventory_waypoint_bookmark_id().is_some() {
             actions.push(ObjectAction::DeployWaypoint);
         }
         actions
@@ -415,7 +420,8 @@ impl AppState {
         self.probe_current_sector_scan()
             .and_then(|s| s.objects.as_ref())
             .and_then(|objects| {
-                objects.iter()
+                objects
+                    .iter()
                     .find(|o| o.id.as_deref() == Some(id))
                     .and_then(|o| o.status.clone())
             })
@@ -449,13 +455,19 @@ impl AppState {
     }
 
     pub(crate) fn probe_current_sector_scan(&self) -> Option<&SectorObservation> {
-        let current_pos = self.probe.as_ref()
+        let current_pos = self
+            .probe
+            .as_ref()
             .and_then(|p| p.sector.as_ref())
             .and_then(|s| s.relative.as_ref())
             .map(|r| (r.x as i64, r.y as i64, r.z as i64));
         if let Some(pos) = current_pos {
             self.scan_history.iter().find(|s| {
-                (s.relative_coordinates.x as i64, s.relative_coordinates.y as i64, s.relative_coordinates.z as i64) == pos
+                (
+                    s.relative_coordinates.x as i64,
+                    s.relative_coordinates.y as i64,
+                    s.relative_coordinates.z as i64,
+                ) == pos
             })
         } else {
             self.scan_history.first()
@@ -533,7 +545,9 @@ impl AppState {
     pub fn batch_tick(&mut self) {
         if let Some(ref mut n) = self.scan_batch {
             *n = n.saturating_sub(1);
-            if *n == 0 { self.scan_batch = None; }
+            if *n == 0 {
+                self.scan_batch = None;
+            }
         }
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 fn make_sector(x: f64, y: f64, z: f64) -> SectorObservation {
-    serde_json::from_str(&format!(r#"{{
+    serde_json::from_str(&format!(
+        r#"{{
         "relativeCoordinates": {{"x": {x}, "y": {y}, "z": {z}}},
         "distance": 1,
         "knowledgeLevel": "detailed",
@@ -19,11 +20,14 @@ fn make_sector(x: f64, y: f64, z: f64) -> SectorObservation {
             "requiredResidenceSeconds": 60,
             "scanQuality": 1.0
         }}
-    }}"#)).unwrap()
+    }}"#
+    ))
+    .unwrap()
 }
 
 fn make_probe(free_capacity: f64, sector_x: f64, sector_y: f64, sector_z: f64) -> Probe {
-    serde_json::from_str(&format!(r#"{{
+    serde_json::from_str(&format!(
+        r#"{{
         "id": 1,
         "name": "test",
         "status": "idle",
@@ -41,7 +45,10 @@ fn make_probe(free_capacity: f64, sector_x: f64, sector_y: f64, sector_z: f64) -
             "externalTanks": [],
             "containers": []
         }}
-    }}"#, used = 10.0 - free_capacity)).unwrap()
+    }}"#,
+        used = 10.0 - free_capacity
+    ))
+    .unwrap()
 }
 
 // ── parse_scan_coords ─────────────────────────────────────────────────────
@@ -152,7 +159,10 @@ fn travel_submit_invalid_input_is_noop() {
     let mut state = AppState::default();
     state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("abc".into()));
     state.travel_submit();
-    assert!(matches!(state.active_wizard, ActiveWizard::Travel(TravelInput::Typing(_))));
+    assert!(matches!(
+        state.active_wizard,
+        ActiveWizard::Travel(TravelInput::Typing(_))
+    ));
 }
 
 #[test]
@@ -176,7 +186,10 @@ fn travel_relative_without_probe_position_is_noop() {
     state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("+2 0 0".into()));
     assert_eq!(state.resolve_travel_target(), None);
     state.travel_submit();
-    assert!(matches!(state.active_wizard, ActiveWizard::Travel(TravelInput::Typing(_))));
+    assert!(matches!(
+        state.active_wizard,
+        ActiveWizard::Travel(TravelInput::Typing(_))
+    ));
 }
 
 #[test]
@@ -207,7 +220,11 @@ fn scan_hist_nav_empty_is_noop() {
 #[test]
 fn scan_hist_next_advances_index() {
     let mut state = AppState::default();
-    state.scan_history = vec![make_sector(0., 0., 0.), make_sector(2., 0., 0.), make_sector(4., 0., 0.)];
+    state.scan_history = vec![
+        make_sector(0., 0., 0.),
+        make_sector(2., 0., 0.),
+        make_sector(4., 0., 0.),
+    ];
     state.scan_hist_next();
     assert_eq!(state.scan_history_idx, 1);
     state.scan_hist_next();
@@ -265,7 +282,8 @@ fn mine_max_amount_clamps_to_zero() {
 // ── inventory_rows / jettison_for_selected ────────────────────────────────
 
 fn probe_with_inventory(items_json: &str, stocks_json: &str) -> Probe {
-    serde_json::from_str(&format!(r#"{{
+    serde_json::from_str(&format!(
+        r#"{{
         "id": 1, "name": "test", "status": "idle",
         "fuel": {{"deuterium": 100.0}}, "sensorMode": "normal",
         "sector": null, "movement": null, "systems": null,
@@ -275,7 +293,9 @@ fn probe_with_inventory(items_json: &str, stocks_json: &str) -> Probe {
             "resourceStocks": {stocks_json},
             "externalTanks": [], "containers": []
         }}
-    }}"#)).unwrap()
+    }}"#
+    ))
+    .unwrap()
 }
 
 const STOCK_METALS: &str = r#"[{
@@ -285,7 +305,8 @@ const STOCK_METALS: &str = r#"[{
 
 fn manny_item(task: Option<&str>) -> String {
     let task_json = task.map(|t| format!("\"{t}\"")).unwrap_or("null".into());
-    format!(r#"{{
+    format!(
+        r#"{{
         "id": "manny-1", "type": "manny", "name": "Manny-1",
         "containerSpace": 1.0,
         "currentTask": {task_json},
@@ -293,7 +314,8 @@ fn manny_item(task: Option<&str>) -> String {
         "location": {{"type": "probe", "sector": null}},
         "cargo": null,
         "container": null
-    }}"#)
+    }}"#
+    )
 }
 
 #[test]
@@ -306,7 +328,8 @@ fn inventory_rows_no_probe_is_empty() {
 #[test]
 fn inventory_rows_order_stocks_active_passive() {
     let mut state = AppState::default();
-    let items = format!(r#"[
+    let items = format!(
+        r#"[
         {{"id": "wb-1", "type": "waypoint_bookmark", "name": "Bookmark",
           "containerSpace": 0.1, "currentTask": null, "taskProgressPercent": 0.0,
           "location": null, "cargo": null, "container": null}},
@@ -314,13 +337,25 @@ fn inventory_rows_order_stocks_active_passive() {
           "containerSpace": 0.1, "currentTask": null, "taskProgressPercent": 0.0,
           "location": null, "cargo": null, "container": null}},
         {}
-    ]"#, manny_item(None));
+    ]"#,
+        manny_item(None)
+    );
     state.probe = Some(probe_with_inventory(&items, STOCK_METALS));
     let rows = state.inventory_rows();
     assert_eq!(rows.len(), 3);
-    assert_eq!(rows[0], InventoryRow::Stock { id: "stock-metals".into() });
+    assert_eq!(
+        rows[0],
+        InventoryRow::Stock {
+            id: "stock-metals".into()
+        }
+    );
     assert_eq!(rows[1], InventoryRow::ActiveItem { id: "manny-1".into() });
-    assert_eq!(rows[2], InventoryRow::PassiveGroup { item_type: "waypoint_bookmark".into() });
+    assert_eq!(
+        rows[2],
+        InventoryRow::PassiveGroup {
+            item_type: "waypoint_bookmark".into()
+        }
+    );
 }
 
 #[test]
@@ -341,7 +376,12 @@ fn jettison_for_selected_stock_enters_amount() {
     let mut state = AppState::default();
     state.probe = Some(probe_with_inventory("[]", STOCK_METALS));
     match state.jettison_for_selected() {
-        Ok(JettisonInput::EnterAmount { item_id, item_name, max_amount, .. }) => {
+        Ok(JettisonInput::EnterAmount {
+            item_id,
+            item_name,
+            max_amount,
+            ..
+        }) => {
             assert_eq!(item_id, "stock-metals");
             assert_eq!(item_name, "Metals");
             assert_eq!(max_amount, 0.5);
@@ -355,7 +395,9 @@ fn jettison_for_selected_idle_manny_confirms() {
     let mut state = AppState::default();
     state.probe = Some(probe_with_inventory(&format!("[{}]", manny_item(None)), "[]"));
     match state.jettison_for_selected() {
-        Ok(JettisonInput::ConfirmManny { item_id, manny_name, .. }) => {
+        Ok(JettisonInput::ConfirmManny {
+            item_id, manny_name, ..
+        }) => {
             assert_eq!(item_id, "manny-1");
             assert_eq!(manny_name, "Manny-1");
         }
@@ -402,7 +444,8 @@ fn jettison_fill_max_sets_buffer() {
 
 #[test]
 fn visited_sector_parses_spec_example() {
-    let v: Vec<VisitedSector> = serde_json::from_str(r#"[
+    let v: Vec<VisitedSector> = serde_json::from_str(
+        r#"[
         {"relativeCoordinates": {"x": 0, "y": 0, "z": 0},
          "firstVisitedAt": "2026-06-01T12:00:00+00:00",
          "lastVisitedAt": "2026-06-01T12:00:00+00:00",
@@ -411,7 +454,9 @@ fn visited_sector_parses_spec_example() {
          "firstVisitedAt": "2026-06-01T13:15:00+00:00",
          "lastVisitedAt": "2026-06-01T15:45:00+00:00",
          "visitCount": 2}
-    ]"#).unwrap();
+    ]"#,
+    )
+    .unwrap();
     assert_eq!(v.len(), 2);
     assert_eq!(v[1].visit_count, 2);
     assert_eq!(v[1].relative_coordinates.x as i32, 1);
@@ -444,7 +489,8 @@ fn make_manny(id: &str, location_type: &str, can_receive_orders: bool, task: Opt
         Some(t) => format!("\"{}\"", t),
         None => "null".into(),
     };
-    serde_json::from_str(&format!(r#"{{
+    serde_json::from_str(&format!(
+        r#"{{
         "id": "{id}",
         "name": "{id}",
         "location": {{"type": "{location_type}", "sector": null}},
@@ -453,11 +499,14 @@ fn make_manny(id: &str, location_type: &str, can_receive_orders: bool, task: Opt
         "cargo": {{"capacity": 0.3, "deuterium": 0.0, "metals": 0.0, "ice": 0.0, "organicCompounds": 0.0}},
         "canReceiveOrders": {can_receive_orders},
         "taskEstimatedEndTime": null
-    }}"#)).unwrap()
+    }}"#
+    ))
+    .unwrap()
 }
 
 fn make_sector_with_objects(x: f64, y: f64, z: f64, objects_json: &str) -> SectorObservation {
-    serde_json::from_str(&format!(r#"{{
+    serde_json::from_str(&format!(
+        r#"{{
         "relativeCoordinates": {{"x": {x}, "y": {y}, "z": {z}}},
         "distance": 1,
         "knowledgeLevel": "detailed",
@@ -471,7 +520,9 @@ fn make_sector_with_objects(x: f64, y: f64, z: f64, objects_json: &str) -> Secto
         "sensorMode": null,
         "dataFreshness": null,
         "scan": {{"currentSectorResidenceSeconds": 60, "requiredResidenceSeconds": 60, "scanQuality": 1.0}}
-    }}"#)).unwrap()
+    }}"#
+    ))
+    .unwrap()
 }
 
 fn probe_at(x: f64, y: f64, z: f64) -> Probe {
@@ -565,7 +616,9 @@ fn repair_max_percent_no_probe() {
 #[test]
 fn repair_max_percent_full_integrity() {
     let mut state = AppState::default();
-    state.probe = Some(serde_json::from_str(r#"{
+    state.probe = Some(
+        serde_json::from_str(
+            r#"{
         "id": 1, "name": "t", "status": "idle",
         "fuel": {"deuterium": null}, "sensorMode": "normal",
         "sector": null, "movement": null,
@@ -573,14 +626,19 @@ fn repair_max_percent_full_integrity() {
                     "energyStored": null, "internalClockRate": null, "currentTask": null},
         "inventory": {"capacity": 1.0, "usedCapacity": 0.0, "freeCapacity": 1.0,
                       "items": [], "resourceStocks": [], "externalTanks": [], "containers": []}
-    }"#).unwrap());
+    }"#,
+        )
+        .unwrap(),
+    );
     assert_eq!(state.repair_max_percent(), 0.0);
 }
 
 #[test]
 fn repair_max_percent_damaged() {
     let mut state = AppState::default();
-    state.probe = Some(serde_json::from_str(r#"{
+    state.probe = Some(
+        serde_json::from_str(
+            r#"{
         "id": 1, "name": "t", "status": "idle",
         "fuel": {"deuterium": null}, "sensorMode": "normal",
         "sector": null, "movement": null,
@@ -588,7 +646,10 @@ fn repair_max_percent_damaged() {
                     "energyStored": null, "internalClockRate": null, "currentTask": null},
         "inventory": {"capacity": 1.0, "usedCapacity": 0.0, "freeCapacity": 1.0,
                       "items": [], "resourceStocks": [], "externalTanks": [], "containers": []}
-    }"#).unwrap());
+    }"#,
+        )
+        .unwrap(),
+    );
     assert_eq!(state.repair_max_percent(), 40.0);
 }
 
@@ -700,15 +761,24 @@ fn update_sector_resets_scroll_and_idx() {
 fn manny_craft_recipes_filters_correctly() {
     let mut state = AppState::default();
     state.recipes = vec![
-        serde_json::from_str(r#"{"id":"r1","name":"R1","craftableBy":["manny"],
+        serde_json::from_str(
+            r#"{"id":"r1","name":"R1","craftableBy":["manny"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
-        serde_json::from_str(r#"{"id":"r2","name":"R2","craftableBy":["atomic_3d_printer"],
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
+        serde_json::from_str(
+            r#"{"id":"r2","name":"R2","craftableBy":["atomic_3d_printer"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
-        serde_json::from_str(r#"{"id":"r3","name":"R3","craftableBy":["manny","atomic_3d_printer"],
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
+        serde_json::from_str(
+            r#"{"id":"r3","name":"R3","craftableBy":["manny","atomic_3d_printer"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
     ];
     let manny = state.manny_craft_recipes();
     assert_eq!(manny.len(), 2);
@@ -720,12 +790,18 @@ fn manny_craft_recipes_filters_correctly() {
 fn atomic_printer_recipes_filters_correctly() {
     let mut state = AppState::default();
     state.recipes = vec![
-        serde_json::from_str(r#"{"id":"r1","name":"R1","craftableBy":["manny"],
+        serde_json::from_str(
+            r#"{"id":"r1","name":"R1","craftableBy":["manny"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
-        serde_json::from_str(r#"{"id":"r2","name":"R2","craftableBy":["atomic_3d_printer"],
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
+        serde_json::from_str(
+            r#"{"id":"r2","name":"R2","craftableBy":["atomic_3d_printer"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
     ];
     let printer = state.atomic_printer_recipes();
     assert_eq!(printer.len(), 1);
@@ -737,25 +813,40 @@ fn fabrication_recipes_orders_atomic_then_manny() {
     use crate::app::Fabricator;
     let mut state = AppState::default();
     state.recipes = vec![
-        serde_json::from_str(r#"{"id":"r1","name":"R1","craftableBy":["manny"],
+        serde_json::from_str(
+            r#"{"id":"r1","name":"R1","craftableBy":["manny"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
-        serde_json::from_str(r#"{"id":"r2","name":"R2","craftableBy":["atomic_3d_printer"],
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
+        serde_json::from_str(
+            r#"{"id":"r2","name":"R2","craftableBy":["atomic_3d_printer"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
         // Craftable by both → appears once in each section.
-        serde_json::from_str(r#"{"id":"r3","name":"R3","craftableBy":["manny","atomic_3d_printer"],
+        serde_json::from_str(
+            r#"{"id":"r3","name":"R3","craftableBy":["manny","atomic_3d_printer"],
             "ingredients":[],"durationSeconds":60,
-            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
+            "output":{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}"#,
+        )
+        .unwrap(),
     ];
-    let rows: Vec<(Fabricator, &str)> = state.fabrication_recipes()
-        .into_iter().map(|(f, r)| (f, r.id.as_str())).collect();
-    assert_eq!(rows, vec![
-        (Fabricator::AtomicPrinter, "r2"),
-        (Fabricator::AtomicPrinter, "r3"),
-        (Fabricator::Manny, "r1"),
-        (Fabricator::Manny, "r3"),
-    ]);
+    let rows: Vec<(Fabricator, &str)> = state
+        .fabrication_recipes()
+        .into_iter()
+        .map(|(f, r)| (f, r.id.as_str()))
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            (Fabricator::AtomicPrinter, "r2"),
+            (Fabricator::AtomicPrinter, "r3"),
+            (Fabricator::Manny, "r1"),
+            (Fabricator::Manny, "r3"),
+        ]
+    );
 }
 
 // ── has_atomic_printer ────────────────────────────────────────────────────
@@ -775,7 +866,9 @@ fn has_atomic_printer_absent() {
 #[test]
 fn has_atomic_printer_present() {
     let mut state = AppState::default();
-    state.probe = Some(serde_json::from_str(r#"{
+    state.probe = Some(
+        serde_json::from_str(
+            r#"{
         "id": 1, "name": "t", "status": "idle",
         "fuel": {"deuterium": null}, "sensorMode": "normal",
         "sector": null, "movement": null, "systems": null,
@@ -784,7 +877,10 @@ fn has_atomic_printer_present() {
             "items": [{"id": "ap-1", "type": "atomic_3d_printer", "name": "Atomic Printer",
                 "containerSpace": 1.0, "currentTask": null, "taskProgressPercent": 0.0,
                 "location": {"type": "probe", "sector": null}, "cargo": null, "container": null}]}
-    }"#).unwrap());
+    }"#,
+        )
+        .unwrap(),
+    );
     assert!(state.has_atomic_printer());
 }
 
@@ -799,7 +895,11 @@ fn collect_mineable_candidates_empty_when_no_sector() {
 fn collect_mineable_candidates_returns_asteroid_targets() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(2., 0., -2.));
-    state.scan_history = vec![make_sector_with_objects(2., 0., -2., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        2.,
+        0.,
+        -2.,
+        r#"[
         {
             "id": "planet-1", "type": "planet", "name": "P1",
             "estimated": null, "summary": null, "mass": null, "massUnit": null,
@@ -813,7 +913,8 @@ fn collect_mineable_candidates_returns_asteroid_targets() {
             ],
             "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     let candidates = state.collect_mineable_candidates();
     assert_eq!(candidates.len(), 2);
     assert!(candidates.iter().any(|(id, _)| id == "ast-1"));
@@ -826,7 +927,11 @@ fn collect_mineable_candidates_includes_top_level_asteroid() {
     // parent minableTargets) — it must still reach the mine picker.
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {
             "id": "deuterium-asteroid-abc", "type": "asteroid",
             "name": "Astéroïde contenant du Deutérium",
@@ -837,7 +942,8 @@ fn collect_mineable_candidates_includes_top_level_asteroid() {
             "capacity": null, "capacityUnit": null, "mannyMineable": true,
             "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     let candidates = state.collect_mineable_candidates();
     assert_eq!(candidates.len(), 1);
     assert_eq!(candidates[0].0, "deuterium-asteroid-abc");
@@ -848,7 +954,11 @@ fn collect_mineable_candidates_includes_top_level_asteroid() {
 fn deuterium_station_detected_in_current_sector() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(2., 0., -2.));
-    state.scan_history = vec![make_sector_with_objects(2., 0., -2., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        2.,
+        0.,
+        -2.,
+        r#"[
         {
             "id": "station-1", "type": "deuterium_refuel_station", "name": "Refuel Stop",
             "estimated": null, "summary": null, "mass": null, "massUnit": null,
@@ -858,12 +968,18 @@ fn deuterium_station_detected_in_current_sector() {
             "capacity": null, "capacityUnit": null,
             "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     assert!(state.deuterium_station_in_current_sector());
 }
 
 fn relay_sector(status: &str) -> SectorObservation {
-    make_sector_with_objects(0., 0., 0., &format!(r#"[
+    make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        &format!(
+            r#"[
         {{
             "id": "42", "type": "scut_relay", "name": "Relais SCUT",
             "estimated": false, "summary": "relay", "mass": 0.0, "massUnit": null,
@@ -876,7 +992,9 @@ fn relay_sector(status: &str) -> SectorObservation {
             "capacity": null, "capacityUnit": null,
             "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
         }}
-    ]"#))
+    ]"#
+        ),
+    )
 }
 
 fn remote_manny(task_visibility: &str, task: &str) -> crate::api::types::Manny {
@@ -913,9 +1031,15 @@ fn remote_mine_advances_to_pick_asteroid_when_sector_loads() {
     state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::Loading {
         manny_id: "mny_remote".into(),
         manny_name: "manny-r".into(),
-        x: 2, y: 0, z: -2,
+        x: 2,
+        y: 0,
+        z: -2,
     });
-    state.scan_history = vec![make_sector_with_objects(2., 0., -2., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        2.,
+        0.,
+        -2.,
+        r#"[
         {
             "id": "ast-9", "type": "asteroid", "name": "Rock", "summary": null,
             "estimated": null, "mass": null, "massUnit": null, "radius": null, "radiusUnit": null,
@@ -924,23 +1048,30 @@ fn remote_mine_advances_to_pick_asteroid_when_sector_loads() {
             "mode": null, "targetObjectId": null, "capacity": null, "capacityUnit": null,
             "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     state.remote_mine_sector_loaded(2, 0, -2);
-    assert!(matches!(state.active_wizard, ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { .. })));
+    assert!(matches!(
+        state.active_wizard,
+        ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { .. })
+    ));
 }
 
 #[test]
 fn unread_message_count_counts_only_unread() {
     let mut state = AppState::default();
     let mk = |id: i64, status: &str| -> crate::api::types::ProbeMessage {
-        serde_json::from_str(&format!(r#"{{
+        serde_json::from_str(&format!(
+            r#"{{
             "id": {id},
             "sender": {{ "type": "probe", "id": 2, "name": "nova" }},
             "recipient": {{ "type": "probe", "id": 1, "name": "me" }},
             "sector": {{ "relative": {{"x":0,"y":0,"z":0}} }},
             "body": "hi", "status": "{status}", "readAt": null,
             "createdAt": "2026-06-06T12:00:00+00:00", "updatedAt": "2026-06-06T12:00:00+00:00"
-        }}"#)).unwrap()
+        }}"#
+        ))
+        .unwrap()
     };
     state.messages = vec![mk(1, "unread"), mk(2, "read"), mk(3, "unread")];
     assert_eq!(state.unread_message_count(), 2);
@@ -951,9 +1082,7 @@ fn scut_coverage_read_from_sector() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
     let mut sector = make_sector_with_objects(0., 0., 0., "[]");
-    sector.scut_networks = vec![
-        serde_json::from_str(r#"{"id": 7, "name": "Delta SCUT"}"#).unwrap(),
-    ];
+    sector.scut_networks = vec![serde_json::from_str(r#"{"id": 7, "name": "Delta SCUT"}"#).unwrap()];
     state.scan_history = vec![sector];
     let cov = state.scut_coverage();
     assert_eq!(cov.len(), 1);
@@ -976,7 +1105,9 @@ fn inactive_relay_offers_turn_on_and_salvage() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
     state.scan_history = vec![relay_sector("off")];
-    let entry = state.scanner_objects().into_iter()
+    let entry = state
+        .scanner_objects()
+        .into_iter()
         .find(|e| matches!(e.object_type, crate::api::types::SectorObjectType::ScutRelay))
         .expect("relay entry present");
     let actions = state.actions_for_object(&entry);
@@ -989,7 +1120,9 @@ fn active_relay_offers_no_turn_on() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
     state.scan_history = vec![relay_sector("on")];
-    let entry = state.scanner_objects().into_iter()
+    let entry = state
+        .scanner_objects()
+        .into_iter()
         .find(|e| matches!(e.object_type, crate::api::types::SectorObjectType::ScutRelay))
         .expect("relay entry present");
     let actions = state.actions_for_object(&entry);
@@ -1000,7 +1133,11 @@ fn active_relay_offers_no_turn_on() {
 fn deuterium_station_absent_in_current_sector() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {
             "id": "planet-1", "type": "planet", "name": "P1",
             "estimated": null, "summary": null, "mass": null, "massUnit": null,
@@ -1010,7 +1147,8 @@ fn deuterium_station_absent_in_current_sector() {
             "capacity": null, "capacityUnit": null,
             "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     assert!(!state.deuterium_station_in_current_sector());
 }
 
@@ -1018,7 +1156,11 @@ fn deuterium_station_absent_in_current_sector() {
 fn collect_mineable_candidates_unnamed_fallback() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {
             "id": "planet-1", "type": "planet", "name": null,
             "estimated": null, "summary": null, "mass": null, "massUnit": null,
@@ -1029,7 +1171,8 @@ fn collect_mineable_candidates_unnamed_fallback() {
             "minableTargets": [{"id": "ast-x", "type": "asteroid", "name": null, "mass": null, "resourceTypes": null}],
             "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     let candidates = state.collect_mineable_candidates();
     assert_eq!(candidates[0].1, "unnamed");
 }
@@ -1045,7 +1188,7 @@ fn collect_idle_onboard_mannies_empty_when_no_mannies() {
 fn collect_idle_onboard_mannies_filters_correctly() {
     let mut state = AppState::default();
     state.mannies = Some(vec![
-        make_manny("m1", "probe", true, None),           // included
+        make_manny("m1", "probe", true, None),            // included
         make_manny("m2", "probe", false, Some("mining")), // busy — excluded
         make_manny("m3", "sector", true, None),           // in sector — excluded
     ]);
@@ -1064,7 +1207,9 @@ fn collect_detachable_containers_empty_when_no_probe() {
 #[test]
 fn collect_detachable_containers_excludes_probe_container() {
     let mut state = AppState::default();
-    state.probe = Some(serde_json::from_str(r#"{
+    state.probe = Some(
+        serde_json::from_str(
+            r#"{
         "id": 1, "name": "t", "status": "idle",
         "fuel": {"deuterium": null}, "sensorMode": "normal",
         "sector": null, "movement": null, "systems": null,
@@ -1078,7 +1223,10 @@ fn collect_detachable_containers_excludes_probe_container() {
                  "capacity": 2.0, "usedCapacity": 0.0, "freeCapacity": 2.0,
                  "rules": {"priority": [], "exclusion": [], "strictExclusion": []}}
             ]}
-    }"#).unwrap());
+    }"#,
+        )
+        .unwrap(),
+    );
     let result = state.collect_detachable_containers();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].0, "c-ext");
@@ -1088,7 +1236,9 @@ fn collect_detachable_containers_excludes_probe_container() {
 #[test]
 fn collect_empty_containers_excludes_probe_and_non_empty() {
     let mut state = AppState::default();
-    state.probe = Some(serde_json::from_str(r#"{
+    state.probe = Some(
+        serde_json::from_str(
+            r#"{
         "id": 1, "name": "t", "status": "idle",
         "fuel": {"deuterium": null}, "sensorMode": "normal",
         "sector": null, "movement": null, "systems": null,
@@ -1105,7 +1255,10 @@ fn collect_empty_containers_excludes_probe_and_non_empty() {
                  "capacity": 2.0, "usedCapacity": 1.5, "freeCapacity": 0.5,
                  "rules": {"priority": [], "exclusion": [], "strictExclusion": []}}
             ]}
-    }"#).unwrap());
+    }"#,
+        )
+        .unwrap(),
+    );
     let result = state.collect_empty_containers();
     assert_eq!(result.len(), 1, "only the empty additional container");
     assert_eq!(result[0].0, "c-empty");
@@ -1122,7 +1275,11 @@ fn collect_detached_containers_empty_when_no_scan() {
 fn collect_detached_containers_returns_only_detached_type() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {
             "id": "dc-1", "type": "detached_container", "name": "Floater",
             "estimated": null, "summary": null, "mass": null, "massUnit": null,
@@ -1141,7 +1298,8 @@ fn collect_detached_containers_returns_only_detached_type() {
             "capacity": null, "capacityUnit": null, "minableTargets": null,
             "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     let result = state.collect_detached_containers();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].0, "dc-1");
@@ -1152,7 +1310,11 @@ fn collect_detached_containers_returns_only_detached_type() {
 fn collect_detached_containers_unnamed_fallback() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {
             "id": "dc-2", "type": "detached_container", "name": null,
             "estimated": null, "summary": null, "mass": null, "massUnit": null,
@@ -1162,7 +1324,8 @@ fn collect_detached_containers_unnamed_fallback() {
             "capacity": null, "capacityUnit": null, "minableTargets": null,
             "waypointBookmarks": [], "bookmarkTargets": []
         }
-    ]"#)];
+    ]"#,
+    )];
     let result = state.collect_detached_containers();
     assert_eq!(result[0].1, "unnamed container");
 }
@@ -1243,7 +1406,13 @@ fn scanner_objects_nest_hidden_containers_under_host() {
         "[{},{},{},{}]",
         tmpl("ast-1", "asteroid", "Rock A", "null", "null"),
         tmpl("c-drift", "detached_container", "Floater", "\"drifting\"", "null"),
-        tmpl("c-hidden", "detached_container", "Cache", "\"hidden_on_asteroid\"", "\"ast-1\""),
+        tmpl(
+            "c-hidden",
+            "detached_container",
+            "Cache",
+            "\"hidden_on_asteroid\"",
+            "\"ast-1\""
+        ),
         tmpl("ast-2", "asteroid", "Rock B", "null", "null"),
     );
     let mut state = AppState::default();
@@ -1301,14 +1470,21 @@ fn actions_for_object_by_kind() {
     // manny wreck: salvage
     assert_eq!(state.actions_for_object(&entries[2]), vec![ObjectAction::Salvage]);
     // detached container: recover + inspect (API v65 lets a Manny inspect it)
-    assert_eq!(state.actions_for_object(&entries[3]), vec![ObjectAction::Recover, ObjectAction::Inspect]);
+    assert_eq!(
+        state.actions_for_object(&entries[3]),
+        vec![ObjectAction::Recover, ObjectAction::Inspect]
+    );
 }
 
 #[test]
 fn dormant_construct_offers_inspect() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {"id": "dc-1", "type": "dormant_construct", "name": "Relic",
          "estimated": null, "summary": null, "mass": null, "massUnit": null,
          "radius": null, "radiusUnit": null, "dangerLevel": null, "salvageable": null,
@@ -1316,12 +1492,16 @@ fn dormant_construct_offers_inspect() {
          "quantity": null, "containerSpace": null, "mode": null, "targetObjectId": null,
          "capacity": null, "capacityUnit": null,
          "minableTargets": null, "waypointBookmarks": [], "bookmarkTargets": []}
-    ]"#)];
+    ]"#,
+    )];
     let entries = state.scanner_objects();
     assert_eq!(state.actions_for_object(&entries[0]), vec![ObjectAction::Inspect]);
     // …and it shows up as an inspectable candidate for the Mannies-pane flow.
     let cands = state.collect_inspectable_candidates();
-    assert!(cands.iter().any(|(id, _)| id == "dc-1"), "dormant construct is inspectable");
+    assert!(
+        cands.iter().any(|(id, _)| id == "dc-1"),
+        "dormant construct is inspectable"
+    );
 }
 
 #[test]
@@ -1338,7 +1518,10 @@ fn actions_include_deploy_when_bookmark_in_inventory() {
     state.scan_history = vec![make_sector_with_objects(0., 0., 0., MIXED_OBJECTS)];
     let entries = state.scanner_objects();
     // top-level planet gains deploy; nested minable target does not
-    assert_eq!(state.actions_for_object(&entries[0]), vec![ObjectAction::DeployWaypoint]);
+    assert_eq!(
+        state.actions_for_object(&entries[0]),
+        vec![ObjectAction::DeployWaypoint]
+    );
     assert_eq!(state.actions_for_object(&entries[1]), vec![ObjectAction::Mine]);
 }
 
@@ -1355,7 +1538,7 @@ fn filtered_history_respects_objects_filter() {
     let mut state = AppState::default();
     state.scan_history = vec![
         make_sector_with_objects(0., 0., 0., MIXED_OBJECTS), // has objects
-        make_sector(2., 0., 0.),                              // objects: null
+        make_sector(2., 0., 0.),                             // objects: null
     ];
     state.scan_filter = ScanFilter::Objects;
     assert_eq!(state.filtered_history_indices(), vec![0]);
@@ -1404,7 +1587,8 @@ fn collect_waypoints_empty_history() {
 #[test]
 fn collect_waypoints_bookmarks_first_then_sorted_by_distance() {
     let mut state = AppState::default();
-    let star_far: SectorObservation = serde_json::from_str(r#"{
+    let star_far: SectorObservation = serde_json::from_str(
+        r#"{
         "relativeCoordinates": {"x": 6.0, "y": 0.0, "z": 0.0},
         "distance": 6, "knowledgeLevel": "detailed", "confidence": 1.0,
         "objects": [{
@@ -1419,7 +1603,9 @@ fn collect_waypoints_bookmarks_first_then_sorted_by_distance() {
         "probes": null, "possibleObjects": null, "estimatedObjects": null,
         "navigationalRisk": null, "message": null, "sensorMode": null, "dataFreshness": null,
         "scan": {"currentSectorResidenceSeconds": 0, "requiredResidenceSeconds": 0, "scanQuality": 1.0}
-    }"#).unwrap();
+    }"#,
+    )
+    .unwrap();
     let bookmark_near: SectorObservation = serde_json::from_str(r#"{
         "relativeCoordinates": {"x": 2.0, "y": 0.0, "z": 0.0},
         "distance": 2, "knowledgeLevel": "detailed", "confidence": 1.0,
@@ -1541,7 +1727,7 @@ fn mannies_context_menu_reflects_manny_state() {
     assert!(!menu_item(&menu, MenuAction::Refuel).enabled); // no station
     assert!(!menu_item(&menu, MenuAction::TransferDeuterium).enabled); // single probe
     assert!(!menu_item(&menu, MenuAction::DropCargo).enabled); // not waiting
-    // Cursor lands on the first enabled item.
+                                                               // Cursor lands on the first enabled item.
     assert!(menu.items[menu.cursor].enabled);
 
     // Busy manny with a task: order-requiring actions disabled, recall enabled.
@@ -1570,14 +1756,18 @@ fn probe_menu_offers_scut_inspect_disabled_without_coverage() {
         .iter()
         .find(|i| i.action == MenuAction::ScutInspect)
         .expect("SCUT inspect offered");
-    assert!(!item.enabled && item.disabled_reason.is_some(), "no coverage → disabled with a reason");
+    assert!(
+        !item.enabled && item.disabled_reason.is_some(),
+        "no coverage → disabled with a reason"
+    );
 }
 
 fn improvement(id: &str, available: bool, done: bool) -> crate::api::types::ProbeImprovement {
     serde_json::from_str(&format!(
         r#"{{"id":"{id}","name":"{id}","description":"d","available":{available},"done":{done},
             "durationSeconds":300,"ingredients":[],"effects":null}}"#
-    )).unwrap()
+    ))
+    .unwrap()
 }
 
 #[test]
@@ -1598,7 +1788,11 @@ fn probe_menu_improve_enabled_only_with_an_orderable_improvement() {
     state.active_pane = Pane::Probe;
     state.probe_improvements = vec![improvement("deuterium_compression", true, false)];
     let menu = state.build_context_menu().expect("probe menu");
-    let item = menu.items.iter().find(|i| i.action == MenuAction::Improve).expect("improve offered");
+    let item = menu
+        .items
+        .iter()
+        .find(|i| i.action == MenuAction::Improve)
+        .expect("improve offered");
     assert!(item.enabled, "orderable improvement → enabled");
 }
 
@@ -1618,7 +1812,9 @@ fn inventory_context_menu_present_but_disabled_when_empty() {
 fn inventory_menu_offers_deploy_only_with_a_held_bookmark() {
     let mut state = AppState::default();
     state.active_pane = Pane::Inventory;
-    state.probe = Some(serde_json::from_str(r#"{
+    state.probe = Some(
+        serde_json::from_str(
+            r#"{
         "id": 1, "name": "t", "status": "idle",
         "fuel": {"deuterium": null}, "sensorMode": "normal",
         "sector": null, "movement": null, "systems": null,
@@ -1627,9 +1823,16 @@ fn inventory_menu_offers_deploy_only_with_a_held_bookmark() {
             "items": [{"id": "wp-1", "type": "waypoint_bookmark", "name": "Waypoint bookmark",
                 "containerSpace": 0.01, "currentTask": null, "taskProgressPercent": 0.0,
                 "location": {"type": "probe", "sector": null}, "cargo": null, "container": null}]}
-    }"#).unwrap());
+    }"#,
+        )
+        .unwrap(),
+    );
     let menu = state.build_context_menu().expect("inventory menu");
-    let deploy = menu.items.iter().find(|i| i.action == MenuAction::Deploy).expect("deploy offered");
+    let deploy = menu
+        .items
+        .iter()
+        .find(|i| i.action == MenuAction::Deploy)
+        .expect("deploy offered");
     // No idle manny / no sector target here → offered but disabled with a reason.
     assert!(!deploy.enabled && deploy.disabled_reason.is_some());
 }
@@ -1736,7 +1939,8 @@ fn manny_task_progress_complete_when_past_end() {
 #[test]
 fn sector_object_planet_science_fields_deserialize() {
     use crate::api::types::SectorObject;
-    let planet: SectorObject = serde_json::from_str(r#"{
+    let planet: SectorObject = serde_json::from_str(
+        r#"{
         "type": "planet",
         "name": "Kepler-relative-1",
         "summary": "temperate ocean world",
@@ -1745,7 +1949,9 @@ fn sector_object_planet_science_fields_deserialize() {
         "mannyMineable": true,
         "resourceTypes": ["metals", "ice"],
         "resourceComposition": {"deuterium": 0.0, "metals": 0.6, "ice": 0.4, "carbon_compounds": 0.0}
-    }"#).unwrap();
+    }"#,
+    )
+    .unwrap();
     assert_eq!(planet.category.as_deref(), Some("ocean"));
     assert_eq!(planet.habitability_score, Some(0.82));
     assert_eq!(planet.manny_mineable, Some(true));
@@ -1757,13 +1963,16 @@ fn sector_object_planet_science_fields_deserialize() {
 #[test]
 fn sector_object_asteroid_reserves_deserialize() {
     use crate::api::types::SectorObject;
-    let ast: SectorObject = serde_json::from_str(r#"{
+    let ast: SectorObject = serde_json::from_str(
+        r#"{
         "type": "asteroid",
         "name": "AX-12",
         "summary": "carbonaceous",
         "composition": "carbonaceous",
         "resourceAmounts": {"deuterium": 0.0, "metals": 1.25, "ice": 0.0, "carbon_compounds": 3.5}
-    }"#).unwrap();
+    }"#,
+    )
+    .unwrap();
     assert_eq!(ast.composition.as_deref(), Some("carbonaceous"));
     let amt = ast.resource_amounts.expect("amounts");
     assert!((amt.carbon_compounds - 3.5).abs() < 1e-9);
@@ -1776,11 +1985,16 @@ fn scanner_objects_number_unnamed_by_type() {
     let mut state = AppState::default();
     state.probe = Some(probe_at(0., 0., 0.));
     // Two unnamed top-level asteroids + one named planet.
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {"type": "asteroid", "id": "a1", "name": null, "summary": ""},
         {"type": "planet", "id": "p1", "name": "Vulcan", "summary": ""},
         {"type": "asteroid", "id": "a2", "name": null, "summary": ""}
-    ]"#)];
+    ]"#,
+    )];
     let entries = state.scanner_objects();
     let by_id = |id: &str| entries.iter().find(|e| e.id == id).unwrap().name.clone();
     assert_eq!(by_id("a1"), "asteroid #1");
@@ -1793,11 +2007,16 @@ fn scanner_objects_number_unnamed_by_type() {
 #[test]
 fn minable_target_reserves_reads_types_and_amounts() {
     let mut state = AppState::default();
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {"type": "asteroid", "id": "ast-1", "name": "AX", "summary": "",
          "resourceTypes": ["metals", "ice"],
          "resourceAmounts": {"deuterium": 0.0, "metals": 2.0, "ice": 1.0, "carbon_compounds": 0.0}}
-    ]"#)];
+    ]"#,
+    )];
     let (flags, res) = state.minable_target_reserves("ast-1").expect("reserves");
     assert_eq!(flags, [false, true, true, false]);
     assert_eq!(res, [0.0, 2.0, 1.0, 0.0]);
@@ -1811,9 +2030,14 @@ fn minable_target_reserves_reads_types_and_amounts() {
 fn mine_reserve_max_falls_back_to_free_capacity_without_reserves() {
     let mut state = AppState::default();
     state.probe = Some(make_probe(0.5, 0., 0., 0.));
-    state.scan_history = vec![make_sector_with_objects(0., 0., 0., r#"[
+    state.scan_history = vec![make_sector_with_objects(
+        0.,
+        0.,
+        0.,
+        r#"[
         {"type": "asteroid", "id": "ast-1", "name": "AX", "summary": "", "resourceTypes": ["metals"]}
-    ]"#)];
+    ]"#,
+    )];
     // No resourceAmounts → reserves are 0 → fall back to free capacity (0.5).
     assert_eq!(state.mine_reserve_max("ast-1", [false, true, false, false]), 0.5);
 }
@@ -1829,7 +2053,13 @@ fn map_context_menu_goto_disabled_without_visited() {
     let goto = menu.items.iter().find(|i| i.action == MenuAction::GotoVisited).unwrap();
     assert!(!goto.enabled, "no visited sectors → jump disabled");
     // Open map / travel are always available.
-    assert!(menu.items.iter().find(|i| i.action == MenuAction::Travel).unwrap().enabled);
+    assert!(
+        menu.items
+            .iter()
+            .find(|i| i.action == MenuAction::Travel)
+            .unwrap()
+            .enabled
+    );
 }
 
 #[test]
@@ -1839,13 +2069,23 @@ fn scanner_travel_here_enabled_for_remote_selection_only() {
     state.probe = Some(probe_at(0., 0., 0.));
     // Remote observation selected → Travel here enabled.
     state.scan_history = vec![make_sector(2., 0., 0.)];
-    let travel = state.build_context_menu().unwrap().items.into_iter()
-        .find(|i| i.action == MenuAction::ScanTravel).unwrap();
+    let travel = state
+        .build_context_menu()
+        .unwrap()
+        .items
+        .into_iter()
+        .find(|i| i.action == MenuAction::ScanTravel)
+        .unwrap();
     assert!(travel.enabled);
     // Current sector selected → disabled ("already here").
     state.scan_history = vec![make_sector(0., 0., 0.)];
-    let travel = state.build_context_menu().unwrap().items.into_iter()
-        .find(|i| i.action == MenuAction::ScanTravel).unwrap();
+    let travel = state
+        .build_context_menu()
+        .unwrap()
+        .items
+        .into_iter()
+        .find(|i| i.action == MenuAction::ScanTravel)
+        .unwrap();
     assert!(!travel.enabled);
 }
 
@@ -1878,12 +2118,15 @@ fn recipe_affordable_checks_stocks_and_items() {
     assert!(state.recipe_affordable(&recipe), "have 5.0 metals ≥ 2.0");
 
     // Needs 2 integrated circuits but only 1 on hand.
-    let hungry: CraftingRecipe = serde_json::from_str(r#"{
+    let hungry: CraftingRecipe = serde_json::from_str(
+        r#"{
         "id":"r2","name":"Board","craftableBy":["manny"],
         "ingredients":[{"type":"integrated_circuit","quantity":2.0,"unit":"item","kind":null}],
         "durationSeconds":600,
         "output":{"type":"board","name":"Board","containerSpace":0.1,"containerSpaceUnit":"ece","capacityBonus":null}
-    }"#).unwrap();
+    }"#,
+    )
+    .unwrap();
     assert!(!state.recipe_affordable(&hungry));
     assert_eq!(state.recipe_ingredient_have(&hungry.ingredients[0]), 1.0);
 }
@@ -1920,7 +2163,10 @@ fn run_command_travel_and_goto() {
     state.probe = Some(probe_at(0., 0., 0.));
     // even-sum target → travel confirm
     state.run_command("travel 2 0 -2");
-    assert!(matches!(state.active_wizard, ActiveWizard::Travel(TravelInput::Confirming { x: 2, y: 0, z: -2, .. })));
+    assert!(matches!(
+        state.active_wizard,
+        ActiveWizard::Travel(TravelInput::Confirming { x: 2, y: 0, z: -2, .. })
+    ));
 
     state.run_command("goto 1 1 0");
     assert!(state.map.open);
@@ -1977,7 +2223,10 @@ fn run_command_records_history_deduping_repeats() {
     state.run_command("zoom");
     state.run_command("zoom"); // consecutive duplicate is not re-pushed
     state.run_command("filter all");
-    assert_eq!(state.command_history, vec!["zoom".to_string(), "filter all".to_string()]);
+    assert_eq!(
+        state.command_history,
+        vec!["zoom".to_string(), "filter all".to_string()]
+    );
     // Blank lines are never recorded.
     state.run_command("   ");
     assert_eq!(state.command_history.len(), 2);
@@ -2026,7 +2275,13 @@ fn mine_one_shot_stages_fire_with_defaults() {
     // Only an amount given → resources default to metals, destination = probe.
     state.run_command("mine 0.5");
     match state.pending_fire.take() {
-        Some(CommandFire::Mine { manny_id, object_id, resources, amount, container_id }) => {
+        Some(CommandFire::Mine {
+            manny_id,
+            object_id,
+            resources,
+            amount,
+            container_id,
+        }) => {
             assert_eq!(manny_id, "m1");
             assert_eq!(object_id, "ast-1");
             assert_eq!(resources, vec!["metals".to_string()]);
@@ -2089,7 +2344,10 @@ fn craft_one_shot_stages_manny_fire() {
     state.run_command("craft widget"); // case-insensitive
     assert_eq!(
         state.pending_fire,
-        Some(CommandFire::MannyCraft { manny_id: "m1".into(), recipe_id: "r1".into() })
+        Some(CommandFire::MannyCraft {
+            manny_id: "m1".into(),
+            recipe_id: "r1".into()
+        })
     );
 }
 
@@ -2117,7 +2375,10 @@ fn craft_bare_still_opens_wizard() {
     )
     .unwrap()];
     state.run_command("craft");
-    assert!(matches!(state.active_wizard, ActiveWizard::Fabrication(FabricationInput::PickRecipe { .. })));
+    assert!(matches!(
+        state.active_wizard,
+        ActiveWizard::Fabrication(FabricationInput::PickRecipe { .. })
+    ));
     assert!(state.pending_fire.is_none());
 }
 

--- a/src/app/travel.rs
+++ b/src/app/travel.rs
@@ -1,6 +1,6 @@
+use super::*;
 use crate::api::types::ProbeMovement;
 use chrono::Utc;
-use super::*;
 
 impl AppState {
     pub fn travel_type_char(&mut self, c: char) {
@@ -43,38 +43,60 @@ impl AppState {
     /// Destination currently typed in the travel overlay, resolved to
     /// absolute coordinates (None while incomplete or invalid).
     pub fn resolve_travel_target(&self) -> Option<(i32, i32, i32)> {
-        let ActiveWizard::Travel(TravelInput::Typing(buf)) = &self.active_wizard else { return None };
+        let ActiveWizard::Travel(TravelInput::Typing(buf)) = &self.active_wizard else {
+            return None;
+        };
         Self::parse_travel_buf(buf, self.probe_sector_coords())
     }
 
     pub fn travel_submit(&mut self) {
-        let Some((x, y, z)) = self.resolve_travel_target() else { return };
+        let Some((x, y, z)) = self.resolve_travel_target() else {
+            return;
+        };
         let error = if (x + y + z) % 2 != 0 {
             Some("x+y+z must be even".to_string())
         } else {
             None
         };
         let (sector_distance, fuel_cost, eta_minutes) = self.travel_preview(x, y, z);
-        self.active_wizard = ActiveWizard::Travel(TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error });
+        self.active_wizard = ActiveWizard::Travel(TravelInput::Confirming {
+            x,
+            y,
+            z,
+            sector_distance,
+            fuel_cost,
+            eta_minutes,
+            error,
+        });
     }
 
     pub fn travel_go_sector(&mut self, x: i32, y: i32, z: i32) {
         let (sector_distance, fuel_cost, eta_minutes) = self.travel_preview(x, y, z);
-        self.active_wizard = ActiveWizard::Travel(TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error: None });
+        self.active_wizard = ActiveWizard::Travel(TravelInput::Confirming {
+            x,
+            y,
+            z,
+            sector_distance,
+            fuel_cost,
+            eta_minutes,
+            error: None,
+        });
     }
 
     fn travel_preview(&self, x: i32, y: i32, z: i32) -> (Option<i64>, Option<f64>, Option<i64>) {
-        let sector_distance = self.distance_to(x, y, z)
-            .or_else(|| {
-                self.scan_history.iter()
-                    .find(|s| {
-                        s.relative_coordinates.x as i32 == x
-                            && s.relative_coordinates.y as i32 == y
-                            && s.relative_coordinates.z as i32 == z
-                    })
-                    .map(|s| s.distance)
-            });
-        let fuel_cost = self.probe.as_ref()
+        let sector_distance = self.distance_to(x, y, z).or_else(|| {
+            self.scan_history
+                .iter()
+                .find(|s| {
+                    s.relative_coordinates.x as i32 == x
+                        && s.relative_coordinates.y as i32 == y
+                        && s.relative_coordinates.z as i32 == z
+                })
+                .map(|s| s.distance)
+        });
+        let fuel_cost = self
+            .probe
+            .as_ref()
             .and_then(|p| p.fuel.deuterium)
             .map(|d| (d * 0.02 * 10000.0).round() / 10000.0);
         let eta_minutes = sector_distance.map(|d| 5 + 35 * d);

--- a/src/app/waypoints.rs
+++ b/src/app/waypoints.rs
@@ -1,5 +1,5 @@
-use crate::api::types::SectorObjectType;
 use super::*;
+use crate::api::types::SectorObjectType;
 
 /// Category of a known destination shown in the waypoints overlay.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -40,7 +40,9 @@ impl AppState {
                 let obj_name = o.name.clone().unwrap_or_else(|| "object".into());
                 for wb in &o.waypoint_bookmarks {
                     bookmarks.push(WaypointEntry {
-                        x, y, z,
+                        x,
+                        y,
+                        z,
                         distance: s.distance,
                         label: format!("{} @ {}", wb.name, obj_name),
                         kind: WaypointKind::Bookmark,
@@ -50,7 +52,9 @@ impl AppState {
                     let t_name = t.name.clone().unwrap_or_else(|| "object".into());
                     for wb in &t.waypoint_bookmarks {
                         bookmarks.push(WaypointEntry {
-                            x, y, z,
+                            x,
+                            y,
+                            z,
                             distance: s.distance,
                             label: format!("{} @ {}", wb.name, t_name),
                             kind: WaypointKind::Bookmark,
@@ -59,24 +63,28 @@ impl AppState {
                 }
             }
 
-            let has_star = objects.iter().any(|o| {
-                matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem)
-            });
+            let has_star = objects
+                .iter()
+                .any(|o| matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem));
             if has_star {
                 stars.push(WaypointEntry {
-                    x, y, z,
+                    x,
+                    y,
+                    z,
                     distance: s.distance,
                     label: "star".into(),
                     kind: WaypointKind::Star,
                 });
             }
 
-            let has_minable = objects.iter().any(|o| {
-                o.minable_targets.as_ref().is_some_and(|t| !t.is_empty())
-            });
+            let has_minable = objects
+                .iter()
+                .any(|o| o.minable_targets.as_ref().is_some_and(|t| !t.is_empty()));
             if has_minable {
                 minables.push(WaypointEntry {
-                    x, y, z,
+                    x,
+                    y,
+                    z,
                     distance: s.distance,
                     label: "minable resources".into(),
                     kind: WaypointKind::Minable,

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,8 +110,7 @@ pub fn write_config(base_url: &str, api_key: &str) -> Result<PathBuf> {
 /// Path-injectable core of `write_config`.
 fn write_config_at(path: &std::path::Path, base_url: &str, api_key: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating config dir {}", parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| format!("creating config dir {}", parent.display()))?;
     }
     // `{:?}` emits a double-quoted, backslash-escaped string — valid TOML basic
     // string syntax, and API keys / URLs never contain anything exotic.
@@ -141,11 +140,7 @@ pub fn history_path() -> PathBuf {
 /// source.
 pub fn db_path() -> PathBuf {
     ProjectDirs::from("net", "neumann", "neumann-cockpit")
-        .map(|d| {
-            d.state_dir()
-                .unwrap_or_else(|| d.data_local_dir())
-                .join("cockpit.db")
-        })
+        .map(|d| d.state_dir().unwrap_or_else(|| d.data_local_dir()).join("cockpit.db"))
         .unwrap_or_else(|| PathBuf::from("cockpit.db"))
 }
 
@@ -216,7 +211,10 @@ mod tests {
     fn placeholder_and_empty_key_need_key() {
         let path = tmp("placeholder");
         std::fs::write(&path, format!("api_key = {PLACEHOLDER_KEY:?}\n")).unwrap();
-        assert!(matches!(load_status_at(&path), ConfigStatus::NeedsKey), "example key is not real");
+        assert!(
+            matches!(load_status_at(&path), ConfigStatus::NeedsKey),
+            "example key is not real"
+        );
         std::fs::write(&path, "api_key = \"\"\n").unwrap();
         assert!(matches!(load_status_at(&path), ConfigStatus::NeedsKey), "empty key");
         std::fs::write(&path, "base_url = \"https://x\"\n").unwrap();

--- a/src/input/alerts.rs
+++ b/src/input/alerts.rs
@@ -22,7 +22,11 @@ pub(super) fn handle_alerts_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let ActiveWizard::Alerts(AlertsInput::Browsing { selection, show_warnings }) = state.active_wizard else {
+    let ActiveWizard::Alerts(AlertsInput::Browsing {
+        selection,
+        show_warnings,
+    }) = state.active_wizard
+    else {
         return;
     };
     let count = tab_len(state, show_warnings);
@@ -41,7 +45,10 @@ pub(super) fn handle_alerts_event(
         }
         KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
             if let Some(new_sel) = list_nav(code, selection, count) {
-                state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing { selection: new_sel, show_warnings });
+                state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing {
+                    selection: new_sel,
+                    show_warnings,
+                });
             }
         }
         KeyCode::Enter => {

--- a/src/input/assemble.rs
+++ b/src/input/assemble.rs
@@ -28,8 +28,12 @@ pub(super) fn handle_assemble_probe_event(
             }
         }
         KeyCode::Char(' ') => {
-            if let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { selected, cursor, error, .. }) =
-                &mut state.active_wizard
+            if let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers {
+                selected,
+                cursor,
+                error,
+                ..
+            }) = &mut state.active_wizard
             {
                 let cur = *cursor;
                 if let Some(pos) = selected.iter().position(|&i| i == cur) {
@@ -46,11 +50,13 @@ pub(super) fn handle_assemble_probe_event(
         KeyCode::Enter => {
             // Extract the order without holding a borrow across the fire.
             let order = match &state.active_wizard {
-                ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { manny_id, containers, selected, .. })
-                    if selected.len() == 2 =>
-                {
-                    let ids: Vec<String> =
-                        selected.iter().map(|&i| containers[i].0.clone()).collect();
+                ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers {
+                    manny_id,
+                    containers,
+                    selected,
+                    ..
+                }) if selected.len() == 2 => {
+                    let ids: Vec<String> = selected.iter().map(|&i| containers[i].0.clone()).collect();
                     Some((manny_id.clone(), ids))
                 }
                 _ => None,

--- a/src/input/cockpit.rs
+++ b/src/input/cockpit.rs
@@ -11,28 +11,21 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{
-    fetch_ack_alert, fetch_ack_damage_warning, fetch_alerts, fetch_all, fetch_damage_warnings,
-    fetch_inspect, fetch_messages, fetch_recover, fetch_scut_network, fetch_sector,
-    fetch_sent_messages, fetch_set_default_probe, fetch_storage_container_detail,
+    fetch_ack_alert, fetch_ack_damage_warning, fetch_alerts, fetch_all, fetch_damage_warnings, fetch_inspect,
+    fetch_messages, fetch_recover, fetch_scut_network, fetch_sector, fetch_sent_messages, fetch_set_default_probe,
+    fetch_storage_container_detail,
 };
 use crate::api::types::{MannyTask, MannyTaskVisibility};
 use crate::app::{
-    ActiveWizard, ApiMessage, AppState, AssembleProbeInput, CommsCategory, MissionsCategory, DeployInput, FabricationInput, ImproveInput, DetachInput, DropCargoInput, LogEvent,
-    CommandLine, DropStorageContainerInput, DrillLevel, InputMode, InspectInput, MenuAction,
-    MessagesInput,
-    MindSnapshotInput, MineInput, MissionsInput, ObjectActionInput, Pane, RecallInput, RecoverInput,
-    GotoVisitedInput, ProbeSwitchInput, RefuelInput, RemoteMineInput, RenameContainerInput, RenameMannyInput, TransferDeuteriumInput,
-    RenameProbeInput,
-    RepairInput, SalvageInput, ScanMode, ScutNetworkInput, StorageMoveInput, TravelInput,
-    WaypointsInput,
+    ActiveWizard, ApiMessage, AppState, AssembleProbeInput, CommandLine, CommsCategory, DeployInput, DetachInput,
+    DrillLevel, DropCargoInput, DropStorageContainerInput, FabricationInput, GotoVisitedInput, ImproveInput, InputMode,
+    InspectInput, LogEvent, MenuAction, MessagesInput, MindSnapshotInput, MineInput, MissionsCategory, MissionsInput,
+    ObjectActionInput, Pane, ProbeSwitchInput, RecallInput, RecoverInput, RefuelInput, RemoteMineInput,
+    RenameContainerInput, RenameMannyInput, RenameProbeInput, RepairInput, SalvageInput, ScanMode, ScutNetworkInput,
+    StorageMoveInput, TransferDeuteriumInput, TravelInput, WaypointsInput,
 };
 
-pub fn handle_cockpit_event(
-    code: KeyCode,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
+pub fn handle_cockpit_event(code: KeyCode, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     // Cockpit keys (ertdfgcvb, jkhl, z, q, …) are all lowercase, but CapsLock —
     // or Shift — sends uppercase letters, and no cockpit binding uses those.
     // Normalize so the grid stays navigable regardless of CapsLock. Text entry
@@ -136,7 +129,10 @@ fn comms_activate(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<Ap
     match state.comms_drill() {
         None => match CommsCategory::ALL.get(cursor) {
             Some(CommsCategory::Messages) => {
-                state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 });
+                state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing {
+                    sent_tab: false,
+                    selection: 0,
+                });
                 fetch_messages(client.clone(), tx.clone());
                 fetch_sent_messages(client.clone(), tx.clone());
             }
@@ -205,9 +201,7 @@ fn drill_in(state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessa
     }
     state.pane_drill_in();
     if state.active_pane == Pane::Storage {
-        if let Some(DrillLevel::Container(id)) =
-            state.pane_nav[Pane::Storage.index()].drill.last().cloned()
-        {
+        if let Some(DrillLevel::Container(id)) = state.pane_nav[Pane::Storage.index()].drill.last().cloned() {
             state.storage_container_detail = None;
             state.storage_container_detail_error = None;
             fetch_storage_container_detail(id, client.clone(), tx.clone());
@@ -244,12 +238,7 @@ fn open_sector_object_actions(state: &mut AppState) {
     });
 }
 
-fn handle_menu_key(
-    code: KeyCode,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
+fn handle_menu_key(code: KeyCode, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     match code {
         KeyCode::Esc => state.mode = InputMode::Normal,
         KeyCode::Up | KeyCode::Char('k') => {
@@ -295,12 +284,7 @@ fn handle_menu_key(
 
 /// Launch the wizard behind a menu action for the selected Manny. Mirrors the
 /// classic single-key launches; the shared wizard handlers take over next.
-fn fire_menu_action(
-    action: MenuAction,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
+fn fire_menu_action(action: MenuAction, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     // Inventory-pane actions operate on the selected inventory row, not a Manny.
     match action {
         MenuAction::Jettison => {
@@ -336,7 +320,10 @@ fn fire_menu_action(
                         selection: 0,
                     });
                 }
-                _ => state.active_wizard = ActiveWizard::StorageMove(StorageMoveInput::PickManny { mannies, selection: 0 }),
+                _ => {
+                    state.active_wizard =
+                        ActiveWizard::StorageMove(StorageMoveInput::PickManny { mannies, selection: 0 })
+                }
             }
             return;
         }
@@ -362,13 +349,21 @@ fn fire_menu_action(
                     state.scut_network_view = None;
                     fetch_scut_network(nets[0].0, client.clone(), tx.clone());
                 }
-                _ => state.active_wizard = ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks: nets, selection: 0 }),
+                _ => {
+                    state.active_wizard = ActiveWizard::ScutNetwork(ScutNetworkInput::Picking {
+                        networks: nets,
+                        selection: 0,
+                    })
+                }
             }
             return;
         }
         MenuAction::Improve => {
             if state.has_orderable_improvement() {
-                state.active_wizard = ActiveWizard::Improve(ImproveInput::PickImprovement { selection: 0, error: None });
+                state.active_wizard = ActiveWizard::Improve(ImproveInput::PickImprovement {
+                    selection: 0,
+                    error: None,
+                });
             } else {
                 state.error = Some("no probe improvement available".into());
             }
@@ -462,11 +457,7 @@ fn fire_menu_action(
             if state.fleet.len() > 1 {
                 // Open the picker on the currently active probe.
                 let active = state.active_probe_id.or(state.default_probe_id);
-                let selection = state
-                    .fleet
-                    .iter()
-                    .position(|p| Some(p.id) == active)
-                    .unwrap_or(0);
+                let selection = state.fleet.iter().position(|p| Some(p.id) == active).unwrap_or(0);
                 state.probe_switch = ProbeSwitchInput::Picking { selection };
             }
             return;
@@ -510,7 +501,12 @@ fn fire_menu_action(
 
     match action {
         MenuAction::Repair if can => {
-            state.active_wizard = ActiveWizard::Repair(RepairInput::Typing { manny_id: id, manny_name: name, buf: String::new(), error: None });
+            state.active_wizard = ActiveWizard::Repair(RepairInput::Typing {
+                manny_id: id,
+                manny_name: name,
+                buf: String::new(),
+                error: None,
+            });
         }
         MenuAction::Fabricate if can => {
             if state.fabrication_recipes().is_empty() {
@@ -567,7 +563,14 @@ fn fire_menu_action(
                             error: None,
                         });
                     }
-                    _ => state.active_wizard = ActiveWizard::Mine(MineInput::PickAsteroid { manny_id: id, manny_name: name, candidates, selection: 0 }),
+                    _ => {
+                        state.active_wizard = ActiveWizard::Mine(MineInput::PickAsteroid {
+                            manny_id: id,
+                            manny_name: name,
+                            candidates,
+                            selection: 0,
+                        })
+                    }
                 }
             }
         }
@@ -577,9 +580,22 @@ fn fire_menu_action(
                 0 => state.error = Some("no salvageable objects in current sector — scan first".into()),
                 1 => {
                     let (object_id, object_name) = candidates.into_iter().next().unwrap();
-                    state.active_wizard = ActiveWizard::Salvage(SalvageInput::Confirm { manny_id: id, manny_name: name, object_id, object_name, error: None });
+                    state.active_wizard = ActiveWizard::Salvage(SalvageInput::Confirm {
+                        manny_id: id,
+                        manny_name: name,
+                        object_id,
+                        object_name,
+                        error: None,
+                    });
                 }
-                _ => state.active_wizard = ActiveWizard::Salvage(SalvageInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0 }),
+                _ => {
+                    state.active_wizard = ActiveWizard::Salvage(SalvageInput::PickTarget {
+                        manny_id: id,
+                        manny_name: name,
+                        candidates,
+                        selection: 0,
+                    })
+                }
             }
         }
         MenuAction::Inspect if can => {
@@ -591,7 +607,15 @@ fn fire_menu_action(
                     fetch_inspect(id, object_id, client.clone(), tx.clone());
                     state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
                 }
-                _ => state.active_wizard = ActiveWizard::Inspect(InspectInput::PickTarget { manny_id: id, manny_name: name, candidates, selection: 0, error: None }),
+                _ => {
+                    state.active_wizard = ActiveWizard::Inspect(InspectInput::PickTarget {
+                        manny_id: id,
+                        manny_name: name,
+                        candidates,
+                        selection: 0,
+                        error: None,
+                    })
+                }
             }
         }
         MenuAction::Recover if can => {
@@ -603,7 +627,15 @@ fn fire_menu_action(
                     fetch_recover(id, object_id, client.clone(), tx.clone());
                     state.log_event(LogEvent::recover(&container_name, state.active_probe_id));
                 }
-                _ => state.active_wizard = ActiveWizard::Recover(RecoverInput::PickContainer { manny_id: id, manny_name: name, candidates, selection: 0, error: None }),
+                _ => {
+                    state.active_wizard = ActiveWizard::Recover(RecoverInput::PickContainer {
+                        manny_id: id,
+                        manny_name: name,
+                        candidates,
+                        selection: 0,
+                        error: None,
+                    })
+                }
             }
         }
         MenuAction::Detach if can => {
@@ -612,9 +644,23 @@ fn fire_menu_action(
                 0 => state.error = Some("no detachable containers in inventory".into()),
                 1 => {
                     let (container_id, container_name) = containers.into_iter().next().unwrap();
-                    state.active_wizard = ActiveWizard::Detach(DetachInput::PickMode { manny_id: id, manny_name: name, container_id, container_name, selection: 0, error: None });
+                    state.active_wizard = ActiveWizard::Detach(DetachInput::PickMode {
+                        manny_id: id,
+                        manny_name: name,
+                        container_id,
+                        container_name,
+                        selection: 0,
+                        error: None,
+                    });
                 }
-                _ => state.active_wizard = ActiveWizard::Detach(DetachInput::PickContainer { manny_id: id, manny_name: name, containers, selection: 0 }),
+                _ => {
+                    state.active_wizard = ActiveWizard::Detach(DetachInput::PickContainer {
+                        manny_id: id,
+                        manny_name: name,
+                        containers,
+                        selection: 0,
+                    })
+                }
             }
         }
         MenuAction::DropStorageContainer if can => {
@@ -650,7 +696,11 @@ fn fire_menu_action(
         }
         MenuAction::Refuel if can => {
             if state.deuterium_station_in_current_sector() {
-                state.active_wizard = ActiveWizard::Refuel(RefuelInput::Confirm { manny_id: id, manny_name: name, error: None });
+                state.active_wizard = ActiveWizard::Refuel(RefuelInput::Confirm {
+                    manny_id: id,
+                    manny_name: name,
+                    error: None,
+                });
             } else {
                 state.error = Some("no deuterium refuel station in this sector".into());
             }
@@ -669,14 +719,28 @@ fn fire_menu_action(
             }
         }
         MenuAction::DropCargo if waiting_space => {
-            state.active_wizard = ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_id: id, manny_name: name, error: None });
+            state.active_wizard = ActiveWizard::DropCargo(DropCargoInput::Confirm {
+                manny_id: id,
+                manny_name: name,
+                error: None,
+            });
         }
         MenuAction::Recall if !can && has_task => {
-            state.active_wizard = ActiveWizard::Recall(RecallInput::Confirm { manny_id: id, manny_name: name, remote: remote_recall, error: None });
+            state.active_wizard = ActiveWizard::Recall(RecallInput::Confirm {
+                manny_id: id,
+                manny_name: name,
+                remote: remote_recall,
+                error: None,
+            });
         }
         MenuAction::Rename => {
             let buf = state.next_name_suggestion();
-            state.active_wizard = ActiveWizard::RenameManny(RenameMannyInput::Typing { manny_id: id, manny_name: name, buf, error: None });
+            state.active_wizard = ActiveWizard::RenameManny(RenameMannyInput::Typing {
+                manny_id: id,
+                manny_name: name,
+                buf,
+                error: None,
+            });
         }
         // Guard mismatch (state changed since the menu was built): no-op.
         _ => {}

--- a/src/input/command.rs
+++ b/src/input/command.rs
@@ -3,9 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_all, fetch_atomic_printer_craft, fetch_craft, fetch_mine};
-use crate::app::{
-    command_usage, ApiMessage, AppState, CommandFire, CompletionState, InputMode, LogEvent,
-};
+use crate::app::{command_usage, ApiMessage, AppState, CommandFire, CompletionState, InputMode, LogEvent};
 
 /// Route a key while the `:` command line is open. Typed characters are literal
 /// input; `Enter` runs the command, `Tab` completes/cycles the token under the
@@ -31,24 +29,40 @@ pub(super) fn handle_command_event(
             if let Some(fire) = state.pending_fire.take() {
                 match fire {
                     CommandFire::AtomicCraft { recipe_id } => {
-                        let name = state.fabrication_recipes().iter()
-                            .find(|(_, r)| r.id == recipe_id).map(|(_, r)| r.name.clone());
+                        let name = state
+                            .fabrication_recipes()
+                            .iter()
+                            .find(|(_, r)| r.id == recipe_id)
+                            .map(|(_, r)| r.name.clone());
                         fetch_atomic_printer_craft(recipe_id, client.clone(), tx.clone());
                         if let Some(name) = name {
                             state.log_event(LogEvent::craft(&name, true, state.active_probe_id));
                         }
                     }
                     CommandFire::MannyCraft { manny_id, recipe_id } => {
-                        let name = state.fabrication_recipes().iter()
-                            .find(|(_, r)| r.id == recipe_id).map(|(_, r)| r.name.clone());
+                        let name = state
+                            .fabrication_recipes()
+                            .iter()
+                            .find(|(_, r)| r.id == recipe_id)
+                            .map(|(_, r)| r.name.clone());
                         fetch_craft(manny_id, recipe_id, client.clone(), tx.clone());
                         if let Some(name) = name {
                             state.log_event(LogEvent::craft(&name, false, state.active_probe_id));
                         }
                     }
-                    CommandFire::Mine { manny_id, object_id, resources, amount, container_id } => {
+                    CommandFire::Mine {
+                        manny_id,
+                        object_id,
+                        resources,
+                        amount,
+                        container_id,
+                    } => {
                         let resources_label = resources.join(", ");
-                        let destination = if container_id.is_some() { "a container" } else { "the probe" };
+                        let destination = if container_id.is_some() {
+                            "a container"
+                        } else {
+                            "the probe"
+                        };
                         fetch_mine(
                             manny_id,
                             object_id,
@@ -58,7 +72,12 @@ pub(super) fn handle_command_event(
                             client.clone(),
                             tx.clone(),
                         );
-                        state.log_event(LogEvent::mine(&resources_label, amount, destination, state.active_probe_id));
+                        state.log_event(LogEvent::mine(
+                            &resources_label,
+                            amount,
+                            destination,
+                            state.active_probe_id,
+                        ));
                     }
                 }
             }
@@ -67,7 +86,9 @@ pub(super) fn handle_command_event(
         KeyCode::Up => history_step(state, -1),
         KeyCode::Down => history_step(state, 1),
         KeyCode::Backspace => {
-            let InputMode::Command(cmd) = &mut state.mode else { return };
+            let InputMode::Command(cmd) = &mut state.mode else {
+                return;
+            };
             if cmd.cursor > 0 {
                 cmd.cursor -= 1;
                 cmd.input.remove(byte_at(&cmd.input, cmd.cursor));
@@ -76,17 +97,23 @@ pub(super) fn handle_command_event(
             cmd.history_idx = None;
         }
         KeyCode::Left => {
-            let InputMode::Command(cmd) = &mut state.mode else { return };
+            let InputMode::Command(cmd) = &mut state.mode else {
+                return;
+            };
             cmd.cursor = cmd.cursor.saturating_sub(1);
             cmd.completion = None;
         }
         KeyCode::Right => {
-            let InputMode::Command(cmd) = &mut state.mode else { return };
+            let InputMode::Command(cmd) = &mut state.mode else {
+                return;
+            };
             cmd.cursor = (cmd.cursor + 1).min(cmd.input.chars().count());
             cmd.completion = None;
         }
         KeyCode::Char(c) => {
-            let InputMode::Command(cmd) = &mut state.mode else { return };
+            let InputMode::Command(cmd) = &mut state.mode else {
+                return;
+            };
             let byte = byte_at(&cmd.input, cmd.cursor);
             cmd.input.insert(byte, c);
             cmd.cursor += 1;
@@ -145,12 +172,17 @@ fn cycle_completion(state: &mut AppState) {
     }
     let cursor = new_input.chars().count();
 
-    let InputMode::Command(cmd) = &mut state.mode else { return };
+    let InputMode::Command(cmd) = &mut state.mode else {
+        return;
+    };
     cmd.input = new_input;
     cmd.cursor = cursor;
     cmd.history_idx = None;
-    cmd.completion =
-        (!unique).then_some(CompletionState { candidates, index, token_start });
+    cmd.completion = (!unique).then_some(CompletionState {
+        candidates,
+        index,
+        token_start,
+    });
 }
 
 /// `↑`/`↓`: step through the command history. `dir` is `-1` (older) or `1`
@@ -175,7 +207,9 @@ fn history_step(state: &mut AppState, dir: i32) {
         (Some(i), _) if i + 1 < len => Some(i + 1),
         // Newer past the end → drop back to the live (empty) line.
         (Some(_), _) => {
-            let InputMode::Command(cmd) = &mut state.mode else { return };
+            let InputMode::Command(cmd) = &mut state.mode else {
+                return;
+            };
             cmd.history_idx = None;
             cmd.input.clear();
             cmd.cursor = 0;
@@ -185,7 +219,9 @@ fn history_step(state: &mut AppState, dir: i32) {
     };
 
     let line = state.command_history[new_idx.unwrap()].clone();
-    let InputMode::Command(cmd) = &mut state.mode else { return };
+    let InputMode::Command(cmd) = &mut state.mode else {
+        return;
+    };
     cmd.history_idx = new_idx;
     cmd.cursor = line.chars().count();
     cmd.input = line;

--- a/src/input/containers.rs
+++ b/src/input/containers.rs
@@ -43,7 +43,10 @@ pub(super) fn handle_rename_container_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if !matches!(state.active_wizard, ActiveWizard::RenameContainer(RenameContainerInput::Typing { .. })) {
+    if !matches!(
+        state.active_wizard,
+        ActiveWizard::RenameContainer(RenameContainerInput::Typing { .. })
+    ) {
         return;
     }
     match code {
@@ -61,7 +64,8 @@ pub(super) fn handle_rename_container_event(
         }
         KeyCode::Enter => {
             let (id, label) = {
-                let ActiveWizard::RenameContainer(RenameContainerInput::Typing { container_id, buf, .. }) = &state.active_wizard
+                let ActiveWizard::RenameContainer(RenameContainerInput::Typing { container_id, buf, .. }) =
+                    &state.active_wizard
                 else {
                     return;
                 };
@@ -76,7 +80,9 @@ pub(super) fn handle_rename_container_event(
             state.log_event(LogEvent::rename_container(&new_label, state.active_probe_id));
         }
         KeyCode::Char(c) => {
-            if let ActiveWizard::RenameContainer(RenameContainerInput::Typing { buf, error, .. }) = &mut state.active_wizard {
+            if let ActiveWizard::RenameContainer(RenameContainerInput::Typing { buf, error, .. }) =
+                &mut state.active_wizard
+            {
                 if buf.chars().count() < 80 {
                     buf.push(c);
                     *error = None;
@@ -93,7 +99,8 @@ pub(super) fn handle_container_rules_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { selection, types, .. }) = &state.active_wizard else {
+    let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { selection, types, .. }) = &state.active_wizard
+    else {
         return;
     };
     let sel = *selection;
@@ -102,7 +109,9 @@ pub(super) fn handle_container_rules_event(
         KeyCode::Esc => state.close_wizard(),
         KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
             if let Some(ns) = list_nav(code, sel, count) {
-                if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { selection, .. }) = &mut state.active_wizard {
+                if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { selection, .. }) =
+                    &mut state.active_wizard
+                {
                     *selection = ns;
                 }
             }
@@ -116,7 +125,12 @@ pub(super) fn handle_container_rules_event(
         KeyCode::Delete | KeyCode::Backspace => {
             // Clear the selected type back to "none".
             if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
-                types, priority, exclusion, strict_exclusion, selection, ..
+                types,
+                priority,
+                exclusion,
+                strict_exclusion,
+                selection,
+                ..
             }) = &mut state.active_wizard
             {
                 if let Some(ty) = types.get(*selection).cloned() {
@@ -129,7 +143,12 @@ pub(super) fn handle_container_rules_event(
         KeyCode::Enter => {
             let (id, p, e, s, label) = {
                 let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
-                    container_id, priority, exclusion, strict_exclusion, container_label, ..
+                    container_id,
+                    priority,
+                    exclusion,
+                    strict_exclusion,
+                    container_label,
+                    ..
                 }) = &state.active_wizard
                 else {
                     return;
@@ -151,7 +170,12 @@ pub(super) fn handle_container_rules_event(
 
 fn cycle_selected(state: &mut AppState, backward: bool) {
     if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
-        types, priority, exclusion, strict_exclusion, selection, ..
+        types,
+        priority,
+        exclusion,
+        strict_exclusion,
+        selection,
+        ..
     }) = &mut state.active_wizard
     {
         if let Some(ty) = types.get(*selection).cloned() {

--- a/src/input/craft.rs
+++ b/src/input/craft.rs
@@ -1,10 +1,10 @@
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
+use super::geometry::list_nav;
 use crate::api::client::ApiClient;
 use crate::api::tasks::{fetch_atomic_printer_craft, fetch_craft};
-use crate::app::{ActiveWizard, ApiMessage, AppState, Fabricator, FabricationInput, LogEvent};
-use super::geometry::list_nav;
+use crate::app::{ActiveWizard, ApiMessage, AppState, FabricationInput, Fabricator, LogEvent};
 
 /// Drive the unified fabrication wizard. `PickRecipe` browses the sectioned
 /// catalog; committing an atomic recipe fires straight away, a Manny recipe
@@ -29,7 +29,9 @@ pub(super) fn handle_fabrication_event(
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ActiveWizard::Fabrication(FabricationInput::PickRecipe { ref mut selection, .. }) = state.active_wizard {
+                        if let ActiveWizard::Fabrication(FabricationInput::PickRecipe { ref mut selection, .. }) =
+                            state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
@@ -38,20 +40,33 @@ pub(super) fn handle_fabrication_event(
                 _ => {}
             }
         }
-        ActiveWizard::Fabrication(FabricationInput::PickBuilder { selection, ref mannies, .. }) => {
+        ActiveWizard::Fabrication(FabricationInput::PickBuilder {
+            selection, ref mannies, ..
+        }) => {
             let count = mannies.len();
             match code {
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ActiveWizard::Fabrication(FabricationInput::PickBuilder { ref mut selection, .. }) = state.active_wizard {
+                        if let ActiveWizard::Fabrication(FabricationInput::PickBuilder { ref mut selection, .. }) =
+                            state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let picked = if let ActiveWizard::Fabrication(FabricationInput::PickBuilder { ref mannies, selection, ref recipe_id, ref recipe_name, .. }) = state.active_wizard {
-                        mannies.get(selection).map(|(id, _)| (id.clone(), recipe_id.clone(), recipe_name.clone()))
+                    let picked = if let ActiveWizard::Fabrication(FabricationInput::PickBuilder {
+                        ref mannies,
+                        selection,
+                        ref recipe_id,
+                        ref recipe_name,
+                        ..
+                    }) = state.active_wizard
+                    {
+                        mannies
+                            .get(selection)
+                            .map(|(id, _)| (id.clone(), recipe_id.clone(), recipe_name.clone()))
                     } else {
                         None
                     };
@@ -68,13 +83,10 @@ pub(super) fn handle_fabrication_event(
 }
 
 /// Fire (or advance) the craft for the recipe under the catalog cursor.
-fn commit_recipe(
-    selection: usize,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
-    let Some((fab, recipe_id, recipe_name)) = state.fabrication_recipes().get(selection)
+fn commit_recipe(selection: usize, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
+    let Some((fab, recipe_id, recipe_name)) = state
+        .fabrication_recipes()
+        .get(selection)
         .map(|(fab, r)| (*fab, r.id.clone(), r.name.clone()))
     else {
         return;
@@ -89,7 +101,10 @@ fn commit_recipe(
             }
         }
         Fabricator::Manny => {
-            let prefilled = if let ActiveWizard::Fabrication(FabricationInput::PickRecipe { ref prefilled_manny, .. }) = state.active_wizard {
+            let prefilled = if let ActiveWizard::Fabrication(FabricationInput::PickRecipe {
+                ref prefilled_manny, ..
+            }) = state.active_wizard
+            {
                 prefilled_manny.clone()
             } else {
                 None

--- a/src/input/fleet.rs
+++ b/src/input/fleet.rs
@@ -14,7 +14,9 @@ use super::geometry::list_nav;
 /// reconciles the `ApiClient` and refetches. An unreachable probe is refused
 /// with a toast: piloting it would return only limited telemetry.
 pub(super) fn handle_probe_switch_event(code: KeyCode, state: &mut AppState) {
-    let ProbeSwitchInput::Picking { selection } = state.probe_switch else { return };
+    let ProbeSwitchInput::Picking { selection } = state.probe_switch else {
+        return;
+    };
     let count = state.fleet.len();
     match code {
         KeyCode::Esc => state.probe_switch = ProbeSwitchInput::Inactive,
@@ -51,20 +53,27 @@ pub(super) fn handle_transfer_deuterium_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     // Step 1 — destination picker.
-    if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget { targets, selection, .. }) = &state.active_wizard {
+    if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget { targets, selection, .. }) =
+        &state.active_wizard
+    {
         let (count, sel) = (targets.len(), *selection);
         match code {
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
-                if let (Some(ns), ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget { selection, .. })) =
-                    (list_nav(code, sel, count), &mut state.active_wizard)
+                if let (
+                    Some(ns),
+                    ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget { selection, .. }),
+                ) = (list_nav(code, sel, count), &mut state.active_wizard)
                 {
                     *selection = ns;
                 }
             }
             KeyCode::Enter => {
                 if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::PickTarget {
-                    manny_id, manny_name, targets, selection,
+                    manny_id,
+                    manny_name,
+                    targets,
+                    selection,
                 }) = &state.active_wizard
                 {
                     if let Some((target_id, target_name)) = targets.get(*selection).cloned() {
@@ -86,7 +95,10 @@ pub(super) fn handle_transfer_deuterium_event(
 
     // Step 2 — amount entry. Each arm takes its own borrow so reassigning the
     // wizard state never overlaps the mutable buffer borrow.
-    if !matches!(state.active_wizard, ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { .. })) {
+    if !matches!(
+        state.active_wizard,
+        ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { .. })
+    ) {
         return;
     }
     match code {
@@ -112,21 +124,22 @@ pub(super) fn handle_transfer_deuterium_event(
         }
         KeyCode::Enter => {
             let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount {
-                manny_id, target_id, target_name, buf, ..
-            }) = &state.active_wizard else { return };
+                manny_id,
+                target_id,
+                target_name,
+                buf,
+                ..
+            }) = &state.active_wizard
+            else {
+                return;
+            };
             match buf.trim().parse::<f64>() {
                 Ok(amount) if amount > 0.0 => {
                     let (mid, tid, tname) = (manny_id.clone(), *target_id, target_name.clone());
                     fetch_transfer_deuterium(mid, tid, amount, client.clone(), tx.clone());
-                    state.log_event(LogEvent::transfer_deuterium(
-                        &tname,
-                        amount,
-                        state.active_probe_id,
-                    ));
+                    state.log_event(LogEvent::transfer_deuterium(&tname, amount, state.active_probe_id));
                 }
-                _ => state.set_transfer_deuterium_error(
-                    "enter a positive deuterium percentage".to_string(),
-                ),
+                _ => state.set_transfer_deuterium_error("enter a positive deuterium percentage".to_string()),
             }
         }
         _ => {}

--- a/src/input/geometry.rs
+++ b/src/input/geometry.rs
@@ -25,7 +25,7 @@ pub(super) fn face_d2(axis: u8) -> Vec<(i32, i32, i32)> {
                 let coords = match axis {
                     b'x' => (face, u, v),
                     b'y' => (u, face, v),
-                    _    => (u, v, face),
+                    _ => (u, v, face),
                 };
                 if (coords.0 + coords.1 + coords.2) % 2 == 0 {
                     out.push(coords);

--- a/src/input/improve.rs
+++ b/src/input/improve.rs
@@ -1,10 +1,10 @@
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
+use super::geometry::list_nav;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_improve_probe;
 use crate::app::{ActiveWizard, ApiMessage, AppState, ImproveInput, LogEvent};
-use super::geometry::list_nav;
 
 /// Drive the probe-improvement wizard: pick an improvement, then resolve which
 /// idle onboard Manny installs it (auto for a single one, else `PickBuilder`).
@@ -21,7 +21,9 @@ pub(super) fn handle_improve_event(
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ActiveWizard::Improve(ImproveInput::PickImprovement { ref mut selection, .. }) = state.active_wizard {
+                        if let ActiveWizard::Improve(ImproveInput::PickImprovement { ref mut selection, .. }) =
+                            state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
@@ -30,20 +32,33 @@ pub(super) fn handle_improve_event(
                 _ => {}
             }
         }
-        ActiveWizard::Improve(ImproveInput::PickBuilder { selection, ref mannies, .. }) => {
+        ActiveWizard::Improve(ImproveInput::PickBuilder {
+            selection, ref mannies, ..
+        }) => {
             let count = mannies.len();
             match code {
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ActiveWizard::Improve(ImproveInput::PickBuilder { ref mut selection, .. }) = state.active_wizard {
+                        if let ActiveWizard::Improve(ImproveInput::PickBuilder { ref mut selection, .. }) =
+                            state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let picked = if let ActiveWizard::Improve(ImproveInput::PickBuilder { ref mannies, selection, ref improvement_id, ref improvement_name, .. }) = state.active_wizard {
-                        mannies.get(selection).map(|(id, _)| (id.clone(), improvement_id.clone(), improvement_name.clone()))
+                    let picked = if let ActiveWizard::Improve(ImproveInput::PickBuilder {
+                        ref mannies,
+                        selection,
+                        ref improvement_id,
+                        ref improvement_name,
+                        ..
+                    }) = state.active_wizard
+                    {
+                        mannies
+                            .get(selection)
+                            .map(|(id, _)| (id.clone(), improvement_id.clone(), improvement_name.clone()))
                     } else {
                         None
                     };
@@ -61,13 +76,10 @@ pub(super) fn handle_improve_event(
 
 /// Validate the selected improvement, then fire it (auto-picking the sole idle
 /// Manny) or advance to the builder-selection step.
-fn commit_improvement(
-    selection: usize,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
-    let Some((id, name, done, available)) = state.probe_improvements.get(selection)
+fn commit_improvement(selection: usize, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
+    let Some((id, name, done, available)) = state
+        .probe_improvements
+        .get(selection)
         .map(|i| (i.id.clone(), i.name.clone(), i.done, i.available))
     else {
         return;

--- a/src/input/jettison.rs
+++ b/src/input/jettison.rs
@@ -3,9 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_jettison;
-use crate::app::{
-    ActiveWizard, ApiMessage, AppState, JettisonInput,
-};
+use crate::app::{ActiveWizard, ApiMessage, AppState, JettisonInput};
 pub(super) fn handle_jettison_event(
     code: KeyCode,
     state: &mut AppState,
@@ -13,32 +11,34 @@ pub(super) fn handle_jettison_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match &state.active_wizard {
-        ActiveWizard::Jettison(JettisonInput::ConfirmManny { .. }) => {
-            match code {
-                KeyCode::Esc => state.close_wizard(),
-                KeyCode::Enter => {
-                    let item_id = {
-                        let ActiveWizard::Jettison(JettisonInput::ConfirmManny { ref item_id, .. }) = state.active_wizard else { return };
-                        item_id.clone()
+        ActiveWizard::Jettison(JettisonInput::ConfirmManny { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
+            KeyCode::Enter => {
+                let item_id = {
+                    let ActiveWizard::Jettison(JettisonInput::ConfirmManny { ref item_id, .. }) = state.active_wizard
+                    else {
+                        return;
                     };
-                    fetch_jettison(item_id, None, client.clone(), tx.clone());
-                }
-                _ => {}
+                    item_id.clone()
+                };
+                fetch_jettison(item_id, None, client.clone(), tx.clone());
             }
-        }
-        ActiveWizard::Jettison(JettisonInput::ConfirmRelay { .. }) => {
-            match code {
-                KeyCode::Esc => state.close_wizard(),
-                KeyCode::Enter => {
-                    let item_id = {
-                        let ActiveWizard::Jettison(JettisonInput::ConfirmRelay { ref item_id, .. }) = state.active_wizard else { return };
-                        item_id.clone()
+            _ => {}
+        },
+        ActiveWizard::Jettison(JettisonInput::ConfirmRelay { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
+            KeyCode::Enter => {
+                let item_id = {
+                    let ActiveWizard::Jettison(JettisonInput::ConfirmRelay { ref item_id, .. }) = state.active_wizard
+                    else {
+                        return;
                     };
-                    fetch_jettison(item_id, None, client.clone(), tx.clone());
-                }
-                _ => {}
+                    item_id.clone()
+                };
+                fetch_jettison(item_id, None, client.clone(), tx.clone());
             }
-        }
+            _ => {}
+        },
         ActiveWizard::Jettison(JettisonInput::EnterAmount { .. }) => {
             match code {
                 KeyCode::Esc => state.close_wizard(),
@@ -49,12 +49,22 @@ pub(super) fn handle_jettison_event(
                 // irreversible drop, rather than firing straight away.
                 KeyCode::Enter => {
                     let next = {
-                        let ActiveWizard::Jettison(JettisonInput::EnterAmount { ref item_id, ref item_name, ref buf, .. }) = state.active_wizard else { return };
+                        let ActiveWizard::Jettison(JettisonInput::EnterAmount {
+                            ref item_id,
+                            ref item_name,
+                            ref buf,
+                            ..
+                        }) = state.active_wizard
+                        else {
+                            return;
+                        };
                         let amount = if buf.is_empty() {
                             None
                         } else {
                             let Ok(v) = buf.parse::<f64>() else { return };
-                            if v <= 0.0 { return }
+                            if v <= 0.0 {
+                                return;
+                            }
                             Some(v)
                         };
                         JettisonInput::Confirm {
@@ -69,19 +79,22 @@ pub(super) fn handle_jettison_event(
                 _ => {}
             }
         }
-        ActiveWizard::Jettison(JettisonInput::Confirm { .. }) => {
-            match code {
-                KeyCode::Esc => state.close_wizard(),
-                KeyCode::Enter => {
-                    let (item_id, amount) = {
-                        let ActiveWizard::Jettison(JettisonInput::Confirm { ref item_id, amount, .. }) = state.active_wizard else { return };
-                        (item_id.clone(), amount)
+        ActiveWizard::Jettison(JettisonInput::Confirm { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
+            KeyCode::Enter => {
+                let (item_id, amount) = {
+                    let ActiveWizard::Jettison(JettisonInput::Confirm {
+                        ref item_id, amount, ..
+                    }) = state.active_wizard
+                    else {
+                        return;
                     };
-                    fetch_jettison(item_id, amount, client.clone(), tx.clone());
-                }
-                _ => {}
+                    (item_id.clone(), amount)
+                };
+                fetch_jettison(item_id, amount, client.clone(), tx.clone());
             }
-        }
+            _ => {}
+        },
         _ => {}
     }
 }

--- a/src/input/map.rs
+++ b/src/input/map.rs
@@ -7,7 +7,9 @@ use super::geometry::list_nav;
 /// Picker over visited sectors: navigate the list, `Enter` launches the travel
 /// confirm for the chosen sector, `Esc` cancels.
 pub(super) fn handle_goto_visited_event(code: KeyCode, state: &mut AppState) {
-    let GotoVisitedInput::Picking { selection } = state.goto_visited else { return };
+    let GotoVisitedInput::Picking { selection } = state.goto_visited else {
+        return;
+    };
     let count = state.visited_sectors.len();
     match code {
         KeyCode::Esc => state.goto_visited = GotoVisitedInput::Inactive,
@@ -59,10 +61,10 @@ pub(super) fn handle_map_event(code: KeyCode, state: &mut AppState) {
 
     match code {
         KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('b') => state.map.open = false,
-        KeyCode::Char('h') | KeyCode::Left  => state.map.center_x -= 2,
+        KeyCode::Char('h') | KeyCode::Left => state.map.center_x -= 2,
         KeyCode::Char('l') | KeyCode::Right => state.map.center_x += 2,
-        KeyCode::Char('k') | KeyCode::Up    => state.map.center_z -= 2,
-        KeyCode::Char('j') | KeyCode::Down  => state.map.center_z += 2,
+        KeyCode::Char('k') | KeyCode::Up => state.map.center_z -= 2,
+        KeyCode::Char('j') | KeyCode::Down => state.map.center_z += 2,
         KeyCode::Char('u') => state.map_move_y(1),
         KeyCode::Char('d') => state.map_move_y(-1),
         KeyCode::Char('0') => state.map_recenter_on_probe(),

--- a/src/input/messages.rs
+++ b/src/input/messages.rs
@@ -17,17 +17,27 @@ pub(super) fn handle_messages_event(
         ActiveWizard::Messages(MessagesInput::Browsing { sent_tab, selection }) => {
             let sent_tab = *sent_tab;
             let selection = *selection;
-            let count = if sent_tab { state.sent_messages.len() } else { state.messages.len() };
+            let count = if sent_tab {
+                state.sent_messages.len()
+            } else {
+                state.messages.len()
+            };
             match code {
                 KeyCode::Esc | KeyCode::Char('Y') | KeyCode::Char('q') => {
                     state.close_wizard();
                 }
                 KeyCode::Tab | KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l') => {
-                    state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: !sent_tab, selection: 0 });
+                    state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing {
+                        sent_tab: !sent_tab,
+                        selection: 0,
+                    });
                 }
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab, selection: new_sel });
+                        state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing {
+                            sent_tab,
+                            selection: new_sel,
+                        });
                     }
                 }
                 KeyCode::Enter => {
@@ -50,7 +60,10 @@ pub(super) fn handle_messages_event(
                     if recipients.is_empty() {
                         state.error = Some("no reachable recipient in this sector".into());
                     } else {
-                        state.active_wizard = ActiveWizard::Messages(MessagesInput::PickRecipient { recipients, selection: 0 });
+                        state.active_wizard = ActiveWizard::Messages(MessagesInput::PickRecipient {
+                            recipients,
+                            selection: 0,
+                        });
                     }
                 }
                 _ => {}
@@ -58,7 +71,10 @@ pub(super) fn handle_messages_event(
         }
         ActiveWizard::Messages(MessagesInput::Reading { sent_tab, .. }) => {
             let sent_tab = *sent_tab;
-            if matches!(code, KeyCode::Esc | KeyCode::Char('h') | KeyCode::Left | KeyCode::Char('q')) {
+            if matches!(
+                code,
+                KeyCode::Esc | KeyCode::Char('h') | KeyCode::Left | KeyCode::Char('q')
+            ) {
                 state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab, selection: 0 });
             }
         }
@@ -66,16 +82,29 @@ pub(super) fn handle_messages_event(
             let sel = *selection;
             let count = recipients.len();
             match code {
-                KeyCode::Esc => state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 }),
+                KeyCode::Esc => {
+                    state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing {
+                        sent_tab: false,
+                        selection: 0,
+                    })
+                }
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ActiveWizard::Messages(MessagesInput::PickRecipient { ref mut selection, .. }) = state.active_wizard {
+                        if let ActiveWizard::Messages(MessagesInput::PickRecipient { ref mut selection, .. }) =
+                            state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
-                    let ActiveWizard::Messages(MessagesInput::PickRecipient { ref recipients, selection }) = state.active_wizard else { return };
+                    let ActiveWizard::Messages(MessagesInput::PickRecipient {
+                        ref recipients,
+                        selection,
+                    }) = state.active_wizard
+                    else {
+                        return;
+                    };
                     let (kind, id, name) = recipients[selection].clone();
                     state.active_wizard = ActiveWizard::Messages(MessagesInput::Compose {
                         recipient_type: kind,
@@ -89,7 +118,12 @@ pub(super) fn handle_messages_event(
             }
         }
         ActiveWizard::Messages(MessagesInput::Compose { .. }) => match code {
-            KeyCode::Esc => state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 }),
+            KeyCode::Esc => {
+                state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing {
+                    sent_tab: false,
+                    selection: 0,
+                })
+            }
             KeyCode::Backspace => {
                 if let ActiveWizard::Messages(MessagesInput::Compose { ref mut body_buf, .. }) = state.active_wizard {
                     body_buf.pop();
@@ -102,9 +136,25 @@ pub(super) fn handle_messages_event(
             }
             KeyCode::Enter => {
                 let (kind, id, body, recipient_name) = {
-                    let ActiveWizard::Messages(MessagesInput::Compose { ref recipient_type, ref recipient_id, ref body_buf, ref recipient_name, .. }) = state.active_wizard else { return };
-                    if body_buf.trim().is_empty() { return }
-                    (recipient_type.clone(), recipient_id.clone(), body_buf.clone(), recipient_name.clone())
+                    let ActiveWizard::Messages(MessagesInput::Compose {
+                        ref recipient_type,
+                        ref recipient_id,
+                        ref body_buf,
+                        ref recipient_name,
+                        ..
+                    }) = state.active_wizard
+                    else {
+                        return;
+                    };
+                    if body_buf.trim().is_empty() {
+                        return;
+                    }
+                    (
+                        recipient_type.clone(),
+                        recipient_id.clone(),
+                        body_buf.clone(),
+                        recipient_name.clone(),
+                    )
                 };
                 fetch_send_message(kind, id, body, client.clone(), tx.clone());
                 state.log_event(LogEvent::message_sent(&recipient_name, state.active_probe_id));

--- a/src/input/mine.rs
+++ b/src/input/mine.rs
@@ -1,12 +1,10 @@
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
+use super::geometry::list_nav;
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_mine;
-use crate::app::{
-    ActiveWizard, ApiMessage, AppState, LogEvent, MineInput, RemoteMineInput, RESOURCE_TYPES,
-};
-use super::geometry::list_nav;
+use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, MineInput, RemoteMineInput, RESOURCE_TYPES};
 
 /// Cycle the optional mining target container: None → first → … → last → None.
 pub(crate) fn next_target_container(
@@ -51,7 +49,9 @@ mod tests {
         let list = vec![c("a")];
         let stale = c("gone");
         assert_eq!(
-            next_target_container(Some(&stale), &list).as_ref().map(|(id, _)| id.as_str()),
+            next_target_container(Some(&stale), &list)
+                .as_ref()
+                .map(|(id, _)| id.as_str()),
             Some("a")
         );
     }
@@ -64,21 +64,32 @@ pub(super) fn handle_mine_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match &state.active_wizard {
-        ActiveWizard::Mine(MineInput::PickAsteroid { selection, candidates, .. }) => {
+        ActiveWizard::Mine(MineInput::PickAsteroid {
+            selection, candidates, ..
+        }) => {
             let sel = *selection;
             let count = candidates.len();
             match code {
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ActiveWizard::Mine(MineInput::PickAsteroid { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::Mine(MineInput::PickAsteroid { selection, .. }) = &mut state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (manny_id, manny_name, object_id, object_name) = {
-                        let ActiveWizard::Mine(MineInput::PickAsteroid { manny_id, manny_name, candidates, selection }) = &state.active_wizard else { return };
+                        let ActiveWizard::Mine(MineInput::PickAsteroid {
+                            manny_id,
+                            manny_name,
+                            candidates,
+                            selection,
+                        }) = &state.active_wizard
+                        else {
+                            return;
+                        };
                         let (id, name) = candidates[*selection].clone();
                         (manny_id.clone(), manny_name.clone(), id, name)
                     };
@@ -90,7 +101,10 @@ pub(super) fn handle_mine_event(
                         .filter(|f| f.iter().any(|&x| x))
                         .unwrap_or([false, true, false, false]);
                     state.active_wizard = ActiveWizard::Mine(MineInput::Configure {
-                        manny_id, manny_name, object_id, object_name,
+                        manny_id,
+                        manny_name,
+                        object_id,
+                        object_name,
                         resources,
                         amount_buf: "0.30".into(),
                         amount_mode: false,
@@ -101,14 +115,21 @@ pub(super) fn handle_mine_event(
                 _ => {}
             }
         }
-        ActiveWizard::Mine(MineInput::Configure { amount_mode, object_id, resources, .. }) => {
+        ActiveWizard::Mine(MineInput::Configure {
+            amount_mode,
+            object_id,
+            resources,
+            ..
+        }) => {
             let am = *amount_mode;
             let obj_id = object_id.clone();
             let res = *resources;
             match code {
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Tab => {
-                    if let ActiveWizard::Mine(MineInput::Configure { amount_mode, error, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::Mine(MineInput::Configure { amount_mode, error, .. }) =
+                        &mut state.active_wizard
+                    {
                         *amount_mode = !am;
                         *error = None;
                     }
@@ -121,7 +142,9 @@ pub(super) fn handle_mine_event(
                         .map(|(flags, _)| flags[idx])
                         .unwrap_or(true);
                     if present {
-                        if let ActiveWizard::Mine(MineInput::Configure { resources, error, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::Mine(MineInput::Configure { resources, error, .. }) =
+                            &mut state.active_wizard
+                        {
                             resources[idx] = !resources[idx];
                             *error = None;
                         }
@@ -129,13 +152,15 @@ pub(super) fn handle_mine_event(
                 }
                 KeyCode::Char('m') | KeyCode::Char('M') if am => {
                     let max = state.mine_reserve_max(&obj_id, res);
-                    if let ActiveWizard::Mine(MineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::Mine(MineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard
+                    {
                         *amount_buf = format!("{:.4}", max);
                         *error = None;
                     }
                 }
                 KeyCode::Char(c) if am && (c.is_ascii_digit() || c == '.') => {
-                    if let ActiveWizard::Mine(MineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::Mine(MineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard
+                    {
                         if !(c == '.' && amount_buf.contains('.')) {
                             amount_buf.push(c);
                             *error = None;
@@ -149,30 +174,71 @@ pub(super) fn handle_mine_event(
                 }
                 KeyCode::Char('c') => {
                     let containers = state.collect_detached_containers();
-                    if let ActiveWizard::Mine(MineInput::Configure { target_container, error, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::Mine(MineInput::Configure {
+                        target_container,
+                        error,
+                        ..
+                    }) = &mut state.active_wizard
+                    {
                         *target_container = next_target_container(target_container.as_ref(), &containers);
                         *error = None;
                     }
                 }
                 KeyCode::Enter => {
                     let (manny_id, object_id, selected_resources, amount, container_id, destination) = {
-                        let ActiveWizard::Mine(MineInput::Configure { manny_id, object_id, resources, amount_buf, target_container, .. }) = &state.active_wizard else { return };
-                        let selected: Vec<String> = RESOURCE_TYPES.iter().enumerate()
+                        let ActiveWizard::Mine(MineInput::Configure {
+                            manny_id,
+                            object_id,
+                            resources,
+                            amount_buf,
+                            target_container,
+                            ..
+                        }) = &state.active_wizard
+                        else {
+                            return;
+                        };
+                        let selected: Vec<String> = RESOURCE_TYPES
+                            .iter()
+                            .enumerate()
                             .filter(|(i, _)| resources[*i])
                             .map(|(_, &t)| t.to_string())
                             .collect();
-                        if selected.is_empty() { return }
+                        if selected.is_empty() {
+                            return;
+                        }
                         let Ok(amount) = amount_buf.parse::<f64>() else { return };
-                        if amount <= 0.0 { return }
+                        if amount <= 0.0 {
+                            return;
+                        }
                         let destination = target_container
                             .as_ref()
                             .map(|(_, n)| n.clone())
                             .unwrap_or_else(|| "the probe".to_string());
-                        (manny_id.clone(), object_id.clone(), selected, amount, target_container.as_ref().map(|(id, _)| id.clone()), destination)
+                        (
+                            manny_id.clone(),
+                            object_id.clone(),
+                            selected,
+                            amount,
+                            target_container.as_ref().map(|(id, _)| id.clone()),
+                            destination,
+                        )
                     };
                     let resources_label = selected_resources.join(", ");
-                    fetch_mine(manny_id, object_id, selected_resources, amount, container_id, client.clone(), tx.clone());
-                    state.log_event(LogEvent::mine(&resources_label, amount, &destination, state.active_probe_id));
+                    fetch_mine(
+                        manny_id,
+                        object_id,
+                        selected_resources,
+                        amount,
+                        container_id,
+                        client.clone(),
+                        tx.clone(),
+                    );
+                    state.log_event(LogEvent::mine(
+                        &resources_label,
+                        amount,
+                        &destination,
+                        state.active_probe_id,
+                    ));
                 }
                 _ => {}
             }
@@ -193,29 +259,43 @@ pub(super) fn handle_remote_mine_event(
                 state.close_wizard();
             }
         }
-        ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { selection, candidates, .. }) => {
+        ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid {
+            selection, candidates, ..
+        }) => {
             let sel = *selection;
             let count = candidates.len();
             match code {
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid { selection, .. }) =
+                            &mut state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let ActiveWizard::RemoteMine(RemoteMineInput::PickAsteroid {
-                        manny_id, manny_name, x, y, z, candidates, selection,
-                    }) = &state.active_wizard else { return };
+                        manny_id,
+                        manny_name,
+                        x,
+                        y,
+                        z,
+                        candidates,
+                        selection,
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     let (object_id, object_name) = candidates[*selection].clone();
-                    let (manny_id, manny_name, x, y, z) =
-                        (manny_id.clone(), manny_name.clone(), *x, *y, *z);
+                    let (manny_id, manny_name, x, y, z) = (manny_id.clone(), manny_name.clone(), *x, *y, *z);
                     state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::Configure {
                         manny_id,
                         manny_name,
-                        x, y, z,
+                        x,
+                        y,
+                        z,
                         object_id,
                         object_name,
                         resources: [false, true, false, false],
@@ -232,20 +312,26 @@ pub(super) fn handle_remote_mine_event(
             match code {
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Tab => {
-                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_mode, error, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_mode, error, .. }) =
+                        &mut state.active_wizard
+                    {
                         *amount_mode = !am;
                         *error = None;
                     }
                 }
                 KeyCode::Char(c @ '1'..='4') if !am => {
                     let idx = (c as u8 - b'1') as usize;
-                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { resources, error, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { resources, error, .. }) =
+                        &mut state.active_wizard
+                    {
                         resources[idx] = !resources[idx];
                         *error = None;
                     }
                 }
                 KeyCode::Char(c) if am && (c.is_ascii_digit() || c == '.') => {
-                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_buf, error, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_buf, error, .. }) =
+                        &mut state.active_wizard
+                    {
                         if !(c == '.' && amount_buf.contains('.')) {
                             amount_buf.push(c);
                             *error = None;
@@ -253,18 +339,34 @@ pub(super) fn handle_remote_mine_event(
                     }
                 }
                 KeyCode::Backspace if am => {
-                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_buf, .. }) = &mut state.active_wizard {
+                    if let ActiveWizard::RemoteMine(RemoteMineInput::Configure { amount_buf, .. }) =
+                        &mut state.active_wizard
+                    {
                         amount_buf.pop();
                     }
                 }
                 KeyCode::Enter => {
                     let (manny_id, object_id, resources, amount, coords) = {
                         let ActiveWizard::RemoteMine(RemoteMineInput::Configure {
-                            manny_id, object_id, resources, amount_buf, x, y, z, ..
-                        }) = &state.active_wizard else { return };
-                        if !resources.iter().any(|&r| r) { return }
+                            manny_id,
+                            object_id,
+                            resources,
+                            amount_buf,
+                            x,
+                            y,
+                            z,
+                            ..
+                        }) = &state.active_wizard
+                        else {
+                            return;
+                        };
+                        if !resources.iter().any(|&r| r) {
+                            return;
+                        }
                         let Ok(amount) = amount_buf.parse::<f64>() else { return };
-                        if amount <= 0.0 { return }
+                        if amount <= 0.0 {
+                            return;
+                        }
                         (manny_id.clone(), object_id.clone(), *resources, amount, (*x, *y, *z))
                     };
                     let containers = state
@@ -272,9 +374,7 @@ pub(super) fn handle_remote_mine_event(
                         .map(|s| state.collect_detached_containers_in(s))
                         .unwrap_or_default();
                     if containers.is_empty() {
-                        state.set_remote_mine_error(
-                            "no detached container in the Manny's sector".into(),
-                        );
+                        state.set_remote_mine_error("no detached container in the Manny's sector".into());
                         return;
                     }
                     state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::PickContainer {
@@ -290,14 +390,18 @@ pub(super) fn handle_remote_mine_event(
                 _ => {}
             }
         }
-        ActiveWizard::RemoteMine(RemoteMineInput::PickContainer { selection, containers, .. }) => {
+        ActiveWizard::RemoteMine(RemoteMineInput::PickContainer {
+            selection, containers, ..
+        }) => {
             let sel = *selection;
             let count = containers.len();
             match code {
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ActiveWizard::RemoteMine(RemoteMineInput::PickContainer { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::RemoteMine(RemoteMineInput::PickContainer { selection, .. }) =
+                            &mut state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
@@ -305,17 +409,48 @@ pub(super) fn handle_remote_mine_event(
                 KeyCode::Enter => {
                     let (manny_id, object_id, selected_resources, amount, container_id, destination) = {
                         let ActiveWizard::RemoteMine(RemoteMineInput::PickContainer {
-                            manny_id, object_id, resources, amount, containers, selection, ..
-                        }) = &state.active_wizard else { return };
-                        let selected: Vec<String> = RESOURCE_TYPES.iter().enumerate()
+                            manny_id,
+                            object_id,
+                            resources,
+                            amount,
+                            containers,
+                            selection,
+                            ..
+                        }) = &state.active_wizard
+                        else {
+                            return;
+                        };
+                        let selected: Vec<String> = RESOURCE_TYPES
+                            .iter()
+                            .enumerate()
                             .filter(|(i, _)| resources[*i])
                             .map(|(_, &t)| t.to_string())
                             .collect();
-                        (manny_id.clone(), object_id.clone(), selected, *amount, containers[*selection].0.clone(), containers[*selection].1.clone())
+                        (
+                            manny_id.clone(),
+                            object_id.clone(),
+                            selected,
+                            *amount,
+                            containers[*selection].0.clone(),
+                            containers[*selection].1.clone(),
+                        )
                     };
                     let resources_label = selected_resources.join(", ");
-                    fetch_mine(manny_id, object_id, selected_resources, amount, Some(container_id), client.clone(), tx.clone());
-                    state.log_event(LogEvent::mine(&resources_label, amount, &destination, state.active_probe_id));
+                    fetch_mine(
+                        manny_id,
+                        object_id,
+                        selected_resources,
+                        amount,
+                        Some(container_id),
+                        client.clone(),
+                        tx.clone(),
+                    );
+                    state.log_event(LogEvent::mine(
+                        &resources_label,
+                        amount,
+                        &destination,
+                        state.active_probe_id,
+                    ));
                 }
                 _ => {}
             }

--- a/src/input/missions.rs
+++ b/src/input/missions.rs
@@ -1,10 +1,10 @@
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
+use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_abandon_mission;
 use crate::api::types::MissionStatus;
 use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, MissionsInput};
-use crate::api::client::ApiClient;
 
 use super::geometry::list_nav;
 
@@ -49,7 +49,11 @@ pub(super) fn handle_missions_event(
             }
             KeyCode::Enter | KeyCode::Char('y') => {
                 let (mission_id, mission_title) = {
-                    let ActiveWizard::Missions(MissionsInput::ConfirmAbandon { ref mission_id, ref mission_title, .. }) = state.active_wizard
+                    let ActiveWizard::Missions(MissionsInput::ConfirmAbandon {
+                        ref mission_id,
+                        ref mission_title,
+                        ..
+                    }) = state.active_wizard
                     else {
                         return;
                     };

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3,10 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_sector;
-use crate::app::{
-    ActiveWizard, ApiMessage, AppState, ScanMode,
-    GotoVisitedInput, InputMode, ProbeSwitchInput,
-};
+use crate::app::{ActiveWizard, ApiMessage, AppState, GotoVisitedInput, InputMode, ProbeSwitchInput, ScanMode};
 mod alerts;
 mod assemble;
 mod cockpit;
@@ -30,32 +27,24 @@ mod travel;
 use alerts::handle_alerts_event;
 use assemble::handle_assemble_probe_event;
 use cockpit::handle_cockpit_event;
-use containers::{
-    handle_container_rules_event, handle_rename_container_event,
-};
+use command::handle_command_event;
+use containers::{handle_container_rules_event, handle_rename_container_event};
 use craft::handle_fabrication_event;
-use fleet::{
-    handle_probe_switch_event, handle_rename_probe_event, handle_transfer_deuterium_event,
-};
+use fleet::{handle_probe_switch_event, handle_rename_probe_event, handle_transfer_deuterium_event};
 use geometry::face_d2;
 use improve::handle_improve_event;
 use jettison::handle_jettison_event;
-use command::handle_command_event;
 use map::{handle_goto_visited_event, handle_map_event};
 use messages::handle_messages_event;
 use mine::{handle_mine_event, handle_remote_mine_event};
 use missions::handle_missions_event;
 use pickers::{
-    handle_deploy_event, handle_detach_event, handle_drop_cargo_event,
-    handle_drop_container_event, handle_inspect_event, handle_mind_snapshot_event,
-    handle_recall_event, handle_recover_event, handle_refuel_event, handle_rename_manny_event,
-    handle_salvage_event,
+    handle_deploy_event, handle_detach_event, handle_drop_cargo_event, handle_drop_container_event,
+    handle_inspect_event, handle_mind_snapshot_event, handle_recall_event, handle_recover_event, handle_refuel_event,
+    handle_rename_manny_event, handle_salvage_event,
 };
 use repair::handle_repair_event;
-use scanner::{
-    handle_object_action_event, handle_scut_network_event, handle_scut_relay_event,
-    handle_waypoints_event,
-};
+use scanner::{handle_object_action_event, handle_scut_network_event, handle_scut_relay_event, handle_waypoints_event};
 use storage_move::handle_storage_move_event;
 use travel::handle_travel_event;
 
@@ -69,6 +58,7 @@ type WizardHandler = fn(KeyCode, &mut AppState, &ApiClient, &mpsc::Sender<ApiMes
 /// uniform `(KeyCode, &mut AppState, &ApiClient, &Sender)` shape; `waypoints`
 /// (which ignores client/tx) is wrapped to match.
 #[allow(clippy::type_complexity)]
+#[rustfmt::skip]
 const WIZARD_INPUTS: &[(WizardGuard, WizardHandler)] = &[
     (|s| matches!(s.active_wizard, ActiveWizard::AssembleProbe(_)), handle_assemble_probe_event),
     (|s| matches!(s.active_wizard, ActiveWizard::RenameProbe(_)), handle_rename_probe_event),
@@ -104,12 +94,7 @@ const WIZARD_INPUTS: &[(WizardGuard, WizardHandler)] = &[
 ];
 
 /// Route a key to the first active wizard. Returns `true` if one consumed it.
-fn dispatch_wizard_key(
-    code: KeyCode,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) -> bool {
+fn dispatch_wizard_key(code: KeyCode, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) -> bool {
     for (active, handle) in WIZARD_INPUTS {
         if active(state) {
             handle(code, state, client, tx);
@@ -119,14 +104,11 @@ fn dispatch_wizard_key(
     false
 }
 
-pub fn handle_event(
-    event: Event,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
+pub fn handle_event(event: Event, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     let Event::Key(k) = event else { return };
-    if k.kind != KeyEventKind::Press { return };
+    if k.kind != KeyEventKind::Press {
+        return;
+    };
     // Toasts and inline errors are transient: any keypress dismisses them.
     state.toast = None;
     state.error = None;
@@ -156,8 +138,7 @@ pub fn handle_event(
         // Clamp against the same body height the renderer uses (near-fullscreen
         // minus a 2-row margin, 2 borders and the footer).
         let (_, term_h) = crossterm::terminal::size().unwrap_or((80, 24));
-        let max = (crate::ui::overlays::help_row_count() as u16)
-            .saturating_sub(term_h.saturating_sub(5));
+        let max = (crate::ui::overlays::help_row_count() as u16).saturating_sub(term_h.saturating_sub(5));
         match k.code {
             KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => {
                 state.help_open = false;
@@ -278,7 +259,11 @@ mod tests {
         let mut state = AppState::default();
         assert_eq!(state.active_pane, Pane::Probe, "default centre pane");
         press(&mut state, KeyCode::Char('e'));
-        assert_eq!(state.active_pane, Pane::Scanner, "no wizard → cockpit handles the pane key");
+        assert_eq!(
+            state.active_pane,
+            Pane::Scanner,
+            "no wizard → cockpit handles the pane key"
+        );
     }
 
     #[tokio::test]
@@ -304,8 +289,14 @@ mod tests {
             cursor: 0,
         });
         press(&mut state, KeyCode::Char('1'));
-        assert!(matches!(state.mode, InputMode::Normal), "digit fired and closed the menu");
-        assert!(matches!(state.active_wizard, ActiveWizard::Travel(_)), "the item's wizard launched");
+        assert!(
+            matches!(state.mode, InputMode::Normal),
+            "digit fired and closed the menu"
+        );
+        assert!(
+            matches!(state.active_wizard, ActiveWizard::Travel(_)),
+            "the item's wizard launched"
+        );
     }
 
     #[tokio::test]
@@ -313,8 +304,15 @@ mod tests {
         let mut state = AppState::default();
         state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
         press(&mut state, KeyCode::Char('e'));
-        assert_eq!(state.active_pane, Pane::Probe, "wizard swallows the key; cockpit must not switch pane");
-        assert!(matches!(state.active_wizard, ActiveWizard::Travel(_)), "the wizard stays open");
+        assert_eq!(
+            state.active_pane,
+            Pane::Probe,
+            "wizard swallows the key; cockpit must not switch pane"
+        );
+        assert!(
+            matches!(state.active_wizard, ActiveWizard::Travel(_)),
+            "the wizard stays open"
+        );
     }
 
     #[tokio::test]
@@ -322,7 +320,10 @@ mod tests {
         let mut state = AppState::default();
         state.active_wizard = ActiveWizard::Travel(TravelInput::Typing("12".into()));
         press(&mut state, KeyCode::Esc);
-        assert!(matches!(state.active_wizard, ActiveWizard::None), "Esc closes the travel wizard");
+        assert!(
+            matches!(state.active_wizard, ActiveWizard::None),
+            "Esc closes the travel wizard"
+        );
     }
 
     #[tokio::test]
@@ -332,21 +333,36 @@ mod tests {
         // wizards can be open at once (that state is now unrepresentable).
         let mut state = AppState::default();
         state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
-        state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing { selection: 0, show_warnings: false });
-        assert!(matches!(state.active_wizard, ActiveWizard::Alerts(_)), "the second wizard is now active");
-        assert!(!matches!(state.active_wizard, ActiveWizard::Travel(_)), "the first was replaced, not kept alongside");
+        state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing {
+            selection: 0,
+            show_warnings: false,
+        });
+        assert!(
+            matches!(state.active_wizard, ActiveWizard::Alerts(_)),
+            "the second wizard is now active"
+        );
+        assert!(
+            !matches!(state.active_wizard, ActiveWizard::Travel(_)),
+            "the first was replaced, not kept alongside"
+        );
     }
 
     #[tokio::test]
     async fn tabbed_wizard_also_captures_keys_and_closes_on_esc() {
         let mut state = AppState::default();
-        state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing { selection: 0, show_warnings: false });
+        state.active_wizard = ActiveWizard::Alerts(AlertsInput::Browsing {
+            selection: 0,
+            show_warnings: false,
+        });
         // A pane key must not reach the cockpit while the alerts overlay is open.
         press(&mut state, KeyCode::Char('b'));
         assert_eq!(state.active_pane, Pane::Probe, "alerts overlay swallows the pane key");
         assert!(matches!(state.active_wizard, ActiveWizard::Alerts(_)));
         press(&mut state, KeyCode::Esc);
-        assert!(matches!(state.active_wizard, ActiveWizard::None), "Esc closes the alerts overlay");
+        assert!(
+            matches!(state.active_wizard, ActiveWizard::None),
+            "Esc closes the alerts overlay"
+        );
     }
 
     #[tokio::test]
@@ -361,27 +377,38 @@ mod tests {
         });
         press(&mut state, KeyCode::Char('j'));
         match &state.active_wizard {
-            ActiveWizard::Salvage(SalvageInput::PickTarget { selection, .. }) => assert_eq!(*selection, 1, "j moves the cursor"),
+            ActiveWizard::Salvage(SalvageInput::PickTarget { selection, .. }) => {
+                assert_eq!(*selection, 1, "j moves the cursor")
+            }
             _ => panic!("should still be picking"),
         }
         press(&mut state, KeyCode::Esc);
-        assert!(matches!(state.active_wizard, ActiveWizard::None), "Esc closes the picker");
+        assert!(
+            matches!(state.active_wizard, ActiveWizard::None),
+            "Esc closes the picker"
+        );
     }
 
     fn idle_onboard_manny(id: &str) -> crate::api::types::Manny {
-        serde_json::from_str(&format!(r#"{{
+        serde_json::from_str(&format!(
+            r#"{{
             "id": "{id}", "name": "{id}",
             "location": {{"type": "probe", "sector": null}},
             "currentTask": null, "taskProgressPercent": 0.0,
             "cargo": {{"capacity": 0.3, "deuterium": 0.0, "metals": 0.0, "ice": 0.0, "organicCompounds": 0.0}},
             "canReceiveOrders": true, "taskEstimatedEndTime": null
-        }}"#)).unwrap()
+        }}"#
+        ))
+        .unwrap()
     }
 
     fn manny_recipe(id: &str) -> crate::api::types::CraftingRecipe {
-        serde_json::from_str(&format!(r#"{{"id":"{id}","name":"{id}","craftableBy":["manny"],
+        serde_json::from_str(&format!(
+            r#"{{"id":"{id}","name":"{id}","craftableBy":["manny"],
             "ingredients":[],"durationSeconds":60,
-            "output":{{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}}}"#)).unwrap()
+            "output":{{"type":"x","name":"X","containerSpace":1.0,"containerSpaceUnit":"ECE","capacityBonus":null}}}}"#
+        ))
+        .unwrap()
     }
 
     #[tokio::test]
@@ -390,7 +417,11 @@ mod tests {
         let mut state = AppState::default();
         state.recipes = vec![manny_recipe("solar_panel")];
         state.mannies = Some(vec![idle_onboard_manny("m1"), idle_onboard_manny("m2")]);
-        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None });
+        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe {
+            prefilled_manny: None,
+            selection: 0,
+            error: None,
+        });
         press(&mut state, KeyCode::Enter);
         match &state.active_wizard {
             ActiveWizard::Fabrication(FabricationInput::PickBuilder { recipe_id, mannies, .. }) => {
@@ -407,11 +438,18 @@ mod tests {
         let mut state = AppState::default();
         state.recipes = vec![manny_recipe("solar_panel")];
         state.mannies = Some(vec![]);
-        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None });
+        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe {
+            prefilled_manny: None,
+            selection: 0,
+            error: None,
+        });
         press(&mut state, KeyCode::Enter);
         match &state.active_wizard {
             ActiveWizard::Fabrication(FabricationInput::PickRecipe { error, .. }) => {
-                assert!(error.as_deref().unwrap_or("").contains("no idle Manny"), "surfaces the no-manny error");
+                assert!(
+                    error.as_deref().unwrap_or("").contains("no idle Manny"),
+                    "surfaces the no-manny error"
+                );
             }
             _ => panic!("stays on the recipe step with an error"),
         }
@@ -423,16 +461,21 @@ mod tests {
         let mut state = AppState::default();
         state.active_pane = Pane::Probe;
         // Two SCUT networks cover the current sector (first scan, no probe sector).
-        state.scan_history = vec![serde_json::from_str(r#"{
+        state.scan_history = vec![serde_json::from_str(
+            r#"{
             "relativeCoordinates":{"x":0,"y":0,"z":0},"distance":0,
             "knowledgeLevel":"detailed","confidence":1.0,
             "scutNetworks":[{"id":1,"name":"Alpha"},{"id":2,"name":"Beta"}],
             "scan":{"currentSectorResidenceSeconds":60,"requiredResidenceSeconds":60,"scanQuality":1.0}
-        }"#).unwrap()];
+        }"#,
+        )
+        .unwrap()];
         press(&mut state, KeyCode::Enter); // open the Probe context menu
         press(&mut state, KeyCode::Enter); // fire the first enabled item (Inspect SCUT network…)
         match &state.active_wizard {
-            ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks, .. }) => assert_eq!(networks.len(), 2, "both networks offered"),
+            ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks, .. }) => {
+                assert_eq!(networks.len(), 2, "both networks offered")
+            }
             _ => panic!("two networks should open the picker"),
         }
     }
@@ -442,15 +485,24 @@ mod tests {
         use crate::app::{Pane, ScutNetworkInput};
         let mut state = AppState::default();
         state.active_pane = Pane::Probe;
-        state.scan_history = vec![serde_json::from_str(r#"{
+        state.scan_history = vec![serde_json::from_str(
+            r#"{
             "relativeCoordinates":{"x":0,"y":0,"z":0},"distance":0,
             "knowledgeLevel":"detailed","confidence":1.0,
             "scutNetworks":[{"id":7,"name":"Solo"}],
             "scan":{"currentSectorResidenceSeconds":60,"requiredResidenceSeconds":60,"scanQuality":1.0}
-        }"#).unwrap()];
+        }"#,
+        )
+        .unwrap()];
         press(&mut state, KeyCode::Enter);
         press(&mut state, KeyCode::Enter);
-        assert!(matches!(state.active_wizard, ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })), "a single network views directly");
+        assert!(
+            matches!(
+                state.active_wizard,
+                ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })
+            ),
+            "a single network views directly"
+        );
     }
 
     #[tokio::test]
@@ -460,7 +512,11 @@ mod tests {
         state.active_pane = Pane::Comms;
         state.pane_nav[Pane::Comms.index()].cursor = 1; // Alerts row
         press(&mut state, KeyCode::Enter);
-        assert_eq!(state.comms_drill(), Some(CommsCategory::Alerts), "drills into the Alerts list in-pane");
+        assert_eq!(
+            state.comms_drill(),
+            Some(CommsCategory::Alerts),
+            "drills into the Alerts list in-pane"
+        );
         // `h` backs out to the category root.
         press(&mut state, KeyCode::Char('h'));
         assert_eq!(state.comms_drill(), None, "back to the Comms root");
@@ -473,7 +529,13 @@ mod tests {
         state.active_pane = Pane::Comms;
         state.pane_nav[Pane::Comms.index()].cursor = 0; // Messages row
         press(&mut state, KeyCode::Enter);
-        assert!(matches!(state.active_wizard, ActiveWizard::Messages(MessagesInput::Browsing { .. })), "Messages opens its overlay");
+        assert!(
+            matches!(
+                state.active_wizard,
+                ActiveWizard::Messages(MessagesInput::Browsing { .. })
+            ),
+            "Messages opens its overlay"
+        );
     }
 
     #[tokio::test]
@@ -484,11 +546,15 @@ mod tests {
         state.probe_improvements = vec![serde_json::from_str(
             r#"{"id":"deuterium_compression","name":"Deuterium compression","description":"d",
                 "available":true,"done":false,"durationSeconds":300,"ingredients":[],"effects":null}"#,
-        ).unwrap()];
+        )
+        .unwrap()];
         press(&mut state, KeyCode::Enter); // open the Probe menu (Improve is the first enabled item)
         press(&mut state, KeyCode::Enter); // fire it
         assert!(
-            matches!(state.active_wizard, ActiveWizard::Improve(ImproveInput::PickImprovement { .. })),
+            matches!(
+                state.active_wizard,
+                ActiveWizard::Improve(ImproveInput::PickImprovement { .. })
+            ),
             "an orderable improvement opens the picker"
         );
     }

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -1,25 +1,27 @@
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
+use super::geometry::list_move;
 use crate::api::client::ApiClient;
 use crate::api::tasks::{
-    fetch_deploy, fetch_detach, fetch_drop_manny_cargo, fetch_drop_storage_container,
-    fetch_inspect, fetch_reassign_mind_snapshot, fetch_recall, fetch_refill_deuterium,
-    fetch_recover, fetch_rename_manny, fetch_salvage,
+    fetch_deploy, fetch_detach, fetch_drop_manny_cargo, fetch_drop_storage_container, fetch_inspect,
+    fetch_reassign_mind_snapshot, fetch_recall, fetch_recover, fetch_refill_deuterium, fetch_rename_manny,
+    fetch_salvage,
 };
 use crate::app::{
-    ActiveWizard, ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput,
-    DropStorageContainerInput, InspectInput, LogEvent, RecallInput, RefuelInput,
-    RecoverInput, RenameMannyInput, SalvageInput, DETACH_MODES,
+    ActiveWizard, ApiMessage, AppState, DeployInput, DetachInput, DropCargoInput, DropStorageContainerInput,
+    InspectInput, LogEvent, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput, DETACH_MODES,
 };
-use super::geometry::list_move;
 pub(super) fn handle_salvage_event(
     code: KeyCode,
     state: &mut AppState,
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if let ActiveWizard::Salvage(SalvageInput::PickTarget { selection, candidates, .. }) = &mut state.active_wizard {
+    if let ActiveWizard::Salvage(SalvageInput::PickTarget {
+        selection, candidates, ..
+    }) = &mut state.active_wizard
+    {
         if list_move(code, selection, candidates.len()) {
             return;
         }
@@ -29,12 +31,24 @@ pub(super) fn handle_salvage_event(
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, manny_name, object_id, object_name) = {
-                    let ActiveWizard::Salvage(SalvageInput::PickTarget { manny_id, manny_name, candidates, selection }) = &state.active_wizard else { return };
+                    let ActiveWizard::Salvage(SalvageInput::PickTarget {
+                        manny_id,
+                        manny_name,
+                        candidates,
+                        selection,
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     let (id, name) = candidates[*selection].clone();
                     (manny_id.clone(), manny_name.clone(), id, name)
                 };
                 state.active_wizard = ActiveWizard::Salvage(SalvageInput::Confirm {
-                    manny_id, manny_name, object_id, object_name, error: None,
+                    manny_id,
+                    manny_name,
+                    object_id,
+                    object_name,
+                    error: None,
                 });
             }
             _ => {}
@@ -43,7 +57,15 @@ pub(super) fn handle_salvage_event(
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, object_id, object_name) = {
-                    let ActiveWizard::Salvage(SalvageInput::Confirm { manny_id, object_id, object_name, .. }) = &state.active_wizard else { return };
+                    let ActiveWizard::Salvage(SalvageInput::Confirm {
+                        manny_id,
+                        object_id,
+                        object_name,
+                        ..
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     (manny_id.clone(), object_id.clone(), object_name.clone())
                 };
                 fetch_salvage(manny_id, object_id, client.clone(), tx.clone());
@@ -65,7 +87,15 @@ pub(super) fn handle_recall_event(
         KeyCode::Esc => state.close_wizard(),
         KeyCode::Enter => {
             let (manny_id, manny_name, remote) = {
-                let ActiveWizard::Recall(RecallInput::Confirm { manny_id, manny_name, remote, .. }) = &state.active_wizard else { return };
+                let ActiveWizard::Recall(RecallInput::Confirm {
+                    manny_id,
+                    manny_name,
+                    remote,
+                    ..
+                }) = &state.active_wizard
+                else {
+                    return;
+                };
                 (manny_id.clone(), manny_name.clone(), *remote)
             };
             fetch_recall(manny_id, client.clone(), tx.clone());
@@ -85,7 +115,9 @@ pub(super) fn handle_refuel_event(
         KeyCode::Esc | KeyCode::Char('n') => state.close_wizard(),
         KeyCode::Enter | KeyCode::Char('y') => {
             let manny_id = {
-                let ActiveWizard::Refuel(RefuelInput::Confirm { manny_id, .. }) = &state.active_wizard else { return };
+                let ActiveWizard::Refuel(RefuelInput::Confirm { manny_id, .. }) = &state.active_wizard else {
+                    return;
+                };
                 manny_id.clone()
             };
             fetch_refill_deuterium(manny_id, client.clone(), tx.clone());
@@ -118,7 +150,9 @@ pub(super) fn handle_drop_container_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match &mut state.active_wizard {
-        ActiveWizard::DropContainer(DropStorageContainerInput::PickContainer { selection, containers, .. }) => {
+        ActiveWizard::DropContainer(DropStorageContainerInput::PickContainer {
+            selection, containers, ..
+        }) => {
             if list_move(code, selection, containers.len()) {
                 return;
             }
@@ -136,8 +170,14 @@ pub(super) fn handle_drop_container_event(
             KeyCode::Enter => {
                 let (manny_id, manny_name, container_id, container_name) = {
                     let ActiveWizard::DropContainer(DropStorageContainerInput::PickContainer {
-                        manny_id, manny_name, containers, selection,
-                    }) = &state.active_wizard else { return };
+                        manny_id,
+                        manny_name,
+                        containers,
+                        selection,
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     let (id, name) = containers[*selection].clone();
                     (manny_id.clone(), manny_name.clone(), id, name)
                 };
@@ -148,8 +188,13 @@ pub(super) fn handle_drop_container_event(
                     return;
                 }
                 state.active_wizard = ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet {
-                    manny_id, manny_name, container_id, container_name,
-                    planets, selection: 0, error: None,
+                    manny_id,
+                    manny_name,
+                    container_id,
+                    container_name,
+                    planets,
+                    selection: 0,
+                    error: None,
                 });
             }
             _ => {}
@@ -159,8 +204,16 @@ pub(super) fn handle_drop_container_event(
             KeyCode::Enter => {
                 let (manny_id, container_id, planet_id, container_name, planet_name) = {
                     let ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet {
-                        manny_id, container_id, container_name, planets, selection, ..
-                    }) = &state.active_wizard else { return };
+                        manny_id,
+                        container_id,
+                        container_name,
+                        planets,
+                        selection,
+                        ..
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     (
                         manny_id.clone(),
                         container_id.clone(),
@@ -170,7 +223,11 @@ pub(super) fn handle_drop_container_event(
                     )
                 };
                 fetch_drop_storage_container(manny_id, container_id, planet_id, client.clone(), tx.clone());
-                state.log_event(LogEvent::drop_container(&container_name, &planet_name, state.active_probe_id));
+                state.log_event(LogEvent::drop_container(
+                    &container_name,
+                    &planet_name,
+                    state.active_probe_id,
+                ));
             }
             _ => {}
         },
@@ -188,7 +245,9 @@ pub(super) fn handle_drop_cargo_event(
         KeyCode::Esc | KeyCode::Char('n') => state.close_wizard(),
         KeyCode::Enter | KeyCode::Char('y') => {
             let manny_id = {
-                let ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_id, .. }) = &state.active_wizard else { return };
+                let ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_id, .. }) = &state.active_wizard else {
+                    return;
+                };
                 manny_id.clone()
             };
             fetch_drop_manny_cargo(manny_id, client.clone(), tx.clone());
@@ -210,7 +269,9 @@ pub(super) fn handle_deploy_event(
                 return;
             }
         }
-        ActiveWizard::Deploy(DeployInput::PickObject { selection, candidates, .. }) => {
+        ActiveWizard::Deploy(DeployInput::PickObject {
+            selection, candidates, ..
+        }) => {
             if list_move(code, selection, candidates.len()) {
                 return;
             }
@@ -222,7 +283,10 @@ pub(super) fn handle_deploy_event(
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let manny_id = {
-                    let ActiveWizard::Deploy(DeployInput::PickManny { mannies, selection }) = &state.active_wizard else { return };
+                    let ActiveWizard::Deploy(DeployInput::PickManny { mannies, selection }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     mannies[*selection].0.clone()
                 };
                 let candidates = state.collect_deploy_candidates();
@@ -231,9 +295,19 @@ pub(super) fn handle_deploy_event(
                     state.error = Some("no targets in current sector".into());
                 } else if candidates.len() == 1 {
                     let (object_id, object_name) = candidates.into_iter().next().unwrap();
-                    state.active_wizard = ActiveWizard::Deploy(DeployInput::EnterName { manny_id, object_id, object_name, name_buf: String::new(), error: None });
+                    state.active_wizard = ActiveWizard::Deploy(DeployInput::EnterName {
+                        manny_id,
+                        object_id,
+                        object_name,
+                        name_buf: String::new(),
+                        error: None,
+                    });
                 } else {
-                    state.active_wizard = ActiveWizard::Deploy(DeployInput::PickObject { manny_id, candidates, selection: 0 });
+                    state.active_wizard = ActiveWizard::Deploy(DeployInput::PickObject {
+                        manny_id,
+                        candidates,
+                        selection: 0,
+                    });
                 }
             }
             _ => {}
@@ -242,12 +316,23 @@ pub(super) fn handle_deploy_event(
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, object_id, object_name) = {
-                    let ActiveWizard::Deploy(DeployInput::PickObject { manny_id, candidates, selection }) = &state.active_wizard else { return };
+                    let ActiveWizard::Deploy(DeployInput::PickObject {
+                        manny_id,
+                        candidates,
+                        selection,
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     let (id, name) = candidates[*selection].clone();
                     (manny_id.clone(), id, name)
                 };
                 state.active_wizard = ActiveWizard::Deploy(DeployInput::EnterName {
-                    manny_id, object_id, object_name, name_buf: String::new(), error: None,
+                    manny_id,
+                    object_id,
+                    object_name,
+                    name_buf: String::new(),
+                    error: None,
                 });
             }
             _ => {}
@@ -258,8 +343,18 @@ pub(super) fn handle_deploy_event(
             KeyCode::Char(c) => state.deploy_type_char(c),
             KeyCode::Enter => {
                 let (manny_id, object_id, name) = {
-                    let ActiveWizard::Deploy(DeployInput::EnterName { manny_id, object_id, name_buf, .. }) = &state.active_wizard else { return };
-                    if name_buf.is_empty() { return }
+                    let ActiveWizard::Deploy(DeployInput::EnterName {
+                        manny_id,
+                        object_id,
+                        name_buf,
+                        ..
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
+                    if name_buf.is_empty() {
+                        return;
+                    }
                     (manny_id.clone(), object_id.clone(), name_buf.clone())
                 };
                 let waypoint_name = name.clone();
@@ -290,8 +385,18 @@ pub(super) fn handle_rename_manny_event(
         KeyCode::Char(c) => state.rename_manny_type_char(c),
         KeyCode::Enter => {
             let (manny_id, name, old_name) = {
-                let ActiveWizard::RenameManny(RenameMannyInput::Typing { manny_id, buf, manny_name, .. }) = &state.active_wizard else { return };
-                if buf.is_empty() { return }
+                let ActiveWizard::RenameManny(RenameMannyInput::Typing {
+                    manny_id,
+                    buf,
+                    manny_name,
+                    ..
+                }) = &state.active_wizard
+                else {
+                    return;
+                };
+                if buf.is_empty() {
+                    return;
+                }
                 (manny_id.clone(), buf.clone(), manny_name.clone())
             };
             let new_name = name.clone();
@@ -308,7 +413,10 @@ pub(super) fn handle_inspect_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if let ActiveWizard::Inspect(InspectInput::PickTarget { selection, candidates, .. }) = &mut state.active_wizard {
+    if let ActiveWizard::Inspect(InspectInput::PickTarget {
+        selection, candidates, ..
+    }) = &mut state.active_wizard
+    {
         if list_move(code, selection, candidates.len()) {
             return;
         }
@@ -317,8 +425,20 @@ pub(super) fn handle_inspect_event(
         KeyCode::Esc => state.close_wizard(),
         KeyCode::Enter => {
             let (manny_id, object_id, object_name) = {
-                let ActiveWizard::Inspect(InspectInput::PickTarget { manny_id, candidates, selection, .. }) = &state.active_wizard else { return };
-                (manny_id.clone(), candidates[*selection].0.clone(), candidates[*selection].1.clone())
+                let ActiveWizard::Inspect(InspectInput::PickTarget {
+                    manny_id,
+                    candidates,
+                    selection,
+                    ..
+                }) = &state.active_wizard
+                else {
+                    return;
+                };
+                (
+                    manny_id.clone(),
+                    candidates[*selection].0.clone(),
+                    candidates[*selection].1.clone(),
+                )
             };
             fetch_inspect(manny_id, object_id, client.clone(), tx.clone());
             state.log_event(LogEvent::inspect(&object_name, state.active_probe_id));
@@ -333,7 +453,10 @@ pub(super) fn handle_recover_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    if let ActiveWizard::Recover(RecoverInput::PickContainer { selection, candidates, .. }) = &mut state.active_wizard {
+    if let ActiveWizard::Recover(RecoverInput::PickContainer {
+        selection, candidates, ..
+    }) = &mut state.active_wizard
+    {
         if list_move(code, selection, candidates.len()) {
             return;
         }
@@ -342,8 +465,20 @@ pub(super) fn handle_recover_event(
         KeyCode::Esc => state.close_wizard(),
         KeyCode::Enter => {
             let (manny_id, object_id, container_name) = {
-                let ActiveWizard::Recover(RecoverInput::PickContainer { manny_id, candidates, selection, .. }) = &state.active_wizard else { return };
-                (manny_id.clone(), candidates[*selection].0.clone(), candidates[*selection].1.clone())
+                let ActiveWizard::Recover(RecoverInput::PickContainer {
+                    manny_id,
+                    candidates,
+                    selection,
+                    ..
+                }) = &state.active_wizard
+                else {
+                    return;
+                };
+                (
+                    manny_id.clone(),
+                    candidates[*selection].0.clone(),
+                    candidates[*selection].1.clone(),
+                )
             };
             fetch_recover(manny_id, object_id, client.clone(), tx.clone());
             state.log_event(LogEvent::recover(&container_name, state.active_probe_id));
@@ -359,7 +494,9 @@ pub(super) fn handle_detach_event(
     tx: &mpsc::Sender<ApiMessage>,
 ) {
     match &mut state.active_wizard {
-        ActiveWizard::Detach(DetachInput::PickContainer { selection, containers, .. }) => {
+        ActiveWizard::Detach(DetachInput::PickContainer {
+            selection, containers, ..
+        }) => {
             if list_move(code, selection, containers.len()) {
                 return;
             }
@@ -369,7 +506,9 @@ pub(super) fn handle_detach_event(
                 return;
             }
         }
-        ActiveWizard::Detach(DetachInput::PickAsteroid { selection, asteroids, .. }) => {
+        ActiveWizard::Detach(DetachInput::PickAsteroid {
+            selection, asteroids, ..
+        }) => {
             if list_move(code, selection, asteroids.len()) {
                 return;
             }
@@ -381,11 +520,26 @@ pub(super) fn handle_detach_event(
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, manny_name, container_id, container_name) = {
-                    let ActiveWizard::Detach(DetachInput::PickContainer { manny_id, manny_name, containers, selection }) = &state.active_wizard else { return };
+                    let ActiveWizard::Detach(DetachInput::PickContainer {
+                        manny_id,
+                        manny_name,
+                        containers,
+                        selection,
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
                     let (id, name) = containers[*selection].clone();
                     (manny_id.clone(), manny_name.clone(), id, name)
                 };
-                state.active_wizard = ActiveWizard::Detach(DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection: 0, error: None });
+                state.active_wizard = ActiveWizard::Detach(DetachInput::PickMode {
+                    manny_id,
+                    manny_name,
+                    container_id,
+                    container_name,
+                    selection: 0,
+                    error: None,
+                });
             }
             _ => {}
         },
@@ -393,8 +547,24 @@ pub(super) fn handle_detach_event(
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, manny_name, container_id, container_name, sel) = {
-                    let ActiveWizard::Detach(DetachInput::PickMode { manny_id, manny_name, container_id, container_name, selection, .. }) = &state.active_wizard else { return };
-                    (manny_id.clone(), manny_name.clone(), container_id.clone(), container_name.clone(), *selection)
+                    let ActiveWizard::Detach(DetachInput::PickMode {
+                        manny_id,
+                        manny_name,
+                        container_id,
+                        container_name,
+                        selection,
+                        ..
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
+                    (
+                        manny_id.clone(),
+                        manny_name.clone(),
+                        container_id.clone(),
+                        container_name.clone(),
+                        *selection,
+                    )
                 };
                 let mode = DETACH_MODES[sel].0;
                 if mode == "hidden_on_asteroid" {
@@ -402,11 +572,30 @@ pub(super) fn handle_detach_event(
                     if asteroids.is_empty() {
                         state.set_detach_error("no asteroids in current sector — scan first".into());
                     } else {
-                        state.active_wizard = ActiveWizard::Detach(DetachInput::PickAsteroid { manny_id, manny_name, container_id, container_name, asteroids, selection: 0, error: None });
+                        state.active_wizard = ActiveWizard::Detach(DetachInput::PickAsteroid {
+                            manny_id,
+                            manny_name,
+                            container_id,
+                            container_name,
+                            asteroids,
+                            selection: 0,
+                            error: None,
+                        });
                     }
                 } else {
-                    fetch_detach(manny_id, container_id, "drifting".into(), None, client.clone(), tx.clone());
-                    state.log_event(LogEvent::detach_container(&container_name, false, state.active_probe_id));
+                    fetch_detach(
+                        manny_id,
+                        container_id,
+                        "drifting".into(),
+                        None,
+                        client.clone(),
+                        tx.clone(),
+                    );
+                    state.log_event(LogEvent::detach_container(
+                        &container_name,
+                        false,
+                        state.active_probe_id,
+                    ));
                 }
             }
             _ => {}
@@ -415,10 +604,32 @@ pub(super) fn handle_detach_event(
             KeyCode::Esc => state.close_wizard(),
             KeyCode::Enter => {
                 let (manny_id, container_id, object_id, container_name) = {
-                    let ActiveWizard::Detach(DetachInput::PickAsteroid { manny_id, container_id, container_name, asteroids, selection, .. }) = &state.active_wizard else { return };
-                    (manny_id.clone(), container_id.clone(), asteroids[*selection].0.clone(), container_name.clone())
+                    let ActiveWizard::Detach(DetachInput::PickAsteroid {
+                        manny_id,
+                        container_id,
+                        container_name,
+                        asteroids,
+                        selection,
+                        ..
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
+                    (
+                        manny_id.clone(),
+                        container_id.clone(),
+                        asteroids[*selection].0.clone(),
+                        container_name.clone(),
+                    )
                 };
-                fetch_detach(manny_id, container_id, "hidden_on_asteroid".into(), Some(object_id), client.clone(), tx.clone());
+                fetch_detach(
+                    manny_id,
+                    container_id,
+                    "hidden_on_asteroid".into(),
+                    Some(object_id),
+                    client.clone(),
+                    tx.clone(),
+                );
                 state.log_event(LogEvent::detach_container(&container_name, true, state.active_probe_id));
             }
             _ => {}

--- a/src/input/repair.rs
+++ b/src/input/repair.rs
@@ -3,9 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_repair;
-use crate::app::{
-    ActiveWizard, ApiMessage, AppState, LogEvent, RepairInput,
-};
+use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, RepairInput};
 pub(super) fn handle_repair_event(
     code: KeyCode,
     state: &mut AppState,
@@ -19,9 +17,13 @@ pub(super) fn handle_repair_event(
         KeyCode::Char(c) => state.repair_type_char(c),
         KeyCode::Enter => {
             let (manny_id, pct) = {
-                let ActiveWizard::Repair(RepairInput::Typing { manny_id, buf, .. }) = &state.active_wizard else { return };
+                let ActiveWizard::Repair(RepairInput::Typing { manny_id, buf, .. }) = &state.active_wizard else {
+                    return;
+                };
                 let Ok(pct) = buf.parse::<f64>() else { return };
-                if pct <= 0.0 { return }
+                if pct <= 0.0 {
+                    return;
+                }
                 (manny_id.clone(), pct)
             };
             fetch_repair(manny_id, pct, client.clone(), tx.clone());

--- a/src/input/scanner.rs
+++ b/src/input/scanner.rs
@@ -1,18 +1,13 @@
 use crossterm::event::KeyCode;
 use tokio::sync::mpsc;
 
-use crate::api::client::ApiClient;
-use crate::api::tasks::{
-    fetch_inspect,
-    fetch_recover,
-    fetch_scut_network,
-    fetch_turn_on_relay,
-};
-use crate::app::{
-    ActiveWizard, ApiMessage, AppState, DeployInput, LogEvent, MineInput, ObjectAction, ObjectActionInput, SalvageInput,
-    ScutNetworkInput, ScutRelayInput, WaypointsInput,
-};
 use super::geometry::list_nav;
+use crate::api::client::ApiClient;
+use crate::api::tasks::{fetch_inspect, fetch_recover, fetch_scut_network, fetch_turn_on_relay};
+use crate::app::{
+    ActiveWizard, ApiMessage, AppState, DeployInput, LogEvent, MineInput, ObjectAction, ObjectActionInput,
+    SalvageInput, ScutNetworkInput, ScutRelayInput, WaypointsInput,
+};
 /// Send the chosen object action, reusing the existing wizards/endpoints.
 pub(super) fn dispatch_object_action(
     state: &mut AppState,
@@ -92,7 +87,9 @@ pub(super) fn handle_scut_relay_event(
     client: &ApiClient,
     tx: &mpsc::Sender<ApiMessage>,
 ) {
-    let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { .. }) = &state.active_wizard else { return };
+    let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { .. }) = &state.active_wizard else {
+        return;
+    };
     match code {
         KeyCode::Esc => state.close_wizard(),
         KeyCode::Backspace => {
@@ -107,12 +104,20 @@ pub(super) fn handle_scut_relay_event(
         }
         KeyCode::Enter => {
             let (manny_id, relay_id, name) = {
-                let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { manny_id, relay_id, buf, .. }) =
-                    &state.active_wizard
+                let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName {
+                    manny_id,
+                    relay_id,
+                    buf,
+                    ..
+                }) = &state.active_wizard
                 else {
                     return;
                 };
-                let name = if buf.trim().is_empty() { None } else { Some(buf.trim().to_string()) };
+                let name = if buf.trim().is_empty() {
+                    None
+                } else {
+                    Some(buf.trim().to_string())
+                };
                 (manny_id.clone(), *relay_id, name)
             };
             let network = name.clone();
@@ -137,14 +142,20 @@ pub(super) fn handle_scut_network_event(
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, selection, count) {
-                        if let ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { selection, .. }) =
+                            &mut state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let id = {
-                        let ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks, .. }) = &state.active_wizard else { return };
+                        let ActiveWizard::ScutNetwork(ScutNetworkInput::Picking { networks, .. }) =
+                            &state.active_wizard
+                        else {
+                            return;
+                        };
                         networks[selection].0
                     };
                     state.active_wizard = ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { error: None });
@@ -154,17 +165,18 @@ pub(super) fn handle_scut_network_event(
                 _ => {}
             }
         }
-        ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })
-            if code == KeyCode::Esc => {
-                state.close_wizard();
-                state.scut_network_view = None;
-            }
+        ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. }) if code == KeyCode::Esc => {
+            state.close_wizard();
+            state.scut_network_view = None;
+        }
         _ => {}
     }
 }
 
 pub(super) fn handle_waypoints_event(code: KeyCode, state: &mut AppState) {
-    let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, selection }) = &state.active_wizard else { return };
+    let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, selection }) = &state.active_wizard else {
+        return;
+    };
     let count = entries.len();
     let selection = *selection;
     match code {
@@ -178,7 +190,9 @@ pub(super) fn handle_waypoints_event(code: KeyCode, state: &mut AppState) {
         }
         KeyCode::Enter => {
             let (x, y, z) = {
-                let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, .. }) = &state.active_wizard else { return };
+                let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, .. }) = &state.active_wizard else {
+                    return;
+                };
                 let e = &entries[selection];
                 (e.x, e.y, e.z)
             };
@@ -203,14 +217,24 @@ pub(super) fn handle_object_action_event(
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ActiveWizard::ObjectAction(ObjectActionInput::PickAction { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::ObjectAction(ObjectActionInput::PickAction { selection, .. }) =
+                            &mut state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (object_id, object_name, action) = {
-                        let ActiveWizard::ObjectAction(ObjectActionInput::PickAction { object_id, object_name, actions, selection }) = &state.active_wizard else { return };
+                        let ActiveWizard::ObjectAction(ObjectActionInput::PickAction {
+                            object_id,
+                            object_name,
+                            actions,
+                            selection,
+                        }) = &state.active_wizard
+                        else {
+                            return;
+                        };
                         (object_id.clone(), object_name.clone(), actions[*selection])
                     };
                     let mannies = state.collect_idle_onboard_mannies();
@@ -244,15 +268,30 @@ pub(super) fn handle_object_action_event(
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(new_sel) = list_nav(code, sel, count) {
-                        if let ActiveWizard::ObjectAction(ObjectActionInput::PickManny { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::ObjectAction(ObjectActionInput::PickManny { selection, .. }) =
+                            &mut state.active_wizard
+                        {
                             *selection = new_sel;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (object, action, manny) = {
-                        let ActiveWizard::ObjectAction(ObjectActionInput::PickManny { object_id, object_name, action, mannies, selection }) = &state.active_wizard else { return };
-                        ((object_id.clone(), object_name.clone()), *action, mannies[*selection].clone())
+                        let ActiveWizard::ObjectAction(ObjectActionInput::PickManny {
+                            object_id,
+                            object_name,
+                            action,
+                            mannies,
+                            selection,
+                        }) = &state.active_wizard
+                        else {
+                            return;
+                        };
+                        (
+                            (object_id.clone(), object_name.clone()),
+                            *action,
+                            mannies[*selection].clone(),
+                        )
                     };
                     dispatch_object_action(state, client, tx, action, object, manny);
                 }

--- a/src/input/storage_move.rs
+++ b/src/input/storage_move.rs
@@ -8,10 +8,18 @@ use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, StorageMoveInput,
 use super::geometry::list_nav;
 
 fn wrap_prev(i: usize, len: usize) -> usize {
-    if len == 0 { 0 } else { (i + len - 1) % len }
+    if len == 0 {
+        0
+    } else {
+        (i + len - 1) % len
+    }
 }
 fn wrap_next(i: usize, len: usize) -> usize {
-    if len == 0 { 0 } else { (i + 1) % len }
+    if len == 0 {
+        0
+    } else {
+        (i + 1) % len
+    }
 }
 
 pub(super) fn handle_storage_move_event(
@@ -27,15 +35,20 @@ pub(super) fn handle_storage_move_event(
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(ns) = list_nav(code, sel, count) {
-                        if let ActiveWizard::StorageMove(StorageMoveInput::PickManny { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::StorageMove(StorageMoveInput::PickManny { selection, .. }) =
+                            &mut state.active_wizard
+                        {
                             *selection = ns;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (id, name) = {
-                        let ActiveWizard::StorageMove(StorageMoveInput::PickManny { mannies, selection }) = &state.active_wizard
-                        else { return };
+                        let ActiveWizard::StorageMove(StorageMoveInput::PickManny { mannies, selection }) =
+                            &state.active_wizard
+                        else {
+                            return;
+                        };
                         mannies[*selection].clone()
                     };
                     state.active_wizard = ActiveWizard::StorageMove(StorageMoveInput::PickKind {
@@ -53,15 +66,23 @@ pub(super) fn handle_storage_move_event(
                 KeyCode::Esc => state.close_wizard(),
                 KeyCode::Up | KeyCode::Char('k') | KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(ns) = list_nav(code, sel, 2) {
-                        if let ActiveWizard::StorageMove(StorageMoveInput::PickKind { selection, .. }) = &mut state.active_wizard {
+                        if let ActiveWizard::StorageMove(StorageMoveInput::PickKind { selection, .. }) =
+                            &mut state.active_wizard
+                        {
                             *selection = ns;
                         }
                     }
                 }
                 KeyCode::Enter => {
                     let (id, name) = {
-                        let ActiveWizard::StorageMove(StorageMoveInput::PickKind { actor_manny_id, actor_manny_name, .. }) =
-                            &state.active_wizard else { return };
+                        let ActiveWizard::StorageMove(StorageMoveInput::PickKind {
+                            actor_manny_id,
+                            actor_manny_name,
+                            ..
+                        }) = &state.active_wizard
+                        else {
+                            return;
+                        };
                         (actor_manny_id.clone(), actor_manny_name.clone())
                     };
                     if sel == 0 {
@@ -73,7 +94,9 @@ pub(super) fn handle_storage_move_event(
                 _ => {}
             }
         }
-        ActiveWizard::StorageMove(StorageMoveInput::ConfigureResource { .. }) => handle_resource(code, state, client, tx),
+        ActiveWizard::StorageMove(StorageMoveInput::ConfigureResource { .. }) => {
+            handle_resource(code, state, client, tx)
+        }
         ActiveWizard::StorageMove(StorageMoveInput::ConfigureItem { .. }) => handle_item(code, state, client, tx),
         _ => {}
     }
@@ -128,14 +151,16 @@ fn enter_item(state: &mut AppState, actor_manny_id: String, actor_manny_name: St
     });
 }
 
-fn handle_resource(
-    code: KeyCode,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
+fn handle_resource(code: KeyCode, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     let ActiveWizard::StorageMove(StorageMoveInput::ConfigureResource {
-        actor_manny_id, containers, resource_idx, from_sel, to_sel, amount_buf, field, ..
+        actor_manny_id,
+        containers,
+        resource_idx,
+        from_sel,
+        to_sel,
+        amount_buf,
+        field,
+        ..
     }) = &mut state.active_wizard
     else {
         return;
@@ -196,20 +221,27 @@ fn handle_resource(
                 client.clone(),
                 tx.clone(),
             );
-            state.log_event(LogEvent::storage_move_resource(amount, &resource, &from_name, &to_name, state.active_probe_id));
+            state.log_event(LogEvent::storage_move_resource(
+                amount,
+                &resource,
+                &from_name,
+                &to_name,
+                state.active_probe_id,
+            ));
         }
         _ => {}
     }
 }
 
-fn handle_item(
-    code: KeyCode,
-    state: &mut AppState,
-    client: &ApiClient,
-    tx: &mpsc::Sender<ApiMessage>,
-) {
+fn handle_item(code: KeyCode, state: &mut AppState, client: &ApiClient, tx: &mpsc::Sender<ApiMessage>) {
     let ActiveWizard::StorageMove(StorageMoveInput::ConfigureItem {
-        actor_manny_id, containers, items, to_sel, item_cursor, field, ..
+        actor_manny_id,
+        containers,
+        items,
+        to_sel,
+        item_cursor,
+        field,
+        ..
     }) = &mut state.active_wizard
     else {
         return;
@@ -229,8 +261,11 @@ fn handle_item(
         KeyCode::Left | KeyCode::Char('h') if *field == 1 => *to_sel = wrap_prev(*to_sel, clen),
         KeyCode::Right | KeyCode::Char('l') if *field == 1 => *to_sel = wrap_next(*to_sel, clen),
         KeyCode::Enter => {
-            let ids: Vec<String> =
-                items.iter().filter(|(_, _, sel)| *sel).map(|(id, _, _)| id.clone()).collect();
+            let ids: Vec<String> = items
+                .iter()
+                .filter(|(_, _, sel)| *sel)
+                .map(|(id, _, _)| id.clone())
+                .collect();
             if ids.is_empty() {
                 state.set_storage_move_error("select at least one item with Space".into());
                 return;

--- a/src/input/travel.rs
+++ b/src/input/travel.rs
@@ -3,9 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
 use crate::api::tasks::fetch_move;
-use crate::app::{
-    ActiveWizard, ApiMessage, AppState, LogEvent, TravelInput,
-};
+use crate::app::{ActiveWizard, ApiMessage, AppState, LogEvent, TravelInput};
 pub(super) fn handle_travel_event(
     code: KeyCode,
     state: &mut AppState,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,15 +11,11 @@ use std::io;
 use tokio::sync::mpsc;
 
 use neumann_cockpit::api::tasks::{
-    fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies, fetch_messages,
-    fetch_missions, fetch_sent_messages,
+    fetch_all, fetch_api_version, fetch_crafting_recipes, fetch_mannies, fetch_messages, fetch_missions,
+    fetch_sent_messages,
 };
 use neumann_cockpit::app::{
-    ActiveWizard,
-    ApiMessage, AppState, ColorMode,
-    MessagesInput, MissionsInput,
-    Refetch,
-    RemoteMineInput,
+    ActiveWizard, ApiMessage, AppState, ColorMode, MessagesInput, MissionsInput, Refetch, RemoteMineInput,
     ScutNetworkInput,
 };
 use neumann_cockpit::input::handle_event;
@@ -82,11 +78,16 @@ async fn main() -> Result<()> {
     result
 }
 
-async fn run(
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    ready: preflight::Ready,
-) -> Result<()> {
-    let preflight::Ready { config, client, conn, scan_history, journal, api_version, link_ok } = ready;
+async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: preflight::Ready) -> Result<()> {
+    let preflight::Ready {
+        config,
+        client,
+        conn,
+        scan_history,
+        journal,
+        api_version,
+        link_ok,
+    } = ready;
     // Mutable so a probe switch can retarget every subsequent call (auto-refresh
     // + actions) at the newly-active probe — see the reconcile after handle_event.
     let mut client = client;

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -23,8 +23,8 @@ use tokio::time::timeout;
 
 use crate::api::client::ApiClient;
 use crate::api::types::SectorObservation;
-use crate::app::LogEvent;
 use crate::app::ColorMode;
+use crate::app::LogEvent;
 use crate::config::{self, Config, ConfigStatus, DEFAULT_BASE_URL};
 use crate::store;
 
@@ -56,7 +56,10 @@ pub struct BootLog {
 impl BootLog {
     /// Append a new step in the `Pending` state and make it current.
     fn begin(&mut self, label: &'static str) {
-        self.steps.push(Step { label, status: Status::Pending });
+        self.steps.push(Step {
+            label,
+            status: Status::Pending,
+        });
     }
     /// Set the status of the current (last) step.
     fn set(&mut self, status: Status) {
@@ -253,13 +256,7 @@ async fn onboard(
     }
 }
 
-fn redraw(
-    terminal: &mut Term,
-    log: &BootLog,
-    entry: Option<&str>,
-    note: Option<&str>,
-    color: ColorMode,
-) -> Result<()> {
+fn redraw(terminal: &mut Term, log: &BootLog, entry: Option<&str>, note: Option<&str>, color: ColorMode) -> Result<()> {
     terminal.draw(|f| crate::ui::preflight::render(f, f.area(), &log.steps, entry, note, color))?;
     Ok(())
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -114,7 +114,9 @@ fn coords(obs: &SectorObservation) -> (i64, i64, i64) {
 /// Serialize a simple serde enum to its string form (e.g. `KnowledgeLevel` →
 /// `"detailed"`), for storing in a text column.
 fn enum_text<T: serde::Serialize>(v: &T) -> Option<String> {
-    serde_json::to_value(v).ok().and_then(|j| j.as_str().map(str::to_string))
+    serde_json::to_value(v)
+        .ok()
+        .and_then(|j| j.as_str().map(str::to_string))
 }
 
 /// Insert or replace the observation for its sector (keyed by coordinates,
@@ -152,9 +154,7 @@ pub fn upsert_observation(conn: &Connection, obs: &SectorObservation) -> rusqlit
 /// Best-effort: any error yields an empty history, like the old corrupt-JSON
 /// path.
 pub fn load_observations(conn: &Connection) -> Vec<SectorObservation> {
-    let Ok(mut stmt) =
-        conn.prepare("SELECT data FROM sector_observations ORDER BY scanned_at DESC")
-    else {
+    let Ok(mut stmt) = conn.prepare("SELECT data FROM sector_observations ORDER BY scanned_at DESC") else {
         return Vec::new();
     };
     let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(0)) else {
@@ -232,7 +232,9 @@ pub fn migrate_legacy_json(conn: &mut Connection, json_path: &Path) -> rusqlite:
     if count > 0 {
         return Ok(MigrationOutcome::AlreadyMigrated);
     }
-    let Ok(data) = std::fs::read(json_path) else { return Ok(MigrationOutcome::NoLegacyFile) };
+    let Ok(data) = std::fs::read(json_path) else {
+        return Ok(MigrationOutcome::NoLegacyFile);
+    };
     let Ok(history) = serde_json::from_slice::<Vec<SectorObservation>>(&data) else {
         return Ok(MigrationOutcome::NoLegacyFile);
     };
@@ -344,7 +346,7 @@ mod tests {
         )
         .unwrap();
         ensure_columns(&conn); // adds observed_by
-        // A second call must not fail (column already present).
+                               // A second call must not fail (column already present).
         ensure_columns(&conn);
         // The new column is now writable via the normal upsert.
         let mut o = obs(1.0, 1.0, 1.0);
@@ -378,9 +380,7 @@ mod tests {
             append_event(&conn, &LogEvent::action("test", format!("entry {i}"), None)).unwrap();
         }
         // The table keeps the full history (append-only, never trimmed).
-        let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
-            .unwrap();
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0)).unwrap();
         assert_eq!(count as usize, n, "events are append-only, not trimmed");
         // Loading returns only the most recent window, newest first.
         let loaded = load_events(&conn);
@@ -394,7 +394,10 @@ mod tests {
         let path = std::env::temp_dir().join("nc_migrate_import_test.json");
         let history = vec![obs(1.0, 1.0, 1.0), obs(2.0, 2.0, 2.0)];
         std::fs::write(&path, serde_json::to_vec(&history).unwrap()).unwrap();
-        assert_eq!(migrate_legacy_json(&mut conn, &path).unwrap(), MigrationOutcome::Imported(2));
+        assert_eq!(
+            migrate_legacy_json(&mut conn, &path).unwrap(),
+            MigrationOutcome::Imported(2)
+        );
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
             .unwrap();
@@ -408,7 +411,10 @@ mod tests {
         upsert_observation(&conn, &obs(9.0, 9.0, 9.0)).unwrap();
         let path = std::env::temp_dir().join("nc_migrate_skip_test.json");
         std::fs::write(&path, serde_json::to_vec(&vec![obs(1.0, 1.0, 1.0)]).unwrap()).unwrap();
-        assert_eq!(migrate_legacy_json(&mut conn, &path).unwrap(), MigrationOutcome::AlreadyMigrated);
+        assert_eq!(
+            migrate_legacy_json(&mut conn, &path).unwrap(),
+            MigrationOutcome::AlreadyMigrated
+        );
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM sector_observations", [], |r| r.get(0))
             .unwrap();

--- a/src/ui/cockpit_v2/grid.rs
+++ b/src/ui/cockpit_v2/grid.rs
@@ -28,8 +28,7 @@ pub fn visible_panes(area: Rect, active: Pane) -> Vec<(Pane, Rect)> {
     let row_rects = Layout::vertical(vec![Constraint::Ratio(1, rows as u32); rows]).split(area);
     let mut out = Vec::with_capacity(rows * cols);
     for (i, rr) in row_rects.iter().enumerate() {
-        let col_rects =
-            Layout::horizontal(vec![Constraint::Ratio(1, cols as u32); cols]).split(*rr);
+        let col_rects = Layout::horizontal(vec![Constraint::Ratio(1, cols as u32); cols]).split(*rr);
         for (j, cr) in col_rects.iter().enumerate() {
             out.push((Pane::ALL[(r0 + i) * 3 + (c0 + j)], *cr));
         }

--- a/src/ui/cockpit_v2/menu.rs
+++ b/src/ui/cockpit_v2/menu.rs
@@ -21,8 +21,7 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
         .iter()
         .map(|i| {
             // 3 = the " N " accelerator gutter rendered before every label.
-            3 + i.label.chars().count()
-                + i.disabled_reason.as_ref().map_or(0, |r| r.chars().count() + 3)
+            3 + i.label.chars().count() + i.disabled_reason.as_ref().map_or(0, |r| r.chars().count() + 3)
         })
         .max()
         .unwrap_or(0)
@@ -53,7 +52,11 @@ pub fn render(frame: &mut Frame, area: Rect, menu: &ContextMenu, p: Palette) {
         .map(|(i, item)| {
             // The first nine items get a 1-9 accelerator (see handle_menu_key);
             // later items align under a two-space gutter and stay j/k-only.
-            let acc = if i < 9 { format!(" {} ", i + 1) } else { "   ".to_string() };
+            let acc = if i < 9 {
+                format!(" {} ", i + 1)
+            } else {
+                "   ".to_string()
+            };
             if !item.enabled {
                 let reason = item.disabled_reason.as_deref().unwrap_or("unavailable");
                 return Line::from(vec![

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -12,9 +12,7 @@ mod menu;
 mod panes;
 
 use crate::app::{AppState, DrillLevel, Pane};
-use crate::ui::panels::{
-    render_inventory_panel, render_mannies_panel, render_probe_panel, render_scanner_panel,
-};
+use crate::ui::panels::{render_inventory_panel, render_mannies_panel, render_probe_panel, render_scanner_panel};
 use crate::ui::theme::{palette, pane_block, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -77,8 +75,7 @@ fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
 
         if !state.boot_revealed(pane) {
             frame.render_widget(
-                Paragraph::new(Line::styled("· · ·", Style::default().fg(p.dim)))
-                    .alignment(Alignment::Center),
+                Paragraph::new(Line::styled("· · ·", Style::default().fg(p.dim))).alignment(Alignment::Center),
                 inner,
             );
             continue;
@@ -94,9 +91,7 @@ fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
                 break;
             }
             let base_len = label.chars().count() + 1;
-            let pad = width
-                .saturating_sub(base_len + result.chars().count() + 1)
-                .max(1);
+            let pad = width.saturating_sub(base_len + result.chars().count() + 1).max(1);
             let dotted = format!("{label} {}", "·".repeat(pad));
             let revealed = (elapsed - start) as usize * BOOT_CHARS_PER_FRAME;
             if revealed >= dotted.chars().count() {
@@ -115,7 +110,11 @@ fn render_boot(frame: &mut Frame, area: Rect, state: &AppState, p: Palette) {
         // Once the self-check is done, invite the pilot to continue — in the
         // centre probe pane.
         if pane == Pane::Probe && state.boot_complete() {
-            let cur = if (state.boot_frame / 3).is_multiple_of(2) { "▌" } else { " " };
+            let cur = if (state.boot_frame / 3).is_multiple_of(2) {
+                "▌"
+            } else {
+                " "
+            };
             lines.push(Line::raw(""));
             lines.push(Line::from(Span::styled(
                 "— WE ARE LEGION —",
@@ -178,7 +177,11 @@ fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, state: &AppState, acti
 fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette, visible: &[Pane]) {
     // The command line always claims the second row while `:` is open, even if
     // the hints line is toggled off.
-    let command = if let crate::app::InputMode::Command(cmd) = &state.mode { Some(cmd) } else { None };
+    let command = if let crate::app::InputMode::Command(cmd) = &state.mode {
+        Some(cmd)
+    } else {
+        None
+    };
     let want_second = state.hints_visible || command.is_some();
     let (bar, second) = if want_second && area.height >= 2 {
         let rows = Layout::default()
@@ -226,17 +229,15 @@ fn render_status(frame: &mut Frame, area: Rect, state: &AppState, p: Palette, vi
                     };
                     spans.push(Span::styled(cand.clone(), style));
                 }
-            } else if let Some(usage) = cmd
-                .input
-                .split_whitespace()
-                .next()
-                .and_then(crate::app::command_usage)
-            {
+            } else if let Some(usage) = cmd.input.split_whitespace().next().and_then(crate::app::command_usage) {
                 spans.push(Span::styled(format!("   {usage}"), Style::default().fg(p.dim)));
             }
             Line::from(spans)
         } else {
-            Line::from(Span::styled(format!(" {}", state.pane_hints()), Style::default().fg(p.dim)))
+            Line::from(Span::styled(
+                format!(" {}", state.pane_hints()),
+                Style::default().fg(p.dim),
+            ))
         };
         frame.render_widget(Paragraph::new(line), second_area);
     }
@@ -248,9 +249,15 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
     let mut left = vec![
         Span::styled(
             format!(" {tag} "),
-            Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Black)
+                .bg(p.accent)
+                .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(format!("  {}", state.breadcrumb().join(" › ")), Style::default().fg(p.accent)),
+        Span::styled(
+            format!("  {}", state.breadcrumb().join(" › ")),
+            Style::default().fg(p.accent),
+        ),
     ];
     // Position mini-map: shown only when the grid is reduced (not all 9 panes
     // visible), so you know where the active pane sits. Groups of three keys
@@ -263,7 +270,10 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
             }
             let key = pane.key_label().to_string();
             let style = if *pane == state.active_pane {
-                Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(p.accent)
+                    .add_modifier(Modifier::BOLD)
             } else if visible.contains(pane) {
                 Style::default().fg(p.text)
             } else {
@@ -290,7 +300,11 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
     if state.loading {
         meta.push(("⟳ sync".to_string(), accent));
     } else if let Some(age) = state.seconds_since_sync() {
-        let label = if age < 60 { format!("⟳ {age}s") } else { format!("⟳ {}m", age / 60) };
+        let label = if age < 60 {
+            format!("⟳ {age}s")
+        } else {
+            format!("⟳ {}m", age / 60)
+        };
         meta.push((label, dim));
     }
     // Active probe (multi-probe, API v81): shown only when the fleet has more
@@ -311,7 +325,10 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
     // (`i` cycles to the next one).
     let idle = state.idle_manny_count();
     if idle > 0 {
-        meta.push((format!("⚙ {idle} idle"), Style::default().fg(p.warn).add_modifier(Modifier::BOLD)));
+        meta.push((
+            format!("⚙ {idle} idle"),
+            Style::default().fg(p.warn).add_modifier(Modifier::BOLD),
+        ));
     }
     let unread = state.unread_alert_count();
     if unread > 0 {

--- a/src/ui/cockpit_v2/panes.rs
+++ b/src/ui/cockpit_v2/panes.rs
@@ -7,8 +7,7 @@
 //! Colours come from the active [`Palette`].
 
 use crate::api::types::{
-    Manny, MannyLocationType, MannyTaskVisibility, MissionStatus, MissionStepStatus, SectorObject,
-    SectorObjectType,
+    Manny, MannyLocationType, MannyTaskVisibility, MissionStatus, MissionStepStatus, SectorObject, SectorObjectType,
 };
 use crate::app::{AppState, CommsCategory, DrillLevel, MissionsCategory, Pane};
 use crate::ui::panels::mannies::{
@@ -61,7 +60,11 @@ fn scroll_offset(cursor_line: usize, total: usize, height: usize) -> u16 {
         return 0;
     }
     let max_off = total - height;
-    let off = if cursor_line < height { 0 } else { cursor_line + 1 - height };
+    let off = if cursor_line < height {
+        0
+    } else {
+        cursor_line + 1 - height
+    };
     off.min(max_off) as u16
 }
 
@@ -91,15 +94,24 @@ pub fn render_map(frame: &mut Frame, area: Rect, state: &AppState, active: bool,
     let dim = Style::default().fg(p.dim);
     let mut lines = Vec::new();
     match state.probe_sector_coords() {
-        Some((x, y, z)) => lines.push(Line::styled(format!("sector ({x}, {y}, {z})"), Style::default().fg(p.text))),
+        Some((x, y, z)) => lines.push(Line::styled(
+            format!("sector ({x}, {y}, {z})"),
+            Style::default().fg(p.text),
+        )),
         None => lines.push(Line::styled("sector unknown", dim)),
     }
-    lines.push(Line::styled(format!("visited: {}", state.visited_sectors.len()), Style::default().fg(p.text)));
+    lines.push(Line::styled(
+        format!("visited: {}", state.visited_sectors.len()),
+        Style::default().fg(p.text),
+    ));
     let nets = state.scut_coverage();
     if nets.is_empty() {
         lines.push(Line::styled("SCUT: no coverage", dim));
     } else {
-        lines.push(Line::styled(format!("≣ SCUT: {} network(s)", nets.len()), Style::default().fg(p.accent)));
+        lines.push(Line::styled(
+            format!("≣ SCUT: {} network(s)", nets.len()),
+            Style::default().fg(p.accent),
+        ));
     }
     lines.push(Line::styled("z open map · Enter travel", dim));
     render_body(frame, area, " MAP ", active, p, lines, None);
@@ -125,15 +137,32 @@ fn render_comms_root(frame: &mut Frame, area: Rect, state: &AppState, active: bo
     let text = Style::default().fg(p.text);
     let cur = cursor(state, Pane::Comms);
     let latest_msg = state.messages.first().map(|m| {
-        let icon = if m.status == crate::api::types::MessageStatus::Unread { "✉" } else { "·" };
+        let icon = if m.status == crate::api::types::MessageStatus::Unread {
+            "✉"
+        } else {
+            "·"
+        };
         format!("{icon} {}: {}", m.sender.name, comms_preview(&m.body))
     });
     let latest_alert = state.alerts.first().map(|a| format!("✱ {}", comms_preview(&a.message)));
-    let latest_warn = state.damage_warnings.first().map(|w| format!("⚠ {}", comms_preview(&w.message)));
+    let latest_warn = state
+        .damage_warnings
+        .first()
+        .map(|w| format!("⚠ {}", comms_preview(&w.message)));
     let rows = [
-        ("Messages", state.messages.len(), state.unread_message_count(), latest_msg),
+        (
+            "Messages",
+            state.messages.len(),
+            state.unread_message_count(),
+            latest_msg,
+        ),
         ("Alerts", state.alerts.len(), state.unread_alert_count(), latest_alert),
-        ("Warnings", state.damage_warnings.len(), state.damage_warnings.iter().filter(|w| w.is_unread()).count(), latest_warn),
+        (
+            "Warnings",
+            state.damage_warnings.len(),
+            state.damage_warnings.iter().filter(|w| w.is_unread()).count(),
+            latest_warn,
+        ),
     ];
     let mut lines = Vec::new();
     let mut sel_line = None;
@@ -146,7 +175,10 @@ fn render_comms_root(frame: &mut Frame, area: Rect, state: &AppState, active: bo
             Span::styled(format!("{total}"), dim),
         ];
         if *unread > 0 {
-            spans.push(Span::styled(format!("  ({unread} unread)"), Style::default().fg(p.accent)));
+            spans.push(Span::styled(
+                format!("  ({unread} unread)"),
+                Style::default().fg(p.accent),
+            ));
         }
         lines.push(Line::from(spans));
         // Preview of the most recent entry (dash when the category is empty).
@@ -208,7 +240,15 @@ pub fn render_sector(frame: &mut Frame, area: Rect, state: &AppState, active: bo
     let dim = Style::default().fg(p.dim);
     let text = Style::default().fg(p.text);
     let Some(s) = state.current_sector() else {
-        render_body(frame, area, " SECTOR ", active, p, vec![Line::styled("no sector scan yet", dim)], None);
+        render_body(
+            frame,
+            area,
+            " SECTOR ",
+            active,
+            p,
+            vec![Line::styled("no sector scan yet", dim)],
+            None,
+        );
         return;
     };
     let v = &s.relative_coordinates;
@@ -298,18 +338,27 @@ fn sector_entry_tags(state: &AppState, id: &str, p: Palette) -> Vec<Span<'static
         match o.object_type {
             SectorObjectType::SolarSystem => {
                 out.push(Span::styled("  ★".to_string(), Style::default().fg(p.warn)));
-                out.push(Span::styled(format!(" · {} planet(s)", o.planet_count.unwrap_or(0)), dim));
+                out.push(Span::styled(
+                    format!(" · {} planet(s)", o.planet_count.unwrap_or(0)),
+                    dim,
+                ));
             }
             SectorObjectType::Asteroid => {
                 if let Some(c) = &o.composition {
                     out.push(Span::styled(format!("  {c}"), dim));
                 } else if !o.resource_types.is_empty() {
-                    out.push(Span::styled(format!("  {}", resource_types_str(&o.resource_types)), dim));
+                    out.push(Span::styled(
+                        format!("  {}", resource_types_str(&o.resource_types)),
+                        dim,
+                    ));
                 }
             }
             SectorObjectType::Planet => {
                 if let Some(h) = o.habitability_score {
-                    out.push(Span::styled(format!("  hab {:.0}%", h * 100.0), Style::default().fg(ratio_color(h, p))));
+                    out.push(Span::styled(
+                        format!("  hab {:.0}%", h * 100.0),
+                        Style::default().fg(ratio_color(h, p)),
+                    ));
                 }
                 if let Some(c) = &o.category {
                     out.push(Span::styled(format!(" {c}"), dim));
@@ -343,7 +392,10 @@ fn sector_entry_tags(state: &AppState, id: &str, p: Palette) -> Vec<Span<'static
         }
         if let Some(t) = o.bookmark_targets.iter().find(|t| t.id == id) {
             if let Some(h) = t.habitability_score {
-                out.push(Span::styled(format!("  hab {:.0}%", h * 100.0), Style::default().fg(ratio_color(h, p))));
+                out.push(Span::styled(
+                    format!("  hab {:.0}%", h * 100.0),
+                    Style::default().fg(ratio_color(h, p)),
+                ));
             }
             if let Some(c) = &t.category {
                 out.push(Span::styled(format!(" {c}"), dim));
@@ -368,7 +420,10 @@ fn solar_system_zoom_lines(obj: &SectorObject, p: Palette) -> Vec<Line<'static>>
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| object_type_label(&obj.object_type).to_string());
     lines.push(Line::from(vec![
-        Span::styled(format!("{} ", object_icon(&obj.object_type).0), Style::default().fg(object_color(&obj.object_type, p))),
+        Span::styled(
+            format!("{} ", object_icon(&obj.object_type).0),
+            Style::default().fg(object_color(&obj.object_type, p)),
+        ),
         Span::styled(name, text),
     ]));
     lines.push(Line::styled(
@@ -398,7 +453,9 @@ fn solar_system_zoom_lines(obj: &SectorObject, p: Palette) -> Vec<Line<'static>>
     for id in ids {
         let bt = obj.bookmark_targets.iter().find(|t| t.id == id);
         let mt = obj.minable_targets.iter().flatten().find(|t| t.id == id);
-        let otype = bt.map(|b| b.object_type.clone()).or_else(|| mt.map(|m| m.object_type.clone()));
+        let otype = bt
+            .map(|b| b.object_type.clone())
+            .or_else(|| mt.map(|m| m.object_type.clone()));
         let Some(otype) = otype else { continue };
         let label = object_type_label(&otype);
         let n = counts.entry(label).or_insert(0);
@@ -410,7 +467,10 @@ fn solar_system_zoom_lines(obj: &SectorObject, p: Palette) -> Vec<Line<'static>>
             .unwrap_or_else(|| format!("{label} #{n}"));
 
         lines.push(Line::from(vec![
-            Span::styled(format!("  {} ", object_icon(&otype).0), Style::default().fg(object_color(&otype, p))),
+            Span::styled(
+                format!("  {} ", object_icon(&otype).0),
+                Style::default().fg(object_color(&otype, p)),
+            ),
             Span::styled(name, text),
             Span::styled(format!("  {label}"), dim),
         ]));
@@ -422,7 +482,10 @@ fn solar_system_zoom_lines(obj: &SectorObject, p: Palette) -> Vec<Line<'static>>
                 ]));
             }
             if let Some(c) = &b.category {
-                lines.push(Line::from(vec![Span::styled("      class ", dim), Span::styled(c.clone(), text)]));
+                lines.push(Line::from(vec![
+                    Span::styled("      class ", dim),
+                    Span::styled(c.clone(), text),
+                ]));
             }
         }
         if let Some(m) = mt {
@@ -512,7 +575,10 @@ fn render_mission_detail(frame: &mut Frame, area: Rect, state: &AppState, id: &s
         };
         lines.push(Line::from(vec![
             Span::styled(format!("{mark} "), Style::default().fg(color)),
-            Span::styled(step.title.clone(), row_style(active, i == cur).patch(Style::default().fg(p.text))),
+            Span::styled(
+                step.title.clone(),
+                row_style(active, i == cur).patch(Style::default().fg(p.text)),
+            ),
         ]));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
@@ -661,9 +727,7 @@ pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: b
     let mut sel_line = None;
 
     // Drilled into a container: render its contents inline (fetched on drill-in).
-    if let Some(DrillLevel::Container(id)) =
-        state.pane_nav[Pane::Storage.index()].drill.last()
-    {
+    if let Some(DrillLevel::Container(id)) = state.pane_nav[Pane::Storage.index()].drill.last() {
         return render_container_contents(frame, area, state, id, active, p);
     }
 
@@ -676,7 +740,11 @@ pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: b
             const W: usize = 8;
             for (i, c) in cs.iter().enumerate() {
                 let selected = active && i == cur;
-                let ratio = if c.capacity > 0.0 { (c.used_capacity / c.capacity).clamp(0.0, 1.0) } else { 0.0 };
+                let ratio = if c.capacity > 0.0 {
+                    (c.used_capacity / c.capacity).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
                 let filled = (ratio * W as f64).round() as usize;
                 let name_style = if selected {
                     Style::default().fg(p.accent).add_modifier(Modifier::BOLD)
@@ -704,15 +772,27 @@ pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: b
                 // Zoom: routing rules and free capacity per container.
                 if zoomed {
                     if !rules.priority.is_empty() {
-                        lines.push(Line::styled(format!("    priority: {}", rules.priority.join(", ")), dim));
+                        lines.push(Line::styled(
+                            format!("    priority: {}", rules.priority.join(", ")),
+                            dim,
+                        ));
                     }
                     if !rules.exclusion.is_empty() {
-                        lines.push(Line::styled(format!("    exclude:  {}", rules.exclusion.join(", ")), dim));
+                        lines.push(Line::styled(
+                            format!("    exclude:  {}", rules.exclusion.join(", ")),
+                            dim,
+                        ));
                     }
                     if !rules.strict_exclusion.is_empty() {
-                        lines.push(Line::styled(format!("    strict:   {}", rules.strict_exclusion.join(", ")), dim));
+                        lines.push(Line::styled(
+                            format!("    strict:   {}", rules.strict_exclusion.join(", ")),
+                            dim,
+                        ));
                     }
-                    lines.push(Line::styled(format!("    free {:.2} of {:.2}", c.free_capacity, c.capacity), dim));
+                    lines.push(Line::styled(
+                        format!("    free {:.2} of {:.2}", c.free_capacity, c.capacity),
+                        dim,
+                    ));
                 }
             }
         }
@@ -723,14 +803,7 @@ pub fn render_storage(frame: &mut Frame, area: Rect, state: &AppState, active: b
 /// Inline contents of a container (drill-in `l` on the Storage pane): capacity,
 /// resource stocks, and unit items. Fetched on drill-in; shows a placeholder
 /// until the detail arrives.
-fn render_container_contents(
-    frame: &mut Frame,
-    area: Rect,
-    state: &AppState,
-    id: &str,
-    active: bool,
-    p: Palette,
-) {
+fn render_container_contents(frame: &mut Frame, area: Rect, state: &AppState, id: &str, active: bool, p: Palette) {
     let dim = Style::default().fg(p.dim);
     let text = Style::default().fg(p.text);
     let mut lines: Vec<Line> = Vec::new();
@@ -753,8 +826,17 @@ fn render_container_contents(
             } else {
                 0.0
             };
-            lines.push(block_gauge_line("USED", ratio, &format!("{:.0}%", ratio * 100.0), fill_color(p, 1.0 - ratio), p));
-            lines.push(Line::styled(format!("free {:.2} of {:.2}", c.free_capacity, c.capacity), dim));
+            lines.push(block_gauge_line(
+                "USED",
+                ratio,
+                &format!("{:.0}%", ratio * 100.0),
+                fill_color(p, 1.0 - ratio),
+                p,
+            ));
+            lines.push(Line::styled(
+                format!("free {:.2} of {:.2}", c.free_capacity, c.capacity),
+                dim,
+            ));
 
             let rules = &c.rules;
             if !rules.priority.is_empty() {
@@ -764,7 +846,10 @@ fn render_container_contents(
                 lines.push(Line::styled(format!("exclude:  {}", rules.exclusion.join(", ")), dim));
             }
             if !rules.strict_exclusion.is_empty() {
-                lines.push(Line::styled(format!("strict:   {}", rules.strict_exclusion.join(", ")), dim));
+                lines.push(Line::styled(
+                    format!("strict:   {}", rules.strict_exclusion.join(", ")),
+                    dim,
+                ));
             }
 
             lines.push(Line::raw(""));
@@ -849,9 +934,18 @@ fn manny_detail_lines(state: &AppState, m: &Manny, p: Palette) -> Vec<Line<'stat
     let c = &m.cargo;
     let used = c.metals + c.ice + c.deuterium + c.organic_compounds;
     let ratio = if c.capacity > 0.0 { used / c.capacity } else { 0.0 };
-    lines.push(block_gauge_line("CARGO", ratio, &format!("{:.0}%", ratio * 100.0), p.accent, p));
+    lines.push(block_gauge_line(
+        "CARGO",
+        ratio,
+        &format!("{:.0}%", ratio * 100.0),
+        p.accent,
+        p,
+    ));
     lines.push(Line::styled(format!("metals {:.2}  ice {:.2}", c.metals, c.ice), text));
-    lines.push(Line::styled(format!("deut {:.2}  org {:.2}", c.deuterium, c.organic_compounds), text));
+    lines.push(Line::styled(
+        format!("deut {:.2}  org {:.2}", c.deuterium, c.organic_compounds),
+        text,
+    ));
     lines
 }
 
@@ -860,14 +954,20 @@ pub fn render_manny_detail(frame: &mut Frame, area: Rect, state: &AppState, id: 
         let block = pane_block(" MANNY ", active, p);
         let inner = block.inner(area);
         frame.render_widget(block, area);
-        frame.render_widget(Paragraph::new(Line::styled("manny gone", Style::default().fg(p.dim))), inner);
+        frame.render_widget(
+            Paragraph::new(Line::styled("manny gone", Style::default().fg(p.dim))),
+            inner,
+        );
         return;
     };
     let title = format!(" {} ", m.name);
     let block = pane_block(&title, active, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
-    frame.render_widget(Paragraph::new(manny_detail_lines(state, m, p)).wrap(Wrap { trim: false }), inner);
+    frame.render_widget(
+        Paragraph::new(manny_detail_lines(state, m, p)).wrap(Wrap { trim: false }),
+        inner,
+    );
 }
 
 /// Zoomed Mannies pane: a vertical list where each manny is a summary line
@@ -943,7 +1043,13 @@ pub fn render_mannies_overview(frame: &mut Frame, area: Rect, state: &AppState, 
         let c = &m.cargo;
         let used = c.metals + c.ice + c.deuterium + c.organic_compounds;
         let ratio = if c.capacity > 0.0 { used / c.capacity } else { 0.0 };
-        lines.push(block_gauge_line("    CARGO", ratio, &format!("{:.0}%", ratio * 100.0), p.accent, p));
+        lines.push(block_gauge_line(
+            "    CARGO",
+            ratio,
+            &format!("{:.0}%", ratio * 100.0),
+            p.accent,
+            p,
+        ));
         lines.push(Line::styled(
             format!(
                 "    metals {:.2} · ice {:.2} · deut {:.2} · org {:.2}",
@@ -1014,7 +1120,11 @@ pub fn render_scanner_neighbors(frame: &mut Frame, area: Rect, state: &AppState,
     let (dy, ds) = cell(px, py - 1, pz);
     let (lx, ls) = cell(px - 1, py, pz);
     let (rx, rs) = cell(px + 1, py, pz);
-    lines.push(Line::from(vec![Span::raw("      "), Span::styled(uy, us), Span::styled("  +Y", dim)]));
+    lines.push(Line::from(vec![
+        Span::raw("      "),
+        Span::styled(uy, us),
+        Span::styled("  +Y", dim),
+    ]));
     lines.push(Line::from(vec![
         Span::styled(lx, ls),
         Span::styled(" -X   ", dim),
@@ -1022,7 +1132,11 @@ pub fn render_scanner_neighbors(frame: &mut Frame, area: Rect, state: &AppState,
         Span::styled("   +X ", dim),
         Span::styled(rx, rs),
     ]));
-    lines.push(Line::from(vec![Span::raw("      "), Span::styled(dy, ds), Span::styled("  -Y", dim)]));
+    lines.push(Line::from(vec![
+        Span::raw("      "),
+        Span::styled(dy, ds),
+        Span::styled("  -Y", dim),
+    ]));
     lines.push(Line::raw(""));
 
     // Z axis on its own row (out-of-plane).
@@ -1049,7 +1163,12 @@ pub fn render_scanner_neighbors(frame: &mut Frame, area: Rect, state: &AppState,
         let (sym, st, label, coord_color) = match at(x, y, z) {
             Some(s) => {
                 let (sym, st) = map_cell_style(s, p);
-                (sym.to_string(), st, knowledge_label(&s.knowledge_level), sector_interest_color(s, p))
+                (
+                    sym.to_string(),
+                    st,
+                    knowledge_label(&s.knowledge_level),
+                    sector_interest_color(s, p),
+                )
             }
             None => ("·".to_string(), dim, "unscanned", p.dim),
         };
@@ -1099,5 +1218,3 @@ mod tests {
         assert_eq!(scroll_offset(5, 10, 0), 0);
     }
 }
-
-

--- a/src/ui/overlays/alerts.rs
+++ b/src/ui/overlays/alerts.rs
@@ -1,6 +1,6 @@
-use crate::ui::theme::{palette, Palette};
 use crate::api::types::{AlertType, ProbeAlert};
 use crate::app::{ActiveWizard, AlertsInput, AppState};
+use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -46,7 +46,11 @@ fn alert_row(alert: &ProbeAlert, p: Palette) -> ListItem<'static> {
     } else {
         Style::default().fg(p.dim)
     };
-    let label_color = if unread { type_color(&alert.alert_type, p) } else { p.dim };
+    let label_color = if unread {
+        type_color(&alert.alert_type, p)
+    } else {
+        p.dim
+    };
     ListItem::new(Line::from(vec![
         Span::styled(marker, Style::default().fg(marker_color)),
         Span::styled(
@@ -59,7 +63,11 @@ fn alert_row(alert: &ProbeAlert, p: Palette) -> ListItem<'static> {
 
 pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Alerts(AlertsInput::Browsing { selection, show_warnings }) = &state.active_wizard else {
+    let ActiveWizard::Alerts(AlertsInput::Browsing {
+        selection,
+        show_warnings,
+    }) = &state.active_wizard
+    else {
         return;
     };
     let (selection, show_warnings) = (*selection, *show_warnings);
@@ -95,7 +103,10 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     let warns_unread = state.damage_warnings.iter().filter(|w| w.is_unread()).count();
     let tab_style = |active: bool| {
         if active {
-            Style::default().fg(Color::Black).bg(p.accent).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(Color::Black)
+                .bg(p.accent)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(p.dim)
         }
@@ -111,7 +122,11 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
     // ── List ──
     if entries.is_empty() {
-        let label = if show_warnings { "no damage warnings" } else { "no active alerts" };
+        let label = if show_warnings {
+            "no damage warnings"
+        } else {
+            "no active alerts"
+        };
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(label, Style::default().fg(p.dim)))),
             rows[1],
@@ -127,10 +142,15 @@ pub(crate) fn render_alerts_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     }
 
     // ── Footer ──
-    render_footer(frame, rows[2], p, &[
-        FooterKey::nav("[↑/↓]", "select"),
-        FooterKey::nav("[Tab]", "switch"),
-        FooterKey::commit("[Enter]", "ACK"),
-        FooterKey::nav("[Esc]", "close"),
-    ]);
+    render_footer(
+        frame,
+        rows[2],
+        p,
+        &[
+            FooterKey::nav("[↑/↓]", "select"),
+            FooterKey::nav("[Tab]", "switch"),
+            FooterKey::commit("[Enter]", "ACK"),
+            FooterKey::nav("[Esc]", "close"),
+        ],
+    );
 }

--- a/src/ui/overlays/assemble.rs
+++ b/src/ui/overlays/assemble.rs
@@ -22,8 +22,14 @@ const ASSEMBLY_BILL: &[&str] = &[
 ];
 
 pub(crate) fn render_assemble_probe_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { manny_name, containers, selected, cursor, error, .. }) =
-        &state.active_wizard
+    let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers {
+        manny_name,
+        containers,
+        selected,
+        cursor,
+        error,
+        ..
+    }) = &state.active_wizard
     else {
         return;
     };
@@ -68,19 +74,30 @@ pub(crate) fn render_assemble_probe_overlay(frame: &mut Frame, area: Rect, state
     lines.push(Line::default());
     lines.push(Line::from(Span::styled("Also consumes", Style::default().fg(p.dim))));
     for item in ASSEMBLY_BILL {
-        lines.push(Line::from(Span::styled(format!("  · {item}"), Style::default().fg(p.dim))));
+        lines.push(Line::from(Span::styled(
+            format!("  · {item}"),
+            Style::default().fg(p.dim),
+        )));
     }
     lines.push(Line::from(Span::styled(
         "  → new drone in this sector (~3h task)",
         Style::default().fg(p.dim),
     )));
     if let Some(err) = error {
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::nav("[Space]", "select"),
-        FooterKey::commit("[Enter]", "ASSEMBLE"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::nav("[Space]", "select"),
+            FooterKey::commit("[Enter]", "ASSEMBLE"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }

--- a/src/ui/overlays/containers.rs
+++ b/src/ui/overlays/containers.rs
@@ -1,5 +1,5 @@
-use crate::ui::theme::palette;
 use crate::app::{ActiveWizard, AppState, ContainerRulesInput, RenameContainerInput};
+use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -12,8 +12,12 @@ use super::{centered_rect, render_footer, FooterKey};
 
 pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::RenameContainer(RenameContainerInput::Typing { current_label, buf, error, .. }) =
-        &state.active_wizard
+    let ActiveWizard::RenameContainer(RenameContainerInput::Typing {
+        current_label,
+        buf,
+        error,
+        ..
+    }) = &state.active_wizard
     else {
         return;
     };
@@ -40,15 +44,23 @@ pub(crate) fn render_rename_container_overlay(frame: &mut Frame, area: Rect, sta
     ])];
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
 
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::commit("[Enter]", "RENAME"),
-        FooterKey::nav("[Tab]", "suggest"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::commit("[Enter]", "RENAME"),
+            FooterKey::nav("[Tab]", "suggest"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -111,7 +123,10 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
                 ("[ ]", p.dim)
             };
             ListItem::new(Line::from(vec![
-                Span::styled(format!("{tag} "), Style::default().fg(color).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    format!("{tag} "),
+                    Style::default().fg(color).add_modifier(Modifier::BOLD),
+                ),
                 Span::styled(ty.clone(), Style::default().fg(p.text)),
             ]))
         })
@@ -134,11 +149,16 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
             rows[2],
         );
     } else {
-        render_footer(frame, rows[2], p, &[
-            FooterKey::nav("[Space]", "cycle"),
-            FooterKey::nav("[Del]", "clear"),
-            FooterKey::commit("[Enter]", "SAVE"),
-            FooterKey::nav("[Esc]", "cancel"),
-        ]);
+        render_footer(
+            frame,
+            rows[2],
+            p,
+            &[
+                FooterKey::nav("[Space]", "cycle"),
+                FooterKey::nav("[Del]", "clear"),
+                FooterKey::commit("[Enter]", "SAVE"),
+                FooterKey::nav("[Esc]", "cancel"),
+            ],
+        );
     }
 }

--- a/src/ui/overlays/craft.rs
+++ b/src/ui/overlays/craft.rs
@@ -1,4 +1,4 @@
-use crate::app::{ActiveWizard, AppState, Fabricator, FabricationInput};
+use crate::app::{ActiveWizard, AppState, FabricationInput, Fabricator};
 use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -12,19 +12,36 @@ use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
 
 /// Render whichever step of the unified fabrication wizard is active.
 pub(crate) fn render_fabrication_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let ActiveWizard::Fabrication(fabrication) = &state.active_wizard else { return };
+    let ActiveWizard::Fabrication(fabrication) = &state.active_wizard else {
+        return;
+    };
     match fabrication {
         FabricationInput::PickRecipe { selection, error, .. } => {
             render_catalog(frame, area, state, *selection, error.as_deref());
         }
-        FabricationInput::PickBuilder { recipe_name, mannies, selection, error, .. } => {
+        FabricationInput::PickBuilder {
+            recipe_name,
+            mannies,
+            selection,
+            error,
+            ..
+        } => {
             let p = palette(state.color_mode);
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let prompt = format!("Build {recipe_name} with:");
             let height = (names.len() as u16 + 6).clamp(8, 20);
             render_pick_list(
-                frame, area, p, " FABRICATION — SELECT BUILDER ", 46, height,
-                Some(&prompt), &names, *selection, error.as_deref(), "BUILD",
+                frame,
+                area,
+                p,
+                " FABRICATION — SELECT BUILDER ",
+                46,
+                height,
+                Some(&prompt),
+                &names,
+                *selection,
+                error.as_deref(),
+                "BUILD",
             );
         }
     }
@@ -33,13 +50,7 @@ pub(crate) fn render_fabrication_overlay(frame: &mut Frame, area: Rect, state: &
 /// The item-first catalog: every recipe sectioned by fabricator, with a detail
 /// block (output, duration, per-ingredient have/need + the builder/assistant it
 /// will use) for the selected recipe.
-fn render_catalog(
-    frame: &mut Frame,
-    area: Rect,
-    state: &AppState,
-    selection: usize,
-    error: Option<&str>,
-) {
+fn render_catalog(frame: &mut Frame, area: Rect, state: &AppState, selection: usize, error: Option<&str>) {
     let p = palette(state.color_mode);
     let rows = state.fabrication_recipes();
     let sel = rows.get(selection);
@@ -107,7 +118,11 @@ fn render_catalog(
         ]));
     }
     let visible = list_area.height as usize;
-    let scroll = if sel_line >= visible { (sel_line - visible + 1) as u16 } else { 0 };
+    let scroll = if sel_line >= visible {
+        (sel_line - visible + 1) as u16
+    } else {
+        0
+    };
     frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), list_area);
 
     // ── Right panel: the selected recipe's detail, divided by a left border.
@@ -125,10 +140,7 @@ fn render_catalog(
         )));
         detail.push(builder_line(*fab, state, p));
         detail.push(Line::default());
-        let mut out = vec![
-            Span::styled("→ ", dim),
-            Span::styled(recipe.output.name.as_str(), text),
-        ];
+        let mut out = vec![Span::styled("→ ", dim), Span::styled(recipe.output.name.as_str(), text)];
         if let Some(bonus) = recipe.output.capacity_bonus {
             if bonus != 0.0 {
                 out.push(Span::styled(format!("  +{bonus:.2} cap"), dim));
@@ -136,7 +148,8 @@ fn render_catalog(
         }
         detail.push(Line::from(out));
         detail.push(Line::from(Span::styled(
-            format!("⏲ {} min", recipe.duration_seconds / 60), dim,
+            format!("⏲ {} min", recipe.duration_seconds / 60),
+            dim,
         )));
         detail.push(Line::default());
         detail.push(Line::from(Span::styled("INGREDIENTS   have/need", dim)));
@@ -157,15 +170,24 @@ fn render_catalog(
                 format!("{have:.2}")
             };
             detail.push(Line::from(vec![
-                Span::styled(if ok { "✓ " } else { "✗ " }, Style::default().fg(if ok { p.good } else { p.crit })),
+                Span::styled(
+                    if ok { "✓ " } else { "✗ " },
+                    Style::default().fg(if ok { p.good } else { p.crit }),
+                ),
                 Span::styled(format!("{:<19}", ing.ingredient_type), text),
-                Span::styled(format!("{have_str}/{need}"), Style::default().fg(if ok { p.text } else { p.crit })),
+                Span::styled(
+                    format!("{have_str}/{need}"),
+                    Style::default().fg(if ok { p.text } else { p.crit }),
+                ),
             ]));
         }
     }
     if let Some(err) = error {
         detail.push(Line::default());
-        detail.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        detail.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
     frame.render_widget(Paragraph::new(detail), detail_area);
 
@@ -175,13 +197,22 @@ fn render_catalog(
     let commit = if can {
         FooterKey::commit("[Enter]", "FABRICATE")
     } else {
-        FooterKey { key: "[Enter]", label: "FABRICATE", tone: KeyTone::Disabled }
+        FooterKey {
+            key: "[Enter]",
+            label: "FABRICATE",
+            tone: KeyTone::Disabled,
+        }
     };
-    render_footer(frame, layout[1], p, &[
-        FooterKey::nav("[↑/↓]", "select"),
-        commit,
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        layout[1],
+        p,
+        &[
+            FooterKey::nav("[↑/↓]", "select"),
+            commit,
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 fn section_header(fab: Fabricator, p: Palette) -> Line<'static> {
@@ -203,16 +234,26 @@ fn builder_line(fab: Fabricator, state: &AppState, p: Palette) -> Line<'static> 
     match fab {
         Fabricator::AtomicPrinter => {
             if !state.has_atomic_printer() {
-                Line::from(Span::styled("⚠ no atomic printer in inventory", Style::default().fg(p.crit)))
+                Line::from(Span::styled(
+                    "⚠ no atomic printer in inventory",
+                    Style::default().fg(p.crit),
+                ))
             } else if state.collect_idle_onboard_mannies().is_empty() {
-                Line::from(Span::styled("⚠ no idle manny to assist the printer", Style::default().fg(p.warn)))
+                Line::from(Span::styled(
+                    "⚠ no idle manny to assist the printer",
+                    Style::default().fg(p.warn),
+                ))
             } else {
                 Line::from(Span::styled("⚛ printer reserves an idle manny as assistant", dim))
             }
         }
         Fabricator::Manny => {
             // A pre-chosen builder (opened from the Mannies pane) wins.
-            if let ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: Some((_, name)), .. }) = &state.active_wizard {
+            if let ActiveWizard::Fabrication(FabricationInput::PickRecipe {
+                prefilled_manny: Some((_, name)),
+                ..
+            }) = &state.active_wizard
+            {
                 return Line::from(vec![
                     Span::styled("⚙ builder: ", dim),
                     Span::styled(name.clone(), Style::default().fg(p.text)),

--- a/src/ui/overlays/drop_container.rs
+++ b/src/ui/overlays/drop_container.rs
@@ -1,24 +1,56 @@
-use crate::ui::theme::palette;
 use crate::app::{ActiveWizard, AppState, DropStorageContainerInput};
+use crate::ui::theme::palette;
 use ratatui::{layout::Rect, Frame};
 
 use super::render_pick_list;
 
 pub(crate) fn render_drop_container_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let ActiveWizard::DropContainer(drop_container) = &state.active_wizard else { return };
+    let ActiveWizard::DropContainer(drop_container) = &state.active_wizard else {
+        return;
+    };
     match drop_container {
-        DropStorageContainerInput::PickContainer { containers, selection, .. } => {
+        DropStorageContainerInput::PickContainer {
+            containers, selection, ..
+        } => {
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, palette(state.color_mode), " DROP CONTAINER — SELECT CONTAINER ", 54, height,
-                None, &names, *selection, None, "select");
+            render_pick_list(
+                frame,
+                area,
+                palette(state.color_mode),
+                " DROP CONTAINER — SELECT CONTAINER ",
+                54,
+                height,
+                None,
+                &names,
+                *selection,
+                None,
+                "select",
+            );
         }
-        DropStorageContainerInput::PickPlanet { container_name, planets, selection, error, .. } => {
+        DropStorageContainerInput::PickPlanet {
+            container_name,
+            planets,
+            selection,
+            error,
+            ..
+        } => {
             let names: Vec<&str> = planets.iter().map(|(_, n)| n.as_str()).collect();
             let height = (planets.len() as u16 + 7).min(18);
             let prompt = format!("Drop {container_name} on planet:");
-            render_pick_list(frame, area, palette(state.color_mode), " DROP CONTAINER — SELECT PLANET ", 54, height,
-                Some(&prompt), &names, *selection, error.as_deref(), "DROP");
+            render_pick_list(
+                frame,
+                area,
+                palette(state.color_mode),
+                " DROP CONTAINER — SELECT PLANET ",
+                54,
+                height,
+                Some(&prompt),
+                &names,
+                *selection,
+                error.as_deref(),
+                "DROP",
+            );
         }
     }
 }

--- a/src/ui/overlays/fleet.rs
+++ b/src/ui/overlays/fleet.rs
@@ -31,15 +31,28 @@ pub(crate) fn render_probe_switch_overlay(frame: &mut Frame, area: Rect, state: 
             } else {
                 " "
             };
-            let reach = if pr.is_reachable { "" } else { "   ⚠ out of SCUT range" };
+            let reach = if pr.is_reachable {
+                ""
+            } else {
+                "   ⚠ out of SCUT range"
+            };
             format!("{mark} {}  ·  {}{reach}", pr.name, probe_status_label(&pr.status))
         })
         .collect();
     let refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
     let height = (refs.len() as u16 + 6).clamp(8, 20);
     render_pick_list(
-        frame, area, p, " SWITCH PROBE ", 52, height,
-        Some("Pilot:"), &refs, selection, None, "pilot",
+        frame,
+        area,
+        p,
+        " SWITCH PROBE ",
+        52,
+        height,
+        Some("Pilot:"),
+        &refs,
+        selection,
+        None,
+        "pilot",
     );
 }
 
@@ -48,20 +61,40 @@ pub(crate) fn render_probe_switch_overlay(frame: &mut Frame, area: Rect, state: 
 /// server-validated, so a mismatch surfaces as an error line in step 2.
 pub(crate) fn render_transfer_deuterium_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::TransferDeuterium(transfer_deuterium) = &state.active_wizard else { return };
+    let ActiveWizard::TransferDeuterium(transfer_deuterium) = &state.active_wizard else {
+        return;
+    };
     match transfer_deuterium {
-        TransferDeuteriumInput::PickTarget { manny_name, targets, selection, .. } => {
-            let labels: Vec<String> =
-                targets.iter().map(|(id, name)| format!("{name}  ·  #{id}")).collect();
+        TransferDeuteriumInput::PickTarget {
+            manny_name,
+            targets,
+            selection,
+            ..
+        } => {
+            let labels: Vec<String> = targets.iter().map(|(id, name)| format!("{name}  ·  #{id}")).collect();
             let refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (refs.len() as u16 + 6).clamp(8, 20);
             let title = format!(" TRANSFER DEUTERIUM — {manny_name} ");
             render_pick_list(
-                frame, area, p, &title, 54, height,
-                Some("Send to:"), &refs, *selection, None, "select",
+                frame,
+                area,
+                p,
+                &title,
+                54,
+                height,
+                Some("Send to:"),
+                &refs,
+                *selection,
+                None,
+                "select",
             );
         }
-        TransferDeuteriumInput::EnterAmount { target_name, buf, error, .. } => {
+        TransferDeuteriumInput::EnterAmount {
+            target_name,
+            buf,
+            error,
+            ..
+        } => {
             let popup = centered_rect(52, 8, area);
             frame.render_widget(Clear, popup);
             let block = Block::default()
@@ -97,17 +130,28 @@ pub(crate) fn render_transfer_deuterium_overlay(frame: &mut Frame, area: Rect, s
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::commit("[Enter]", "TRANSFER"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[
+                    FooterKey::commit("[Enter]", "TRANSFER"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
+            );
         }
     }
 }
 
 /// Text-entry overlay to rename the piloted probe (API v81).
 pub(crate) fn render_rename_probe_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let ActiveWizard::RenameProbe(RenameProbeInput::Typing { current_name, buf, error, .. }) = &state.active_wizard else {
+    let ActiveWizard::RenameProbe(RenameProbeInput::Typing {
+        current_name,
+        buf,
+        error,
+        ..
+    }) = &state.active_wizard
+    else {
         return;
     };
     let p = palette(state.color_mode);
@@ -134,12 +178,20 @@ pub(crate) fn render_rename_probe_overlay(frame: &mut Frame, area: Rect, state: 
     ]));
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::commit("[Enter]", "RENAME"),
-        FooterKey::nav("[Tab]", "suggest"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::commit("[Enter]", "RENAME"),
+            FooterKey::nav("[Tab]", "suggest"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -206,8 +206,7 @@ mod tests {
             render_help_overlay(f, a, p, 0);
         })
         .unwrap();
-        let text: String =
-            t.backend().buffer().content.iter().map(|c| c.symbol()).collect();
+        let text: String = t.backend().buffer().content.iter().map(|c| c.symbol()).collect();
         assert!(text.contains("Navigate"), "navigation section shown");
         assert!(text.contains("Command mode"), "command-mode section shown");
         assert!(text.contains(":travel"), "command verbs documented");

--- a/src/ui/overlays/improve.rs
+++ b/src/ui/overlays/improve.rs
@@ -12,19 +12,36 @@ use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
 
 /// Render whichever step of the probe-improvement wizard is active.
 pub(crate) fn render_improve_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let ActiveWizard::Improve(improve) = &state.active_wizard else { return };
+    let ActiveWizard::Improve(improve) = &state.active_wizard else {
+        return;
+    };
     match improve {
         ImproveInput::PickImprovement { selection, error } => {
             render_catalog(frame, area, state, *selection, error.as_deref());
         }
-        ImproveInput::PickBuilder { improvement_name, mannies, selection, error, .. } => {
+        ImproveInput::PickBuilder {
+            improvement_name,
+            mannies,
+            selection,
+            error,
+            ..
+        } => {
             let p = palette(state.color_mode);
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let prompt = format!("Install {improvement_name} with:");
             let height = (names.len() as u16 + 6).clamp(8, 20);
             render_pick_list(
-                frame, area, p, " IMPROVE PROBE — SELECT BUILDER ", 48, height,
-                Some(&prompt), &names, *selection, error.as_deref(), "BUILD",
+                frame,
+                area,
+                p,
+                " IMPROVE PROBE — SELECT BUILDER ",
+                48,
+                height,
+                Some(&prompt),
+                &names,
+                *selection,
+                error.as_deref(),
+                "BUILD",
             );
         }
     }
@@ -32,13 +49,7 @@ pub(crate) fn render_improve_overlay(frame: &mut Frame, area: Rect, state: &AppS
 
 /// Two-panel catalog: the improvement list on the left, the selected one's
 /// detail (status, duration, ingredient have/need, description) on the right.
-fn render_catalog(
-    frame: &mut Frame,
-    area: Rect,
-    state: &AppState,
-    selection: usize,
-    error: Option<&str>,
-) {
+fn render_catalog(frame: &mut Frame, area: Rect, state: &AppState, selection: usize, error: Option<&str>) {
     let p = palette(state.color_mode);
     let items = &state.probe_improvements;
     let sel = items.get(selection);
@@ -126,9 +137,15 @@ fn render_catalog(
                 (format!("{:.2}", ing.quantity), format!("{have:.2}"))
             };
             detail.push(Line::from(vec![
-                Span::styled(if ok { "✓ " } else { "✗ " }, Style::default().fg(if ok { p.good } else { p.crit })),
+                Span::styled(
+                    if ok { "✓ " } else { "✗ " },
+                    Style::default().fg(if ok { p.good } else { p.crit }),
+                ),
                 Span::styled(format!("{:<19}", ing.ingredient_type), text),
-                Span::styled(format!("{have_str}/{need}"), Style::default().fg(if ok { p.text } else { p.crit })),
+                Span::styled(
+                    format!("{have_str}/{need}"),
+                    Style::default().fg(if ok { p.text } else { p.crit }),
+                ),
             ]));
         }
         detail.push(Line::default());
@@ -138,22 +155,36 @@ fn render_catalog(
     }
     if let Some(err) = error {
         detail.push(Line::default());
-        detail.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        detail.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
     frame.render_widget(Paragraph::new(detail), detail_area);
 
     // Footer — Enter dimmed unless the selected improvement can be installed now.
-    let can = sel.map(|i| i.available && !i.done && state.improvement_affordable(i)).unwrap_or(false);
+    let can = sel
+        .map(|i| i.available && !i.done && state.improvement_affordable(i))
+        .unwrap_or(false);
     let commit = if can {
         FooterKey::commit("[Enter]", "INSTALL")
     } else {
-        FooterKey { key: "[Enter]", label: "INSTALL", tone: KeyTone::Disabled }
+        FooterKey {
+            key: "[Enter]",
+            label: "INSTALL",
+            tone: KeyTone::Disabled,
+        }
     };
-    render_footer(frame, layout[1], p, &[
-        FooterKey::nav("[↑/↓]", "select"),
-        commit,
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        layout[1],
+        p,
+        &[
+            FooterKey::nav("[↑/↓]", "select"),
+            commit,
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 /// Greedy word-wrap to `width` columns (right detail panel is narrow).
@@ -179,4 +210,3 @@ fn wrap(s: &str, width: usize) -> Vec<String> {
     }
     lines
 }
-

--- a/src/ui/overlays/inventory_detail.rs
+++ b/src/ui/overlays/inventory_detail.rs
@@ -1,5 +1,5 @@
-use crate::ui::theme::{palette, Palette};
 use crate::app::{AppState, InventoryRow};
+use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
@@ -21,12 +21,16 @@ pub(crate) fn detail_kv(p: Palette, key: &str, value: String) -> Line<'static> {
 pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
     let Some(probe) = &state.probe else { return };
-    let Some(row) = state.selected_inventory_row() else { return };
+    let Some(row) = state.selected_inventory_row() else {
+        return;
+    };
     let inv = &probe.inventory;
 
     let (title, lines): (String, Vec<Line>) = match row {
         InventoryRow::Stock { id } => {
-            let Some(stock) = inv.resource_stocks.iter().find(|s| s.id == id) else { return };
+            let Some(stock) = inv.resource_stocks.iter().find(|s| s.id == id) else {
+                return;
+            };
             let mut lines = vec![
                 detail_kv(p, "Type", stock.stock_type.clone()),
                 detail_kv(p, "Amount", format!("{:.4} ECE", stock.amount)),
@@ -34,12 +38,10 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
             ];
             if !stock.containers.is_empty() {
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled(
-                    "── containers ──",
-                    Style::default().fg(p.dim),
-                )));
+                lines.push(Line::from(Span::styled("── containers ──", Style::default().fg(p.dim))));
                 for line in &stock.containers {
-                    lines.push(detail_kv(p, 
+                    lines.push(detail_kv(
+                        p,
                         &line.container.label,
                         format!("{:.4} ECE  (space {:.4})", line.amount, line.container_space),
                     ));
@@ -48,11 +50,14 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
             (stock.name.clone(), lines)
         }
         InventoryRow::ActiveItem { id } => {
-            let Some(item) = inv.items.iter().find(|i| i.id == id) else { return };
+            let Some(item) = inv.items.iter().find(|i| i.id == id) else {
+                return;
+            };
             let mut lines = vec![
                 detail_kv(p, "Type", item.item_type.clone()),
                 detail_kv(p, "Space", format!("{:.4}", item.container_space)),
-                detail_kv(p, 
+                detail_kv(
+                    p,
                     "Task",
                     match item.current_task.as_deref() {
                         None => "idle".into(),
@@ -61,17 +66,18 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
                 ),
             ];
             if let Some(loc) = &item.location {
-                lines.push(detail_kv(p, "Location", format!("{:?}", loc.location_type).to_lowercase()));
+                lines.push(detail_kv(
+                    p,
+                    "Location",
+                    format!("{:?}", loc.location_type).to_lowercase(),
+                ));
             }
             if let Some(container) = &item.container {
                 lines.push(detail_kv(p, "Container", container.label.clone()));
             }
             if let Some(cargo) = &item.cargo {
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled(
-                    "── cargo ──",
-                    Style::default().fg(p.dim),
-                )));
+                lines.push(Line::from(Span::styled("── cargo ──", Style::default().fg(p.dim))));
                 lines.push(detail_kv(p, "Capacity", format!("{:.3}", cargo.capacity)));
                 lines.push(detail_kv(p, "Deuterium", format!("{:.3}", cargo.deuterium)));
                 lines.push(detail_kv(p, "Metals", format!("{:.3}", cargo.metals)));
@@ -86,14 +92,17 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
             let mut lines = vec![
                 detail_kv(p, "Type", item_type.clone()),
                 detail_kv(p, "Count", format!("{}", items.len())),
-                detail_kv(p, 
+                detail_kv(
+                    p,
                     "Space",
                     format!("{:.4} total", items.iter().map(|i| i.container_space).sum::<f64>()),
                 ),
                 Line::default(),
             ];
             for item in &items {
-                let container = item.container.as_ref()
+                let container = item
+                    .container
+                    .as_ref()
                     .map(|c| format!("  ({})", c.label))
                     .unwrap_or_default();
                 lines.push(Line::from(vec![
@@ -123,4 +132,3 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
     frame.render_widget(Paragraph::new(lines), rows[0]);
     render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc]", "close")]);
 }
-

--- a/src/ui/overlays/jettison.rs
+++ b/src/ui/overlays/jettison.rs
@@ -1,5 +1,5 @@
-use crate::ui::theme::palette;
 use crate::app::{ActiveWizard, AppState, JettisonInput};
+use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
@@ -11,7 +11,9 @@ use ratatui::{
 use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Jettison(jettison) = &state.active_wizard else { return };
+    let ActiveWizard::Jettison(jettison) = &state.active_wizard else {
+        return;
+    };
     match jettison {
         JettisonInput::ConfirmManny { manny_name, error, .. } => {
             let popup = centered_rect(48, 8, area);
@@ -42,10 +44,12 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::danger("[Enter]", "EJECT"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[FooterKey::danger("[Enter]", "EJECT"), FooterKey::nav("[Esc]", "cancel")],
+            );
         }
 
         JettisonInput::ConfirmRelay { error, .. } => {
@@ -76,13 +80,24 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::commit("[Enter]", "DEPLOY"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[
+                    FooterKey::commit("[Enter]", "DEPLOY"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
+            );
         }
 
-        JettisonInput::EnterAmount { item_name, max_amount, buf, error, .. } => {
+        JettisonInput::EnterAmount {
+            item_name,
+            max_amount,
+            buf,
+            error,
+            ..
+        } => {
             let popup = centered_rect(46, 8, area);
             frame.render_widget(Clear, popup);
             let block = Block::default()
@@ -120,13 +135,20 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::nav("[Enter]", "review"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[FooterKey::nav("[Enter]", "review"), FooterKey::nav("[Esc]", "cancel")],
+            );
         }
 
-        JettisonInput::Confirm { item_name, amount, error, .. } => {
+        JettisonInput::Confirm {
+            item_name,
+            amount,
+            error,
+            ..
+        } => {
             let popup = centered_rect(50, 8, area);
             frame.render_widget(Clear, popup);
             let block = Block::default()
@@ -151,10 +173,7 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                     format!("Jettison {qty} of {item_name}?"),
                     Style::default().fg(p.crit),
                 )),
-                Line::from(Span::styled(
-                    "Discarded stock is lost.",
-                    Style::default().fg(p.dim),
-                )),
+                Line::from(Span::styled("Discarded stock is lost.", Style::default().fg(p.dim))),
             ];
             if let Some(err) = error {
                 lines.push(Line::default());
@@ -164,12 +183,15 @@ pub(crate) fn render_jettison_overlay(frame: &mut Frame, area: Rect, state: &App
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::danger("[Enter]", "JETTISON"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[
+                    FooterKey::danger("[Enter]", "JETTISON"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
+            );
         }
-
     }
 }
-

--- a/src/ui/overlays/map.rs
+++ b/src/ui/overlays/map.rs
@@ -1,6 +1,4 @@
-use crate::api::types::{
-    DangerLevel, SectorObjectType, SectorObservation,
-};
+use crate::api::types::{DangerLevel, SectorObjectType, SectorObservation};
 use crate::app::AppState;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -10,8 +8,8 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::theme::{format_duration, map_cell_symbol, palette};
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
+use crate::ui::theme::{format_duration, map_cell_symbol, palette};
 
 /// Picker over visited sectors (most-recent first, as returned by the API):
 /// coordinates, distance from the probe, and visit count.
@@ -31,15 +29,28 @@ pub(crate) fn render_goto_visited_overlay(frame: &mut Frame, area: Rect, state: 
                 .map(|(px, py, pz)| (x - px).abs().max((y - py).abs()).max((z - pz).abs()))
                 .map(|d| format!("  d{d}"))
                 .unwrap_or_default();
-            let times = if v.visit_count > 1 { format!("  ×{}", v.visit_count) } else { String::new() };
+            let times = if v.visit_count > 1 {
+                format!("  ×{}", v.visit_count)
+            } else {
+                String::new()
+            };
             format!("({x}, {y}, {z}){dist}{times}")
         })
         .collect();
     let refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
     let height = (refs.len() as u16 + 6).clamp(8, 20);
     render_pick_list(
-        frame, area, p, " JUMP TO VISITED SECTOR ", 46, height,
-        Some("Travel to:"), &refs, selection, None, "travel",
+        frame,
+        area,
+        p,
+        " JUMP TO VISITED SECTOR ",
+        46,
+        height,
+        Some("Travel to:"),
+        &refs,
+        selection,
+        None,
+        "travel",
     );
 }
 
@@ -51,27 +62,41 @@ pub(crate) fn sector_brief(s: &SectorObservation) -> String {
         return "empty".into();
     }
     let mut parts: Vec<String> = Vec::new();
-    if objects.iter().any(|o| matches!(o.object_type, SectorObjectType::BlackHole)) {
+    if objects
+        .iter()
+        .any(|o| matches!(o.object_type, SectorObjectType::BlackHole))
+    {
         parts.push("black hole".into());
     }
-    if objects.iter().any(|o| {
-        matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem)
-    }) {
+    if objects
+        .iter()
+        .any(|o| matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem))
+    {
         parts.push("star".into());
     }
-    let planets = objects.iter().filter(|o| matches!(o.object_type, SectorObjectType::Planet)).count()
-        + objects.iter().flat_map(|o| &o.bookmark_targets)
-            .filter(|t| matches!(t.object_type, SectorObjectType::Planet)).count();
+    let planets = objects
+        .iter()
+        .filter(|o| matches!(o.object_type, SectorObjectType::Planet))
+        .count()
+        + objects
+            .iter()
+            .flat_map(|o| &o.bookmark_targets)
+            .filter(|t| matches!(t.object_type, SectorObjectType::Planet))
+            .count();
     if planets > 0 {
         parts.push(format!("{planets} planet(s)"));
     }
-    let minables: usize = objects.iter()
+    let minables: usize = objects
+        .iter()
         .map(|o| o.minable_targets.as_ref().map(|t| t.len()).unwrap_or(0))
         .sum();
     if minables > 0 {
         parts.push(format!("{minables} minable"));
     }
-    if objects.iter().any(|o| matches!(o.danger_level, Some(DangerLevel::Extreme))) {
+    if objects
+        .iter()
+        .any(|o| matches!(o.danger_level, Some(DangerLevel::Extreme)))
+    {
         parts.push("extreme danger".into());
     }
     if parts.is_empty() {
@@ -91,8 +116,7 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
         .title(Span::styled(
             format!(
                 " MAP  ({},{},{})  y:{} ",
-                state.map.center_x, state.map.y_layer, state.map.center_z,
-                state.map.y_layer,
+                state.map.center_x, state.map.y_layer, state.map.center_z, state.map.y_layer,
             ),
             Style::default().fg(p.accent),
         ))
@@ -156,17 +180,12 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
     let y = state.map.y_layer;
 
     // ── Center cell info ──
-    let mut info_spans: Vec<Span> = vec![
-        Span::styled(
-            format!("({cx},{y},{cz})"),
-            Style::default().fg(p.text).add_modifier(Modifier::BOLD),
-        ),
-    ];
+    let mut info_spans: Vec<Span> = vec![Span::styled(
+        format!("({cx},{y},{cz})"),
+        Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+    )];
     if let Some(d) = state.map_center_distance() {
-        info_spans.push(Span::styled(
-            format!("  d:{d}"),
-            Style::default().fg(p.dim),
-        ));
+        info_spans.push(Span::styled(format!("  d:{d}"), Style::default().fg(p.dim)));
         if d > 0 {
             info_spans.push(Span::styled(
                 format!("  ETA ~{}", format_duration((5 + 35 * d) * 60)),
@@ -190,10 +209,7 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
                 "unscanned".into()
             }
         });
-    info_spans.push(Span::styled(
-        format!("  {brief}"),
-        Style::default().fg(p.dim),
-    ));
+    info_spans.push(Span::styled(format!("  {brief}"), Style::default().fg(p.dim)));
     frame.render_widget(Paragraph::new(Line::from(info_spans)), info_area);
 
     // ── Legend ──
@@ -235,14 +251,19 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
             hint_area,
         );
     } else {
-        render_footer(frame, hint_area, p, &[
-            FooterKey::nav("[hjkl]", "pan"),
-            FooterKey::nav("[u/d]", "y±1"),
-            FooterKey::nav("[0]", "probe"),
-            FooterKey::nav("[c]", "go to"),
-            FooterKey::commit("[g]", "TRAVEL"),
-            FooterKey::nav("[b/Esc]", "close"),
-        ]);
+        render_footer(
+            frame,
+            hint_area,
+            p,
+            &[
+                FooterKey::nav("[hjkl]", "pan"),
+                FooterKey::nav("[u/d]", "y±1"),
+                FooterKey::nav("[0]", "probe"),
+                FooterKey::nav("[c]", "go to"),
+                FooterKey::commit("[g]", "TRAVEL"),
+                FooterKey::nav("[b/Esc]", "close"),
+            ],
+        );
     }
     let w = map_area.width as i32;
     let h = map_area.height as i32;
@@ -304,4 +325,3 @@ pub(crate) fn render_map_overlay(frame: &mut Frame, area: Rect, state: &AppState
         }
     }
 }
-

--- a/src/ui/overlays/messages.rs
+++ b/src/ui/overlays/messages.rs
@@ -7,9 +7,9 @@ use ratatui::{
     Frame,
 };
 
+use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 use crate::api::types::MessageStatus;
 use crate::app::{ActiveWizard, AppState, MessagesInput};
-use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 
 fn preview(body: &str) -> String {
     let one = body.replace('\n', " ");
@@ -22,7 +22,9 @@ fn preview(body: &str) -> String {
 
 pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Messages(messages_input) = &state.active_wizard else { return };
+    let ActiveWizard::Messages(messages_input) = &state.active_wizard else {
+        return;
+    };
     match messages_input {
         MessagesInput::Browsing { sent_tab, selection } => {
             let popup = centered_rect(76, 80, area);
@@ -41,8 +43,16 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
                 .split(inner);
 
             // Tabs
-            let inbox_style = if *sent_tab { Style::default().fg(p.dim) } else { Style::default().fg(p.text).add_modifier(Modifier::BOLD) };
-            let sent_style = if *sent_tab { Style::default().fg(p.text).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.dim) };
+            let inbox_style = if *sent_tab {
+                Style::default().fg(p.dim)
+            } else {
+                Style::default().fg(p.text).add_modifier(Modifier::BOLD)
+            };
+            let sent_style = if *sent_tab {
+                Style::default().fg(p.text).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(p.dim)
+            };
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
                     Span::styled("Inbox", inbox_style),
@@ -55,7 +65,10 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             let mut lines: Vec<Line> = Vec::new();
             if *sent_tab {
                 if state.sent_messages.is_empty() {
-                    lines.push(Line::from(Span::styled("No sent messages.", Style::default().fg(p.dim))));
+                    lines.push(Line::from(Span::styled(
+                        "No sent messages.",
+                        Style::default().fg(p.dim),
+                    )));
                 }
                 for (i, m) in state.sent_messages.iter().enumerate() {
                     let marker = if i == *selection { "▸ " } else { "  " };
@@ -72,8 +85,16 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
                 for (i, m) in state.messages.iter().enumerate() {
                     let marker = if i == *selection { "▸ " } else { "  " };
                     let unread = m.status == MessageStatus::Unread;
-                    let dot = if unread { Span::styled("● ", Style::default().fg(p.accent)) } else { Span::raw("  ") };
-                    let name_style = if unread { Style::default().fg(p.text).add_modifier(Modifier::BOLD) } else { Style::default().fg(p.text) };
+                    let dot = if unread {
+                        Span::styled("● ", Style::default().fg(p.accent))
+                    } else {
+                        Span::raw("  ")
+                    };
+                    let name_style = if unread {
+                        Style::default().fg(p.text).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(p.text)
+                    };
                     lines.push(Line::from(vec![
                         Span::styled(marker, Style::default().fg(p.accent)),
                         dot,
@@ -84,19 +105,32 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             }
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[1]);
 
-            render_footer(frame, rows[2], p, &[
-                FooterKey::nav("[Tab]", "inbox/sent"),
-                FooterKey::nav("[Enter]", "read"),
-                FooterKey::nav("[c]", "compose"),
-                FooterKey::nav("[Esc]", "close"),
-            ]);
+            render_footer(
+                frame,
+                rows[2],
+                p,
+                &[
+                    FooterKey::nav("[Tab]", "inbox/sent"),
+                    FooterKey::nav("[Enter]", "read"),
+                    FooterKey::nav("[c]", "compose"),
+                    FooterKey::nav("[Esc]", "close"),
+                ],
+            );
         }
 
         MessagesInput::Reading { id, sent_tab } => {
             let msg = if *sent_tab {
-                state.sent_messages.iter().find(|m| m.id == *id).map(|m| (&m.sender, &m.recipient, &m.body, &m.sector, &m.created_at))
+                state
+                    .sent_messages
+                    .iter()
+                    .find(|m| m.id == *id)
+                    .map(|m| (&m.sender, &m.recipient, &m.body, &m.sector, &m.created_at))
             } else {
-                state.messages.iter().find(|m| m.id == *id).map(|m| (&m.sender, &m.recipient, &m.body, &m.sector, &m.created_at))
+                state
+                    .messages
+                    .iter()
+                    .find(|m| m.id == *id)
+                    .map(|m| (&m.sender, &m.recipient, &m.body, &m.sector, &m.created_at))
             };
             let popup = centered_rect(64, 16, area);
             frame.render_widget(Clear, popup);
@@ -115,8 +149,14 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             let text = Style::default().fg(p.text);
             let mut lines = Vec::new();
             if let Some((sender, recipient, body, sector, created)) = msg {
-                lines.push(Line::from(vec![Span::styled("from ", dim), Span::styled(sender.name.clone(), text)]));
-                lines.push(Line::from(vec![Span::styled("to   ", dim), Span::styled(recipient.name.clone(), text)]));
+                lines.push(Line::from(vec![
+                    Span::styled("from ", dim),
+                    Span::styled(sender.name.clone(), text),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("to   ", dim),
+                    Span::styled(recipient.name.clone(), text),
+                ]));
                 if let Some(v) = sector.as_ref().and_then(|s| s.relative.as_ref()) {
                     lines.push(Line::from(vec![
                         Span::styled("at   ", dim),
@@ -134,18 +174,33 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
         }
 
         MessagesInput::PickRecipient { recipients, selection } => {
-            let names: Vec<String> = recipients.iter()
+            let names: Vec<String> = recipients
+                .iter()
                 .map(|(kind, _, name)| format!("{name}  ({kind})"))
                 .collect();
             let refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
             let height = (recipients.len() as u16 + 6).min(16);
             render_pick_list(
-                frame, area, palette(state.color_mode), " NEW MESSAGE — recipient ", 54, height,
-                Some("Send to:"), &refs, *selection, None, "compose",
+                frame,
+                area,
+                palette(state.color_mode),
+                " NEW MESSAGE — recipient ",
+                54,
+                height,
+                Some("Send to:"),
+                &refs,
+                *selection,
+                None,
+                "compose",
             );
         }
 
-        MessagesInput::Compose { recipient_name, body_buf, error, .. } => {
+        MessagesInput::Compose {
+            recipient_name,
+            body_buf,
+            error,
+            ..
+        } => {
             let popup = centered_rect(60, 9, area);
             frame.render_widget(Clear, popup);
             let block = Block::default()
@@ -167,14 +222,18 @@ pub(crate) fn render_messages_overlay(frame: &mut Frame, area: Rect, state: &App
             ])];
             if let Some(err) = error {
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+                lines.push(Line::from(Span::styled(
+                    format!("✗ {err}"),
+                    Style::default().fg(p.crit),
+                )));
             }
             frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::commit("[Enter]", "SEND"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[FooterKey::commit("[Enter]", "SEND"), FooterKey::nav("[Esc]", "cancel")],
+            );
         }
-
     }
 }

--- a/src/ui/overlays/mine.rs
+++ b/src/ui/overlays/mine.rs
@@ -7,8 +7,8 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_footer, render_pick_list, FooterKey, KeyTone};
+use crate::ui::theme::{format_duration, palette};
 /// A mining-target picker row: `#n [name][ danger]  metals 1.20  ice 0.55 …`.
 /// Thin wrapper over the shared [`super::probe_object_label`] so every
 /// asteroid/object picker renders identically.
@@ -46,9 +46,16 @@ pub(crate) fn estimate_mine_duration(target_amount: f64, travel_deducted: bool) 
 
 pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Mine(mine) = &state.active_wizard else { return };
+    let ActiveWizard::Mine(mine) = &state.active_wizard else {
+        return;
+    };
     match mine {
-        MineInput::PickAsteroid { manny_name, candidates, selection, .. } => {
+        MineInput::PickAsteroid {
+            manny_name,
+            candidates,
+            selection,
+            ..
+        } => {
             // Asteroids are usually unnamed, so label each by index + its known
             // resource content (like the Sector pane) instead of a bare name.
             let labels: Vec<String> = candidates
@@ -58,17 +65,46 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 .collect();
             let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" MINE — {manny_name} "), 62, height,
-                Some("Select mining target:"), &names, *selection, None, "confirm");
+            render_pick_list(
+                frame,
+                area,
+                palette(state.color_mode),
+                &format!(" MINE — {manny_name} "),
+                62,
+                height,
+                Some("Select mining target:"),
+                &names,
+                *selection,
+                None,
+                "confirm",
+            );
         }
 
-        MineInput::Configure { manny_name, object_name, object_id, resources, amount_buf, amount_mode, target_container, error, .. } => {
+        MineInput::Configure {
+            manny_name,
+            object_name,
+            object_id,
+            resources,
+            amount_buf,
+            amount_mode,
+            target_container,
+            error,
+            ..
+        } => {
             let reserves = state.minable_target_reserves(object_id);
             let popup = centered_rect(52, 15, area);
             frame.render_widget(Clear, popup);
 
-            let manny_short = if manny_name.len() > 10 { &manny_name[..10] } else { manny_name };
-            let obj_short = if object_name.len() > 12 { &object_name[..12] } else { object_name };
+            let manny_short = if manny_name.len() > 10 {
+                &manny_name[..10]
+            } else {
+                manny_name
+            };
+            let obj_short = if object_name.len() > 12 {
+                &object_name[..12]
+            } else {
+                object_name
+            };
             let title = format!(" MINE — {manny_short} → {obj_short} ");
             let block = Block::default()
                 .title(title)
@@ -90,7 +126,11 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             lines.push(Line::from(vec![
                 Span::styled("Resources", Style::default().fg(res_header_color)),
                 Span::styled(
-                    if *amount_mode { "  (Tab to edit)" } else { "  [1-4 to toggle]" },
+                    if *amount_mode {
+                        "  (Tab to edit)"
+                    } else {
+                        "  [1-4 to toggle]"
+                    },
                     Style::default().fg(p.dim),
                 ),
             ]));
@@ -111,10 +151,9 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                 ];
                 // Remaining reserve (ECE) when the target exposes it.
                 match (present, reserve) {
-                    (true, Some(r)) if r > 0.0 => spans.push(Span::styled(
-                        format!(" {r:.2}"),
-                        Style::default().fg(p.dim),
-                    )),
+                    (true, Some(r)) if r > 0.0 => {
+                        spans.push(Span::styled(format!(" {r:.2}"), Style::default().fg(p.dim)))
+                    }
                     (false, _) => spans.push(Span::styled(" —", Style::default().fg(p.dim))),
                     _ => {}
                 }
@@ -154,16 +193,14 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
                         .is_some_and(|(cid, _)| state.mining_travel_deducted(object_id, cid));
                     let (trips, secs) = estimate_mine_duration(amount, travel_deducted);
                     let dest = if travel_deducted { "on-site" } else { "+ travel" };
-                    lines.push(Line::from(vec![
-                        Span::styled(
-                            format!(
-                                "≈ {trips} trip{} · ~{} ({dest})",
-                                if trips == 1 { "" } else { "s" },
-                                format_duration(secs),
-                            ),
-                            Style::default().fg(p.dim),
+                    lines.push(Line::from(vec![Span::styled(
+                        format!(
+                            "≈ {trips} trip{} · ~{} ({dest})",
+                            if trips == 1 { "" } else { "s" },
+                            format_duration(secs),
                         ),
-                    ]));
+                        Style::default().fg(p.dim),
+                    )]));
                 } else {
                     lines.push(Line::default());
                 }
@@ -203,10 +240,18 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             let mine_key = if can_send {
                 FooterKey::commit("[Enter]", "MINE")
             } else {
-                FooterKey { key: "[Enter]", label: "MINE", tone: KeyTone::Disabled }
+                FooterKey {
+                    key: "[Enter]",
+                    label: "MINE",
+                    tone: KeyTone::Disabled,
+                }
             };
             let keys = if *amount_mode {
-                vec![FooterKey::nav("[Tab]", "resources"), mine_key, FooterKey::nav("[Esc]", "cancel")]
+                vec![
+                    FooterKey::nav("[Tab]", "resources"),
+                    mine_key,
+                    FooterKey::nav("[Esc]", "cancel"),
+                ]
             } else {
                 vec![
                     FooterKey::nav("[1-4]", "toggle"),
@@ -217,10 +262,8 @@ pub(crate) fn render_mine_overlay(frame: &mut Frame, area: Rect, state: &AppStat
             };
             render_footer(frame, rows[1], p, &keys);
         }
-
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -249,7 +292,10 @@ mod tests {
     fn unnamed_asteroid_labelled_by_index_and_reserves() {
         let state = state_with_targets();
         let label = asteroid_label(&state, 0, "ast-1", "unnamed");
-        assert_eq!(label, "#1  deuterium 0.42  metals 1.20", "index + named per-resource reserves, no 'unnamed'");
+        assert_eq!(
+            label, "#1  deuterium 0.42  metals 1.20",
+            "index + named per-resource reserves, no 'unnamed'"
+        );
     }
 
     #[test]

--- a/src/ui/overlays/missions.rs
+++ b/src/ui/overlays/missions.rs
@@ -102,13 +102,21 @@ pub(crate) fn render_missions_overlay(frame: &mut Frame, area: Rect, state: &App
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
 
-    render_footer(frame, rows[1], p, &[
-        FooterKey::nav("[↑↓]", "select"),
-        FooterKey::nav("[a]", "abandon"),
-        FooterKey::nav("[Esc]", "close"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::nav("[↑↓]", "select"),
+            FooterKey::nav("[a]", "abandon"),
+            FooterKey::nav("[Esc]", "close"),
+        ],
+    );
 
-    if let ActiveWizard::Missions(MissionsInput::ConfirmAbandon { mission_title, error, .. }) = &state.active_wizard {
+    if let ActiveWizard::Missions(MissionsInput::ConfirmAbandon {
+        mission_title, error, ..
+    }) = &state.active_wizard
+    {
         render_abandon_confirm(frame, area, mission_title, error.as_deref(), p);
     }
 }
@@ -141,8 +149,10 @@ fn render_abandon_confirm(frame: &mut Frame, area: Rect, title: &str, error: Opt
         )));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::danger("[Enter]", "ABANDON"),
-        FooterKey::nav("[Esc]", "keep"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[FooterKey::danger("[Enter]", "ABANDON"), FooterKey::nav("[Esc]", "keep")],
+    );
 }

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -12,12 +12,12 @@ pub(crate) mod map;
 pub(crate) mod messages;
 pub(crate) mod mine;
 pub(crate) mod missions;
-pub(crate) mod remote_mine;
 pub(crate) mod object_actions;
-pub(crate) mod scut_network;
 pub(crate) mod pickers;
+pub(crate) mod remote_mine;
 pub(crate) mod repair;
 pub(crate) mod scanner;
+pub(crate) mod scut_network;
 pub(crate) mod storage_move;
 pub(crate) mod travel;
 pub(crate) mod waypoints;
@@ -26,37 +26,32 @@ pub(crate) use alerts::render_alerts_overlay;
 pub(crate) use assemble::render_assemble_probe_overlay;
 pub(crate) use containers::{render_container_rules_overlay, render_rename_container_overlay};
 pub(crate) use craft::render_fabrication_overlay;
-pub(crate) use improve::render_improve_overlay;
 pub(crate) use drop_container::render_drop_container_overlay;
-pub(crate) use fleet::{
-    render_probe_switch_overlay, render_rename_probe_overlay, render_transfer_deuterium_overlay,
-};
+pub(crate) use fleet::{render_probe_switch_overlay, render_rename_probe_overlay, render_transfer_deuterium_overlay};
 pub(crate) use help::{help_row_count, render_help_overlay};
+pub(crate) use improve::render_improve_overlay;
 pub(crate) use inventory_detail::render_inventory_detail_overlay;
 pub(crate) use jettison::render_jettison_overlay;
 pub(crate) use map::{render_goto_visited_overlay, render_map_overlay};
 pub(crate) use messages::render_messages_overlay;
 pub(crate) use mine::render_mine_overlay;
-pub(crate) use remote_mine::render_remote_mine_overlay;
 pub(crate) use missions::render_missions_overlay;
-pub(crate) use scut_network::render_scut_network_overlay;
 pub(crate) use object_actions::render_object_action_overlay;
 pub(crate) use pickers::{
     render_deploy_overlay, render_detach_overlay, render_drop_cargo_overlay, render_inspect_overlay,
-    render_mind_snapshot_overlay, render_recall_overlay, render_recover_overlay,
-    render_refuel_overlay, render_rename_manny_overlay, render_salvage_overlay,
-    render_scut_relay_overlay,
+    render_mind_snapshot_overlay, render_recall_overlay, render_recover_overlay, render_refuel_overlay,
+    render_rename_manny_overlay, render_salvage_overlay, render_scut_relay_overlay,
 };
+pub(crate) use remote_mine::render_remote_mine_overlay;
 pub(crate) use repair::render_repair_overlay;
 pub(crate) use scanner::render_scan_input_overlay;
+pub(crate) use scut_network::render_scut_network_overlay;
 pub(crate) use storage_move::render_storage_move_overlay;
 pub(crate) use travel::render_travel_overlay;
 pub(crate) use waypoints::render_waypoints_overlay;
 
-use crate::app::{
-    ActiveWizard, AppState, GotoVisitedInput, ProbeSwitchInput, ScanMode, RESOURCE_LABELS,
-};
 use crate::api::types::DangerLevel;
+use crate::app::{ActiveWizard, AppState, GotoVisitedInput, ProbeSwitchInput, ScanMode, RESOURCE_LABELS};
 use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -76,6 +71,7 @@ type OverlayRender = fn(&mut Frame, Rect, &AppState);
 /// render fn early-returns when inactive (several draw their frame before
 /// matching the state), so the caller must gate them.
 #[allow(clippy::type_complexity)]
+#[rustfmt::skip]
 const WIZARD_OVERLAYS: &[(OverlayGuard, OverlayRender)] = &[
     (|s| matches!(s.active_wizard, ActiveWizard::AssembleProbe(_)), render_assemble_probe_overlay),
     (|s| matches!(s.active_wizard, ActiveWizard::RenameProbe(_)), render_rename_probe_overlay),
@@ -167,13 +163,25 @@ pub(crate) struct FooterKey<'a> {
 
 impl<'a> FooterKey<'a> {
     pub fn nav(key: &'a str, label: &'a str) -> Self {
-        Self { key, label, tone: KeyTone::Nav }
+        Self {
+            key,
+            label,
+            tone: KeyTone::Nav,
+        }
     }
     pub fn commit(key: &'a str, label: &'a str) -> Self {
-        Self { key, label, tone: KeyTone::Commit }
+        Self {
+            key,
+            label,
+            tone: KeyTone::Commit,
+        }
     }
     pub fn danger(key: &'a str, label: &'a str) -> Self {
-        Self { key, label, tone: KeyTone::Danger }
+        Self {
+            key,
+            label,
+            tone: KeyTone::Danger,
+        }
     }
 }
 
@@ -289,14 +297,20 @@ pub(crate) fn render_pick_list(
 
     let mut lines: Vec<Line> = Vec::new();
     if let Some(prompt) = prompt {
-        lines.push(Line::from(Span::styled(prompt.to_owned(), Style::default().fg(p.accent))));
+        lines.push(Line::from(Span::styled(
+            prompt.to_owned(),
+            Style::default().fg(p.accent),
+        )));
         lines.push(Line::default());
     }
     for (i, name) in items.iter().enumerate() {
         if i == selection {
             lines.push(Line::from(vec![
                 Span::styled("▶ ", Style::default().fg(p.accent)),
-                Span::styled(name.to_string(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    name.to_string(),
+                    Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+                ),
             ]));
         } else {
             lines.push(Line::from(vec![
@@ -307,7 +321,10 @@ pub(crate) fn render_pick_list(
     }
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
     render_footer(
@@ -321,7 +338,6 @@ pub(crate) fn render_pick_list(
         ],
     );
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -344,7 +360,10 @@ mod tests {
             "#2 Big Rock ⚠  metals",
         );
         // Non-asteroid (no reserves), no danger → bare numbered name.
-        assert_eq!(object_pick_label(2, "dormant construct", None, None), "#3 dormant construct");
+        assert_eq!(
+            object_pick_label(2, "dormant construct", None, None),
+            "#3 dormant construct"
+        );
         // Low/Unknown danger adds no glyph.
         assert_eq!(object_pick_label(0, "", None, Some(&DangerLevel::Low)), "#1");
     }
@@ -368,7 +387,10 @@ mod tests {
         // empty modal — e.g. a stray " TRAVEL " frame after boot. The registry
         // guard prevents it.
         let text = rendered_text(&AppState::default());
-        assert!(!text.contains("TRAVEL"), "no empty TRAVEL frame with an inactive wizard");
+        assert!(
+            !text.contains("TRAVEL"),
+            "no empty TRAVEL frame with an inactive wizard"
+        );
         assert!(!text.contains("REMOTE MINE"), "no empty overlay frames at all");
     }
 
@@ -376,7 +398,10 @@ mod tests {
     fn active_wizard_frame_renders() {
         let mut state = AppState::default();
         state.active_wizard = ActiveWizard::Travel(TravelInput::Typing(String::new()));
-        assert!(rendered_text(&state).contains("TRAVEL"), "active travel wizard renders its frame");
+        assert!(
+            rendered_text(&state).contains("TRAVEL"),
+            "active travel wizard renders its frame"
+        );
     }
 
     #[test]
@@ -391,15 +416,28 @@ mod tests {
                 "ingredients":[],"durationSeconds":300,
                 "output":{"type":"steel_plate","name":"Steel plate","containerSpace":0.01,"containerSpaceUnit":"ECE","capacityBonus":null}}"#).unwrap(),
         ];
-        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe { prefilled_manny: None, selection: 0, error: None });
+        state.active_wizard = ActiveWizard::Fabrication(FabricationInput::PickRecipe {
+            prefilled_manny: None,
+            selection: 0,
+            error: None,
+        });
         let text = rendered_text(&state);
         assert!(text.contains("FABRICATION"), "unified title renders");
         assert!(text.contains("ATOMIC PRINTER"), "atomic section header renders");
         assert!(text.contains("MANNY FABRICATION"), "manny section header renders");
-        assert!(text.contains("Integrated circuit") && text.contains("Steel plate"), "both recipes listed");
+        assert!(
+            text.contains("Integrated circuit") && text.contains("Steel plate"),
+            "both recipes listed"
+        );
         // Regression: the detail panel must always show the selected recipe's
         // ingredient breakdown (have/need), no matter how long the catalog gets.
-        assert!(text.contains("INGREDIENTS"), "detail panel shows the ingredients header");
-        assert!(text.contains("micro_conductor"), "selected recipe's ingredient is listed");
+        assert!(
+            text.contains("INGREDIENTS"),
+            "detail panel shows the ingredients header"
+        );
+        assert!(
+            text.contains("micro_conductor"),
+            "selected recipe's ingredient is listed"
+        );
     }
 }

--- a/src/ui/overlays/object_actions.rs
+++ b/src/ui/overlays/object_actions.rs
@@ -1,27 +1,58 @@
-use crate::ui::theme::palette;
 use crate::app::{ActiveWizard, AppState, ObjectActionInput};
-use ratatui::{
-    layout::Rect,
-    Frame,
-};
+use crate::ui::theme::palette;
+use ratatui::{layout::Rect, Frame};
 
 use super::render_pick_list;
 pub(crate) fn render_object_action_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
-    let ActiveWizard::ObjectAction(object_action) = &state.active_wizard else { return };
+    let ActiveWizard::ObjectAction(object_action) = &state.active_wizard else {
+        return;
+    };
     match object_action {
-        ObjectActionInput::PickAction { object_name, actions, selection, .. } => {
+        ObjectActionInput::PickAction {
+            object_name,
+            actions,
+            selection,
+            ..
+        } => {
             let labels: Vec<&str> = actions.iter().map(|a| a.label()).collect();
             let height = (actions.len() as u16 + 6).min(14);
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" {object_name} "), 46, height,
-                Some("Action:"), &labels, *selection, None, "select");
+            render_pick_list(
+                frame,
+                area,
+                palette(state.color_mode),
+                &format!(" {object_name} "),
+                46,
+                height,
+                Some("Action:"),
+                &labels,
+                *selection,
+                None,
+                "select",
+            );
         }
-        ObjectActionInput::PickManny { object_name, action, mannies, selection, .. } => {
+        ObjectActionInput::PickManny {
+            object_name,
+            action,
+            mannies,
+            selection,
+            ..
+        } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(16);
             let prompt = format!("{} — select manny:", action.label());
-            render_pick_list(frame, area, palette(state.color_mode), &format!(" {object_name} "), 46, height,
-                Some(&prompt), &names, *selection, None, "confirm");
+            render_pick_list(
+                frame,
+                area,
+                palette(state.color_mode),
+                &format!(" {object_name} "),
+                46,
+                height,
+                Some(&prompt),
+                &names,
+                *selection,
+                None,
+                "confirm",
+            );
         }
     }
 }
-

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -1,5 +1,8 @@
+use crate::app::{
+    ActiveWizard, AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, MindSnapshotInput, RecallInput,
+    RecoverInput, RefuelInput, RenameMannyInput, SalvageInput, ScutRelayInput,
+};
 use crate::ui::theme::palette;
-use crate::app::{ActiveWizard, AppState, DeployInput, DetachInput, DropCargoInput, InspectInput, MindSnapshotInput, RecallInput, RecoverInput, RefuelInput, RenameMannyInput, SalvageInput, ScutRelayInput};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -11,16 +14,39 @@ use ratatui::{
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
 pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Salvage(salvage) = &state.active_wizard else { return };
+    let ActiveWizard::Salvage(salvage) = &state.active_wizard else {
+        return;
+    };
     match salvage {
-        SalvageInput::PickTarget { manny_name, candidates, selection, .. } => {
+        SalvageInput::PickTarget {
+            manny_name,
+            candidates,
+            selection,
+            ..
+        } => {
             let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, p, &format!(" SALVAGE — {manny_name} "), 50, height,
-                Some("Select salvage target:"), &names, *selection, None, "confirm");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                &format!(" SALVAGE — {manny_name} "),
+                50,
+                height,
+                Some("Select salvage target:"),
+                &names,
+                *selection,
+                None,
+                "confirm",
+            );
         }
 
-        SalvageInput::Confirm { manny_name, object_name, error, .. } => {
+        SalvageInput::Confirm {
+            manny_name,
+            object_name,
+            error,
+            ..
+        } => {
             let popup = centered_rect(50, 8, area);
             frame.render_widget(Clear, popup);
             let block = Block::default()
@@ -39,7 +65,10 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
             let mut lines: Vec<Line> = Vec::new();
             lines.push(Line::from(vec![
                 Span::styled("Target: ", Style::default().fg(p.dim)),
-                Span::styled(object_name.as_str(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    object_name.as_str(),
+                    Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+                ),
             ]));
             if let Some(err) = error {
                 lines.push(Line::default());
@@ -49,17 +78,24 @@ pub(crate) fn render_salvage_overlay(frame: &mut Frame, area: Rect, state: &AppS
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::commit("[Enter]", "SALVAGE"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[
+                    FooterKey::commit("[Enter]", "SALVAGE"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
+            );
         }
     }
 }
 
 pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_name, error, .. }) = &state.active_wizard else { return };
+    let ActiveWizard::DropCargo(DropCargoInput::Confirm { manny_name, error, .. }) = &state.active_wizard else {
+        return;
+    };
 
     let popup = centered_rect(54, 8, area);
     frame.render_widget(Clear, popup);
@@ -90,18 +126,34 @@ pub(crate) fn render_drop_cargo_overlay(frame: &mut Frame, area: Rect, state: &A
     ];
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::danger("[Enter/y]", "DROP"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::danger("[Enter/y]", "DROP"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Recall(RecallInput::Confirm { manny_name, remote, error, .. }) = &state.active_wizard else { return };
+    let ActiveWizard::Recall(RecallInput::Confirm {
+        manny_name,
+        remote,
+        error,
+        ..
+    }) = &state.active_wizard
+    else {
+        return;
+    };
 
     let popup = centered_rect(52, 8, area);
     frame.render_widget(Clear, popup);
@@ -126,7 +178,11 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
-        if *remote { "Abandon this Manny's remote task?" } else { "Send recall order?" },
+        if *remote {
+            "Abandon this Manny's remote task?"
+        } else {
+            "Send recall order?"
+        },
         Style::default().fg(p.text),
     )));
     if *remote {
@@ -154,7 +210,9 @@ pub(crate) fn render_recall_overlay(frame: &mut Frame, area: Rect, state: &AppSt
 
 pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Refuel(RefuelInput::Confirm { manny_name, error, .. }) = &state.active_wizard else { return };
+    let ActiveWizard::Refuel(RefuelInput::Confirm { manny_name, error, .. }) = &state.active_wizard else {
+        return;
+    };
 
     let popup = centered_rect(50, 7, area);
     frame.render_widget(Clear, popup);
@@ -186,16 +244,26 @@ pub(crate) fn render_refuel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::commit("[Enter]", "REFUEL"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::commit("[Enter]", "REFUEL"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { manny_name, relay_name, buf, error, .. }) =
-        &state.active_wizard
+    let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName {
+        manny_name,
+        relay_name,
+        buf,
+        error,
+        ..
+    }) = &state.active_wizard
     else {
         return;
     };
@@ -230,18 +298,28 @@ pub(crate) fn render_scut_relay_overlay(frame: &mut Frame, area: Rect, state: &A
     ];
     if let Some(err) = error {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+        lines.push(Line::from(Span::styled(
+            format!("✗ {err}"),
+            Style::default().fg(p.crit),
+        )));
     }
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::commit("[Enter]", "TURN ON"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::commit("[Enter]", "TURN ON"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::MindSnapshot(MindSnapshotInput::Confirm { error }) = &state.active_wizard else { return };
+    let ActiveWizard::MindSnapshot(MindSnapshotInput::Confirm { error }) = &state.active_wizard else {
+        return;
+    };
     let alert = state.probe_terminal_alert();
 
     let popup = centered_rect(60, 10, area);
@@ -265,10 +343,7 @@ pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state:
 
     let mut lines: Vec<Line> = Vec::new();
     if let Some(a) = alert {
-        lines.push(Line::from(Span::styled(
-            a.message.clone(),
-            Style::default().fg(p.text),
-        )));
+        lines.push(Line::from(Span::styled(a.message.clone(), Style::default().fg(p.text))));
         lines.push(Line::default());
     }
     lines.push(Line::from(Span::styled(
@@ -287,15 +362,25 @@ pub(crate) fn render_mind_snapshot_overlay(frame: &mut Frame, area: Rect, state:
         )));
     }
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::danger("[Enter]", "REASSIGN"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::danger("[Enter]", "REASSIGN"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::RenameManny(RenameMannyInput::Typing { manny_name, buf, error, .. }) = &state.active_wizard else { return };
+    let ActiveWizard::RenameManny(RenameMannyInput::Typing {
+        manny_name, buf, error, ..
+    }) = &state.active_wizard
+    else {
+        return;
+    };
 
     let popup = centered_rect(46, 7, area);
     frame.render_widget(Clear, popup);
@@ -329,34 +414,73 @@ pub(crate) fn render_rename_manny_overlay(frame: &mut Frame, area: Rect, state: 
     }
 
     frame.render_widget(Paragraph::new(lines), rows[0]);
-    render_footer(frame, rows[1], p, &[
-        FooterKey::commit("[Enter]", "RENAME"),
-        FooterKey::nav("[Tab]", "suggest"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::commit("[Enter]", "RENAME"),
+            FooterKey::nav("[Tab]", "suggest"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Deploy(deploy) = &state.active_wizard else { return };
+    let ActiveWizard::Deploy(deploy) = &state.active_wizard else {
+        return;
+    };
     match deploy {
         DeployInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, p, " DEPLOY WAYPOINT — SELECT MANNY ", 52, height,
-                None, &names, *selection, None, "confirm");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                " DEPLOY WAYPOINT — SELECT MANNY ",
+                52,
+                height,
+                None,
+                &names,
+                *selection,
+                None,
+                "confirm",
+            );
         }
 
-        DeployInput::PickObject { candidates, selection, .. } => {
-            let labels: Vec<String> = candidates.iter().enumerate()
-                .map(|(i, (id, n))| super::probe_object_label(state, i, id, n)).collect();
+        DeployInput::PickObject {
+            candidates, selection, ..
+        } => {
+            let labels: Vec<String> = candidates
+                .iter()
+                .enumerate()
+                .map(|(i, (id, n))| super::probe_object_label(state, i, id, n))
+                .collect();
             let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, p, " DEPLOY WAYPOINT ", 52, height,
-                None, &names, *selection, None, "confirm");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                " DEPLOY WAYPOINT ",
+                52,
+                height,
+                None,
+                &names,
+                *selection,
+                None,
+                "confirm",
+            );
         }
 
-        DeployInput::EnterName { object_name, name_buf, error, .. } => {
+        DeployInput::EnterName {
+            object_name,
+            name_buf,
+            error,
+            ..
+        } => {
             let popup = centered_rect(52, 8, area);
             frame.render_widget(Clear, popup);
             let title = format!(" DEPLOY WAYPOINT — {object_name} ");
@@ -387,63 +511,166 @@ pub(crate) fn render_deploy_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::commit("[Enter]", "DEPLOY"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[
+                    FooterKey::commit("[Enter]", "DEPLOY"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
+            );
         }
     }
 }
 
 pub(crate) fn render_inspect_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Inspect(InspectInput::PickTarget { manny_name, candidates, selection, error, .. }) = &state.active_wizard else { return };
-    let labels: Vec<String> = candidates.iter().enumerate()
-        .map(|(i, (id, n))| super::probe_object_label(state, i, id, n)).collect();
+    let ActiveWizard::Inspect(InspectInput::PickTarget {
+        manny_name,
+        candidates,
+        selection,
+        error,
+        ..
+    }) = &state.active_wizard
+    else {
+        return;
+    };
+    let labels: Vec<String> = candidates
+        .iter()
+        .enumerate()
+        .map(|(i, (id, n))| super::probe_object_label(state, i, id, n))
+        .collect();
     let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
-    render_pick_list(frame, area, p, &format!(" INSPECT — {manny_name} "), 52, height,
-        Some("Select object to inspect:"), &names, *selection, error.as_deref(), "INSPECT");
+    render_pick_list(
+        frame,
+        area,
+        p,
+        &format!(" INSPECT — {manny_name} "),
+        52,
+        height,
+        Some("Select object to inspect:"),
+        &names,
+        *selection,
+        error.as_deref(),
+        "INSPECT",
+    );
 }
 
 pub(crate) fn render_recover_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Recover(RecoverInput::PickContainer { manny_name, candidates, selection, error, .. }) = &state.active_wizard else { return };
+    let ActiveWizard::Recover(RecoverInput::PickContainer {
+        manny_name,
+        candidates,
+        selection,
+        error,
+        ..
+    }) = &state.active_wizard
+    else {
+        return;
+    };
     let names: Vec<&str> = candidates.iter().map(|(_, n)| n.as_str()).collect();
     let error_lines = if error.is_some() { 2u16 } else { 0 };
     let height = (candidates.len() as u16 + 6 + error_lines).min(18);
-    render_pick_list(frame, area, p, &format!(" RECOVER — {manny_name} "), 52, height,
-        Some("Select container to recover:"), &names, *selection, error.as_deref(), "RECOVER");
+    render_pick_list(
+        frame,
+        area,
+        p,
+        &format!(" RECOVER — {manny_name} "),
+        52,
+        height,
+        Some("Select container to recover:"),
+        &names,
+        *selection,
+        error.as_deref(),
+        "RECOVER",
+    );
 }
 
 pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Detach(detach) = &state.active_wizard else { return };
+    let ActiveWizard::Detach(detach) = &state.active_wizard else {
+        return;
+    };
     match detach {
-        DetachInput::PickContainer { manny_name, containers, selection, .. } => {
+        DetachInput::PickContainer {
+            manny_name,
+            containers,
+            selection,
+            ..
+        } => {
             let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
             let height = (containers.len() as u16 + 6).min(16);
-            render_pick_list(frame, area, p, &format!(" DETACH — {manny_name} "), 52, height,
-                Some("Select container to detach:"), &names, *selection, None, "next");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                &format!(" DETACH — {manny_name} "),
+                52,
+                height,
+                Some("Select container to detach:"),
+                &names,
+                *selection,
+                None,
+                "next",
+            );
         }
 
-        DetachInput::PickMode { manny_name, container_name, selection, error, .. } => {
+        DetachInput::PickMode {
+            manny_name,
+            container_name,
+            selection,
+            error,
+            ..
+        } => {
             let names: Vec<&str> = crate::app::DETACH_MODES.iter().map(|(_, l)| *l).collect();
             let prompt = format!("Detach mode  (manny: {manny_name})");
-            render_pick_list(frame, area, p, &format!(" DETACH — {container_name} "), 52, 10,
-                Some(&prompt), &names, *selection, error.as_deref(), "confirm");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                &format!(" DETACH — {container_name} "),
+                52,
+                10,
+                Some(&prompt),
+                &names,
+                *selection,
+                error.as_deref(),
+                "confirm",
+            );
         }
 
-        DetachInput::PickAsteroid { manny_name, container_name, asteroids, selection, error, .. } => {
-            let labels: Vec<String> = asteroids.iter().enumerate()
-                .map(|(i, (id, n))| super::probe_object_label(state, i, id, n)).collect();
+        DetachInput::PickAsteroid {
+            manny_name,
+            container_name,
+            asteroids,
+            selection,
+            error,
+            ..
+        } => {
+            let labels: Vec<String> = asteroids
+                .iter()
+                .enumerate()
+                .map(|(i, (id, n))| super::probe_object_label(state, i, id, n))
+                .collect();
             let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (asteroids.len() as u16 + 8).min(18);
             let prompt = format!("Attach to asteroid  (manny: {manny_name})");
-            render_pick_list(frame, area, p, &format!(" DETACH — hide {container_name} "), 52, height,
-                Some(&prompt), &names, *selection, error.as_deref(), "HIDE HERE");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                &format!(" DETACH — hide {container_name} "),
+                52,
+                height,
+                Some(&prompt),
+                &names,
+                *selection,
+                error.as_deref(),
+                "HIDE HERE",
+            );
         }
     }
 }
-

--- a/src/ui/overlays/remote_mine.rs
+++ b/src/ui/overlays/remote_mine.rs
@@ -7,14 +7,18 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{ActiveWizard, AppState, RemoteMineInput, RESOURCE_LABELS};
 use super::{centered_rect, render_footer, render_pick_list, FooterKey};
+use crate::app::{ActiveWizard, AppState, RemoteMineInput, RESOURCE_LABELS};
 
 pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::RemoteMine(remote_mine) = &state.active_wizard else { return };
+    let ActiveWizard::RemoteMine(remote_mine) = &state.active_wizard else {
+        return;
+    };
     match remote_mine {
-        RemoteMineInput::Loading { manny_name, x, y, z, .. } => {
+        RemoteMineInput::Loading {
+            manny_name, x, y, z, ..
+        } => {
             let popup = centered_rect(50, 5, area);
             frame.render_widget(Clear, popup);
             let block = Block::default()
@@ -39,18 +43,45 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
             render_footer(frame, rows[1], p, &[FooterKey::nav("[Esc]", "cancel")]);
         }
 
-        RemoteMineInput::PickAsteroid { manny_name, candidates, selection, x, y, z, .. } => {
-            let labels: Vec<String> = candidates.iter().enumerate()
-                .map(|(i, (id, n))| super::sector_object_label(state, *x, *y, *z, i, id, n)).collect();
+        RemoteMineInput::PickAsteroid {
+            manny_name,
+            candidates,
+            selection,
+            x,
+            y,
+            z,
+            ..
+        } => {
+            let labels: Vec<String> = candidates
+                .iter()
+                .enumerate()
+                .map(|(i, (id, n))| super::sector_object_label(state, *x, *y, *z, i, id, n))
+                .collect();
             let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
             let height = (candidates.len() as u16 + 6).min(16);
             render_pick_list(
-                frame, area, palette(state.color_mode), &format!(" REMOTE MINE — {manny_name} "), 52, height,
-                Some("Asteroid in the Manny's sector:"), &names, *selection, None, "next",
+                frame,
+                area,
+                palette(state.color_mode),
+                &format!(" REMOTE MINE — {manny_name} "),
+                52,
+                height,
+                Some("Asteroid in the Manny's sector:"),
+                &names,
+                *selection,
+                None,
+                "next",
             );
         }
 
-        RemoteMineInput::Configure { object_name, resources, amount_buf, amount_mode, error, .. } => {
+        RemoteMineInput::Configure {
+            object_name,
+            resources,
+            amount_buf,
+            amount_mode,
+            error,
+            ..
+        } => {
             let popup = centered_rect(54, 13, area);
             frame.render_widget(Clear, popup);
             let block = Block::default()
@@ -68,12 +99,18 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
 
             let mut lines: Vec<Line> = Vec::new();
             let res_color = if *amount_mode { p.dim } else { p.accent };
-            lines.push(Line::from(Span::styled("Resources  [1-4 toggle]", Style::default().fg(res_color))));
+            lines.push(Line::from(Span::styled(
+                "Resources  [1-4 toggle]",
+                Style::default().fg(res_color),
+            )));
             for (i, &label) in RESOURCE_LABELS.iter().enumerate() {
                 let checked = if resources[i] { "[✓]" } else { "[ ]" };
                 let color = if resources[i] { p.text } else { p.dim };
                 lines.push(Line::from(vec![
-                    Span::styled(format!("  {checked} "), Style::default().fg(if resources[i] { p.good } else { p.dim })),
+                    Span::styled(
+                        format!("  {checked} "),
+                        Style::default().fg(if resources[i] { p.good } else { p.dim }),
+                    ),
                     Span::styled(format!("{} {label}", i + 1), Style::default().fg(color)),
                 ]));
             }
@@ -81,30 +118,54 @@ pub(crate) fn render_remote_mine_overlay(frame: &mut Frame, area: Rect, state: &
             let amt_color = if *amount_mode { p.accent } else { p.dim };
             lines.push(Line::from(vec![
                 Span::styled("Amount: ", Style::default().fg(amt_color)),
-                Span::styled(amount_buf.as_str(), Style::default().fg(if *amount_mode { p.text } else { p.dim })),
-                Span::styled(if *amount_mode { "█ ECE" } else { " ECE  [Tab]" }, Style::default().fg(p.dim)),
+                Span::styled(
+                    amount_buf.as_str(),
+                    Style::default().fg(if *amount_mode { p.text } else { p.dim }),
+                ),
+                Span::styled(
+                    if *amount_mode { "█ ECE" } else { " ECE  [Tab]" },
+                    Style::default().fg(p.dim),
+                ),
             ]));
             if let Some(err) = error {
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+                lines.push(Line::from(Span::styled(
+                    format!("✗ {err}"),
+                    Style::default().fg(p.crit),
+                )));
             }
             frame.render_widget(Paragraph::new(lines), rows[0]);
-            render_footer(frame, rows[1], p, &[
-                FooterKey::nav("[1-4]", "res"),
-                FooterKey::nav("[Tab]", "amount"),
-                FooterKey::nav("[Enter]", "container →"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
-        }
-
-        RemoteMineInput::PickContainer { containers, selection, .. } => {
-            let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
-            let height = (containers.len() as u16 + 6).min(16);
-            render_pick_list(
-                frame, area, palette(state.color_mode), " REMOTE MINE — store in ", 52, height,
-                Some("Detached container (required):"), &names, *selection, None, "MINE",
+            render_footer(
+                frame,
+                rows[1],
+                p,
+                &[
+                    FooterKey::nav("[1-4]", "res"),
+                    FooterKey::nav("[Tab]", "amount"),
+                    FooterKey::nav("[Enter]", "container →"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
             );
         }
 
+        RemoteMineInput::PickContainer {
+            containers, selection, ..
+        } => {
+            let names: Vec<&str> = containers.iter().map(|(_, n)| n.as_str()).collect();
+            let height = (containers.len() as u16 + 6).min(16);
+            render_pick_list(
+                frame,
+                area,
+                palette(state.color_mode),
+                " REMOTE MINE — store in ",
+                52,
+                height,
+                Some("Detached container (required):"),
+                &names,
+                *selection,
+                None,
+                "MINE",
+            );
+        }
     }
 }

--- a/src/ui/overlays/repair.rs
+++ b/src/ui/overlays/repair.rs
@@ -7,11 +7,16 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_footer, FooterKey, KeyTone};
+use crate::ui::theme::{format_duration, palette};
 pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Repair(RepairInput::Typing { manny_name, buf, error, .. }) = &state.active_wizard else { return };
+    let ActiveWizard::Repair(RepairInput::Typing {
+        manny_name, buf, error, ..
+    }) = &state.active_wizard
+    else {
+        return;
+    };
 
     let max_pct = state.repair_max_percent();
     let metals_stock = state.repair_metals_stock();
@@ -72,10 +77,7 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             Span::styled(format!("{metals:.4}"), Style::default().fg(metals_color)),
             Span::styled(" ECE", Style::default().fg(p.dim)),
             if insufficient {
-                Span::styled(
-                    format!("  (have {metals_stock:.4})"),
-                    Style::default().fg(p.crit),
-                )
+                Span::styled(format!("  (have {metals_stock:.4})"), Style::default().fg(p.crit))
             } else {
                 Span::raw("")
             },
@@ -86,12 +88,10 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
         ]));
         if let Some(eff) = effective {
             if parsed.is_some_and(|v| v > max_pct + 0.001) {
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        format!("  → capped at {eff:.2}% (probe already at max above)"),
-                        Style::default().fg(p.dim),
-                    ),
-                ]));
+                lines.push(Line::from(vec![Span::styled(
+                    format!("  → capped at {eff:.2}% (probe already at max above)"),
+                    Style::default().fg(p.dim),
+                )]));
             }
         }
     } else {
@@ -117,8 +117,11 @@ pub(crate) fn render_repair_overlay(frame: &mut Frame, area: Rect, state: &AppSt
     let repair_key = if can_send {
         FooterKey::commit("[Enter]", "REPAIR")
     } else {
-        FooterKey { key: "[Enter]", label: "REPAIR", tone: KeyTone::Disabled }
+        FooterKey {
+            key: "[Enter]",
+            label: "REPAIR",
+            tone: KeyTone::Disabled,
+        }
     };
     render_footer(frame, hint_area, p, &[repair_key, FooterKey::nav("[Esc]", "cancel")]);
 }
-

--- a/src/ui/overlays/scanner.rs
+++ b/src/ui/overlays/scanner.rs
@@ -1,5 +1,5 @@
-use crate::ui::theme::{palette, Palette};
 use crate::app::{AppState, ScanMode};
+use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
@@ -53,10 +53,15 @@ fn render_coord_input(frame: &mut Frame, area: Rect, buf: &str, p: Palette) {
         ])),
         rows[1],
     );
-    render_footer(frame, rows[2], p, &[
-        FooterKey::commit("[Enter]", "OBSERVE"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[2],
+        p,
+        &[
+            FooterKey::commit("[Enter]", "OBSERVE"),
+            FooterKey::nav("[Esc]", "cancel"),
+        ],
+    );
 }
 
 fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -91,8 +96,10 @@ fn render_direction_pick(frame: &mut Frame, area: Rect, state: &AppState) {
         ]),
         rows[0],
     );
-    render_footer(frame, rows[1], p, &[
-        FooterKey::nav("[x] [y] [z]", "scan"),
-        FooterKey::nav("[Esc]", "cancel"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[FooterKey::nav("[x] [y] [z]", "scan"), FooterKey::nav("[Esc]", "cancel")],
+    );
 }

--- a/src/ui/overlays/scut_network.rs
+++ b/src/ui/overlays/scut_network.rs
@@ -21,13 +21,18 @@ fn rel(sector: &ProbeSector) -> String {
 
 pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::ScutNetwork(scut_network) = &state.active_wizard else { return };
+    let ActiveWizard::ScutNetwork(scut_network) = &state.active_wizard else {
+        return;
+    };
     match scut_network {
         ScutNetworkInput::Picking { networks, selection } => {
             let items: Vec<&str> = networks.iter().map(|(_, name)| name.as_str()).collect();
             let height = (items.len() as u16) + 4;
             render_pick_list(
-                frame, area, palette(state.color_mode), " SCUT NETWORK ",
+                frame,
+                area,
+                palette(state.color_mode),
+                " SCUT NETWORK ",
                 52,
                 height,
                 Some("Pick a network to inspect"),
@@ -61,15 +66,24 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
                 )));
             } else if let Some(net) = &state.scut_network_view {
                 lines.push(Line::from(vec![
-                    Span::styled(net.name.clone(), Style::default().fg(p.text).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        net.name.clone(),
+                        Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+                    ),
                     Span::raw("   "),
                     Span::styled(
-                        format!("{} relays · {} sectors covered", net.relay_count, net.covered_sector_count),
+                        format!(
+                            "{} relays · {} sectors covered",
+                            net.relay_count, net.covered_sector_count
+                        ),
                         Style::default().fg(p.text),
                     ),
                 ]));
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled("RELAYS", Style::default().fg(p.accent).add_modifier(Modifier::BOLD))));
+                lines.push(Line::from(Span::styled(
+                    "RELAYS",
+                    Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+                )));
                 for r in &net.relays {
                     let (mark, color) = match r.status {
                         ScutRelayStatus::On => ("●", p.good),
@@ -87,7 +101,10 @@ pub(crate) fn render_scut_network_overlay(frame: &mut Frame, area: Rect, state: 
                     ]));
                 }
                 lines.push(Line::default());
-                lines.push(Line::from(Span::styled("PROBES", Style::default().fg(p.accent).add_modifier(Modifier::BOLD))));
+                lines.push(Line::from(Span::styled(
+                    "PROBES",
+                    Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+                )));
                 if net.probes.is_empty() {
                     lines.push(Line::from(Span::styled("  none detected", Style::default().fg(p.dim))));
                 } else {

--- a/src/ui/overlays/storage_move.rs
+++ b/src/ui/overlays/storage_move.rs
@@ -1,5 +1,5 @@
-use crate::ui::theme::{palette, Palette};
 use crate::app::{ActiveWizard, AppState, StorageMoveInput, MOVE_RESOURCE_TYPES};
+use crate::ui::theme::{palette, Palette};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -54,40 +54,88 @@ fn field_row(p: Palette, label: &str, value: String, active: bool, editing: bool
 
 pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::StorageMove(storage_move) = &state.active_wizard else { return };
+    let ActiveWizard::StorageMove(storage_move) = &state.active_wizard else {
+        return;
+    };
     match storage_move {
         StorageMoveInput::PickManny { mannies, selection } => {
             let names: Vec<&str> = mannies.iter().map(|(_, n)| n.as_str()).collect();
             let height = (mannies.len() as u16 + 6).min(18);
-            render_pick_list(frame, area, p, " STORAGE MOVE — SELECT MANNY ", 52, height,
-                None, &names, *selection, None, "select");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                " STORAGE MOVE — SELECT MANNY ",
+                52,
+                height,
+                None,
+                &names,
+                *selection,
+                None,
+                "select",
+            );
         }
         StorageMoveInput::PickKind { selection, .. } => {
-            render_pick_list(frame, area, p, " STORAGE MOVE — KIND ", 46, 8,
-                None, &["resource", "item"], *selection, None, "select");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                " STORAGE MOVE — KIND ",
+                46,
+                8,
+                None,
+                &["resource", "item"],
+                *selection,
+                None,
+                "select",
+            );
         }
         StorageMoveInput::ConfigureResource {
-            containers, resource_idx, from_sel, to_sel, amount_buf, field, error, ..
+            containers,
+            resource_idx,
+            from_sel,
+            to_sel,
+            amount_buf,
+            field,
+            error,
+            ..
         } => {
             let [body, footer] = framed(p, " STORAGE MOVE — RESOURCE ", area, 56, 9, frame);
             let cname = |i: usize| containers.get(i).map(|(_, l)| l.clone()).unwrap_or_default();
             let lines = vec![
-                field_row(p, "Resource:", MOVE_RESOURCE_TYPES[*resource_idx].to_string(), *field == 0, false),
+                field_row(
+                    p,
+                    "Resource:",
+                    MOVE_RESOURCE_TYPES[*resource_idx].to_string(),
+                    *field == 0,
+                    false,
+                ),
                 field_row(p, "From:", cname(*from_sel), *field == 1, false),
                 field_row(p, "To:", cname(*to_sel), *field == 2, false),
                 field_row(p, "Amount:", format!("{amount_buf} ECE"), *field == 3, *field == 3),
                 error_line(p, error),
             ];
             frame.render_widget(Paragraph::new(lines), body);
-            render_footer(frame, footer, p, &[
-                FooterKey::nav("[↑/↓]", "field"),
-                FooterKey::nav("[←/→]", "change"),
-                FooterKey::commit("[Enter]", "MOVE"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                footer,
+                p,
+                &[
+                    FooterKey::nav("[↑/↓]", "field"),
+                    FooterKey::nav("[←/→]", "change"),
+                    FooterKey::commit("[Enter]", "MOVE"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
+            );
         }
         StorageMoveInput::ConfigureItem {
-            containers, items, to_sel, item_cursor, field, error, ..
+            containers,
+            items,
+            to_sel,
+            item_cursor,
+            field,
+            error,
+            ..
         } => {
             let height = (items.len() as u16 + 7).clamp(10, 22);
             let [body, footer] = framed(p, " STORAGE MOVE — ITEMS ", area, 60, height, frame);
@@ -99,7 +147,10 @@ pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: 
             let dest = containers.get(*to_sel).map(|(_, l)| l.clone()).unwrap_or_default();
             let mut head = vec![field_row(p, "To:", dest, *field == 1, false)];
             if let Some(err) = error {
-                head.push(Line::from(Span::styled(format!("✗ {err}"), Style::default().fg(p.crit))));
+                head.push(Line::from(Span::styled(
+                    format!("✗ {err}"),
+                    Style::default().fg(p.crit),
+                )));
             }
             frame.render_widget(Paragraph::new(head), rows[0]);
 
@@ -125,13 +176,18 @@ pub(crate) fn render_storage_move_overlay(frame: &mut Frame, area: Rect, state: 
                 ls.select(Some((*item_cursor).min(items.len() - 1)));
             }
             frame.render_stateful_widget(list, rows[1], &mut ls);
-            render_footer(frame, footer, p, &[
-                FooterKey::nav("[Tab]", "pane"),
-                FooterKey::nav("[Space]", "toggle"),
-                FooterKey::nav("[←/→]", "dest"),
-                FooterKey::commit("[Enter]", "MOVE"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                footer,
+                p,
+                &[
+                    FooterKey::nav("[Tab]", "pane"),
+                    FooterKey::nav("[Space]", "toggle"),
+                    FooterKey::nav("[←/→]", "dest"),
+                    FooterKey::commit("[Enter]", "MOVE"),
+                    FooterKey::nav("[Esc]", "cancel"),
+                ],
+            );
         }
     }
 }
@@ -142,4 +198,3 @@ fn error_line(p: Palette, error: &Option<String>) -> Line<'static> {
         None => Line::default(),
     }
 }
-

--- a/src/ui/overlays/travel.rs
+++ b/src/ui/overlays/travel.rs
@@ -7,11 +7,13 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::theme::{format_duration, palette};
 use super::{centered_rect, render_footer, FooterKey};
+use crate::ui::theme::{format_duration, palette};
 pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Travel(travel) = &state.active_wizard else { return };
+    let ActiveWizard::Travel(travel) = &state.active_wizard else {
+        return;
+    };
     let popup = centered_rect(46, 11, area);
     frame.render_widget(Clear, popup);
 
@@ -37,10 +39,7 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             if let Some((px, py, pz)) = state.probe_sector_coords() {
                 lines.push(Line::from(vec![
                     Span::styled("From: ", Style::default().fg(p.dim)),
-                    Span::styled(
-                        format!("({px},{py},{pz})"),
-                        Style::default().fg(p.text),
-                    ),
+                    Span::styled(format!("({px},{py},{pz})"), Style::default().fg(p.text)),
                 ]));
             }
 
@@ -67,10 +66,7 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 if parity_ok {
                     spans.push(Span::styled("  ✓", Style::default().fg(p.good)));
                 } else {
-                    spans.push(Span::styled(
-                        "  ✗ x+y+z must be even",
-                        Style::default().fg(p.crit),
-                    ));
+                    spans.push(Span::styled("  ✗ x+y+z must be even", Style::default().fg(p.crit)));
                 }
                 lines.push(Line::default());
                 lines.push(Line::from(spans));
@@ -83,13 +79,23 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             }
 
             frame.render_widget(Paragraph::new(lines), body);
-            render_footer(frame, hint_area, p, &[
-                FooterKey::nav("[Enter]", "preview"),
-                FooterKey::nav("[Esc]", "cancel"),
-            ]);
+            render_footer(
+                frame,
+                hint_area,
+                p,
+                &[FooterKey::nav("[Enter]", "preview"), FooterKey::nav("[Esc]", "cancel")],
+            );
         }
 
-        TravelInput::Confirming { x, y, z, sector_distance, fuel_cost, eta_minutes, error } => {
+        TravelInput::Confirming {
+            x,
+            y,
+            z,
+            sector_distance,
+            fuel_cost,
+            eta_minutes,
+            error,
+        } => {
             let mut lines: Vec<Line> = Vec::new();
 
             lines.push(Line::from(vec![
@@ -118,10 +124,7 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             if let Some(mins) = eta_minutes {
                 lines.push(Line::from(vec![
                     Span::styled("   ETA       ", Style::default().fg(p.dim)),
-                    Span::styled(
-                        format_duration(mins * 60),
-                        Style::default().fg(p.warn),
-                    ),
+                    Span::styled(format_duration(mins * 60), Style::default().fg(p.warn)),
                 ]));
             }
 
@@ -138,12 +141,13 @@ pub(crate) fn render_travel_overlay(frame: &mut Frame, area: Rect, state: &AppSt
             if error.is_some() {
                 render_footer(frame, hint_area, p, &[FooterKey::nav("[Esc]", "cancel")]);
             } else {
-                render_footer(frame, hint_area, p, &[
-                    FooterKey::commit("[Enter]", "GO"),
-                    FooterKey::nav("[Esc]", "cancel"),
-                ]);
+                render_footer(
+                    frame,
+                    hint_area,
+                    p,
+                    &[FooterKey::commit("[Enter]", "GO"), FooterKey::nav("[Esc]", "cancel")],
+                );
             }
         }
     }
 }
-

--- a/src/ui/overlays/waypoints.rs
+++ b/src/ui/overlays/waypoints.rs
@@ -1,5 +1,5 @@
-use crate::ui::theme::palette;
 use crate::app::{ActiveWizard, AppState, WaypointKind, WaypointsInput};
+use crate::ui::theme::palette;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -11,7 +11,9 @@ use ratatui::{
 use super::{centered_rect, render_footer, FooterKey};
 pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let p = palette(state.color_mode);
-    let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, selection }) = &state.active_wizard else { return };
+    let ActiveWizard::Waypoints(WaypointsInput::Browsing { entries, selection }) = &state.active_wizard else {
+        return;
+    };
     let selection = *selection;
 
     let height = (entries.len() as u16 + 5).min(20);
@@ -41,10 +43,7 @@ pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &Ap
             ListItem::new(Line::from(vec![
                 Span::styled(format!("{icon} "), Style::default().fg(color)),
                 Span::raw(format!("{:<28}", e.label)),
-                Span::styled(
-                    format!("({},{},{})", e.x, e.y, e.z),
-                    Style::default().fg(p.text),
-                ),
+                Span::styled(format!("({},{},{})", e.x, e.y, e.z), Style::default().fg(p.text)),
                 Span::styled(format!("  d:{}", e.distance), Style::default().fg(p.dim)),
             ]))
         })
@@ -57,10 +56,14 @@ pub(crate) fn render_waypoints_overlay(frame: &mut Frame, area: Rect, state: &Ap
     list_state.select(Some(selection));
     frame.render_stateful_widget(list, rows[0], &mut list_state);
 
-    render_footer(frame, rows[1], p, &[
-        FooterKey::nav("[↑/↓]", "select"),
-        FooterKey::commit("[Enter]", "TRAVEL"),
-        FooterKey::nav("[Esc]", "close"),
-    ]);
+    render_footer(
+        frame,
+        rows[1],
+        p,
+        &[
+            FooterKey::nav("[↑/↓]", "select"),
+            FooterKey::commit("[Enter]", "TRAVEL"),
+            FooterKey::nav("[Esc]", "close"),
+        ],
+    );
 }
-

--- a/src/ui/panels/inventory.rs
+++ b/src/ui/panels/inventory.rs
@@ -17,10 +17,7 @@ pub(crate) fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppS
     frame.render_widget(block, area);
 
     let Some(probe) = &state.probe else {
-        frame.render_widget(
-            Paragraph::new("No data").style(Style::default().fg(p.dim)),
-            inner,
-        );
+        frame.render_widget(Paragraph::new("No data").style(Style::default().fg(p.dim)), inner);
         return;
     };
 
@@ -245,8 +242,12 @@ pub(crate) fn tanks_row_count(inv: &crate::api::types::ProbeInventory, focused: 
 }
 
 pub(crate) fn items_row_count(items: &[crate::api::types::ProbeInventoryItem], expanded: bool) -> usize {
-    if items.is_empty() { return 0; }
-    if !expanded { return 1; }
+    if items.is_empty() {
+        return 0;
+    }
+    if !expanded {
+        return 1;
+    }
     let n_active = items.iter().filter(|i| is_active_item(&i.item_type)).count();
     let mut seen: Vec<&str> = Vec::new();
     for item in items.iter().filter(|i| !is_active_item(&i.item_type)) {

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -1,6 +1,4 @@
-use crate::api::types::{
-    Manny, MannyLocationType, MannyTask, MannyTaskVisibility,
-};
+use crate::api::types::{Manny, MannyLocationType, MannyTask, MannyTaskVisibility};
 use crate::app::AppState;
 use ratatui::{
     layout::Rect,
@@ -114,7 +112,11 @@ pub(crate) fn manny_mining_detail(m: &Manny) -> Option<MiningDetail> {
             .to_string(),
         _ => "probe".to_string(),
     };
-    Some(MiningDetail { target: name, resources, destination })
+    Some(MiningDetail {
+        target: name,
+        resources,
+        destination,
+    })
 }
 
 /// A hidden artificial object (detached container) a Manny turned up while
@@ -198,25 +200,29 @@ pub(crate) fn manny_list_item(m: &Manny, selected: bool, p: Palette) -> ListItem
     ]))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::manny_artificial_detection;
     use crate::api::types::Manny;
 
     fn mining_manny(task: &str) -> Manny {
-        serde_json::from_str(&format!(r#"{{
+        serde_json::from_str(&format!(
+            r#"{{
             "id":"m1","name":"Manny-1","location":{{"type":"sector","sector":null}},
             "currentTask":"mining","taskProgressPercent":50.0,
             "cargo":{{"capacity":0.3,"deuterium":0.0,"metals":0.0,"ice":0.0,"organicCompounds":0.0}},
             "canReceiveOrders":false,"taskEstimatedEndTime":null,"task":{task}
-        }}"#)).unwrap()
+        }}"#
+        ))
+        .unwrap()
     }
 
     #[test]
     fn detects_hidden_container_in_mining_task() {
-        let m = mining_manny(r#"{"objectId":"ast-1","artificialObjectDetected":
-            {"type":"detached_storage_container","detection":"hidden_on_asteroid","objectId":"c-9"}}"#);
+        let m = mining_manny(
+            r#"{"objectId":"ast-1","artificialObjectDetected":
+            {"type":"detached_storage_container","detection":"hidden_on_asteroid","objectId":"c-9"}}"#,
+        );
         let d = manny_artificial_detection(&m).expect("detection present");
         assert_eq!(d.object_id.as_deref(), Some("c-9"));
     }

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -35,7 +35,11 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     let label = |s: &str| Span::styled(format!("{s:<7} "), dim);
 
     let Some(probe) = &state.probe else {
-        let msg = if state.loading { "fetching…" } else { "no data — F5 to refresh" };
+        let msg = if state.loading {
+            "fetching…"
+        } else {
+            "no data — F5 to refresh"
+        };
         frame.render_widget(Paragraph::new(msg).style(dim), content);
         return;
     };
@@ -50,7 +54,10 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     let name_line = if piloting_drone {
         Line::from(vec![
             Span::styled("▸ ", Style::default().fg(p.accent)),
-            Span::styled(probe.name.clone(), Style::default().fg(p.accent).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                probe.name.clone(),
+                Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+            ),
         ])
     } else {
         Line::styled(probe.name.clone(), text.add_modifier(Modifier::BOLD))
@@ -75,8 +82,16 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     // Compact cue in the grid cell; the full roster unfolds when zoomed (`z`),
     // turning the centre pane into a fleet cockpit.
     if state.fleet.len() > 1 {
-        let piloting = if state.active_probe_id.is_none() { "★ default" } else { "▸ drone" };
-        let pilot_col = if state.active_probe_id.is_none() { p.dim } else { p.accent };
+        let piloting = if state.active_probe_id.is_none() {
+            "★ default"
+        } else {
+            "▸ drone"
+        };
+        let pilot_col = if state.active_probe_id.is_none() {
+            p.dim
+        } else {
+            p.accent
+        };
         lines.push(Line::from(vec![
             label("fleet"),
             Span::styled(format!("{} probes  ", state.fleet.len()), text),
@@ -84,9 +99,15 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
         ]));
         if state.zoomed {
             for pr in &state.fleet {
-                let is_active = Some(pr.id) == state.active_probe_id
-                    || (pr.is_default && state.active_probe_id.is_none());
-                let mark = if pr.is_default { "★" } else if is_active { "▸" } else { " " };
+                let is_active =
+                    Some(pr.id) == state.active_probe_id || (pr.is_default && state.active_probe_id.is_none());
+                let mark = if pr.is_default {
+                    "★"
+                } else if is_active {
+                    "▸"
+                } else {
+                    " "
+                };
                 let reach = if pr.is_reachable { "" } else { "  ⚠ far" };
                 let st = if is_active { Style::default().fg(p.accent) } else { dim };
                 lines.push(Line::styled(
@@ -116,15 +137,41 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
     // ── Vital gauges ──
     lines.push(Line::raw(""));
     let max_deuterium = probe.fuel.max_deuterium.unwrap_or(100.0);
-    let fuel = probe.fuel.deuterium.map(|d| (d / max_deuterium).clamp(0.0, 1.0)).unwrap_or(0.0);
-    lines.push(block_gauge_line("FUEL", fuel, &format!("{:.0}%", fuel * 100.0), ratio_color(fuel, p), p));
+    let fuel = probe
+        .fuel
+        .deuterium
+        .map(|d| (d / max_deuterium).clamp(0.0, 1.0))
+        .unwrap_or(0.0);
+    lines.push(block_gauge_line(
+        "FUEL",
+        fuel,
+        &format!("{:.0}%", fuel * 100.0),
+        ratio_color(fuel, p),
+        p,
+    ));
     if let Some(sys) = &probe.systems {
         let integ = (sys.integrity_percent.unwrap_or(100.0) / 100.0).clamp(0.0, 1.0);
-        lines.push(block_gauge_line("INTEG", integ, &format!("{:.0}%", integ * 100.0), ratio_color(integ, p), p));
+        lines.push(block_gauge_line(
+            "INTEG",
+            integ,
+            &format!("{:.0}%", integ * 100.0),
+            ratio_color(integ, p),
+            p,
+        ));
     }
     let inv = &probe.inventory;
-    let cargo = if inv.capacity > 0.0 { (inv.used_capacity / inv.capacity).clamp(0.0, 1.0) } else { 0.0 };
-    lines.push(block_gauge_line("CARGO", cargo, &format!("{:.0}%", cargo * 100.0), p.accent, p));
+    let cargo = if inv.capacity > 0.0 {
+        (inv.used_capacity / inv.capacity).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    lines.push(block_gauge_line(
+        "CARGO",
+        cargo,
+        &format!("{:.0}%", cargo * 100.0),
+        p.accent,
+        p,
+    ));
 
     // ── Movement (active) or current sector ──
     let active = probe.movement.as_ref().filter(|mv| {
@@ -146,20 +193,45 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
             Span::styled(
                 format!(
                     "({},{},{}) → ({},{},{})",
-                    mv.origin.x as i64, mv.origin.y as i64, mv.origin.z as i64,
-                    mv.target.x as i64, mv.target.y as i64, mv.target.z as i64,
+                    mv.origin.x as i64,
+                    mv.origin.y as i64,
+                    mv.origin.z as i64,
+                    mv.target.x as i64,
+                    mv.target.y as i64,
+                    mv.target.z as i64,
                 ),
                 text,
             ),
         ]));
-        lines.push(Line::from(vec![label("dist"), Span::styled(format!("{}", mv.distance), text)]));
+        lines.push(Line::from(vec![
+            label("dist"),
+            Span::styled(format!("{}", mv.distance), text),
+        ]));
         lines.push(Line::from(vec![
             label("phase"),
-            Span::styled(movement_phase_label(mv.phase.as_ref().unwrap_or(&mv.status)), Style::default().fg(p.warn)),
+            Span::styled(
+                movement_phase_label(mv.phase.as_ref().unwrap_or(&mv.status)),
+                Style::default().fg(p.warn),
+            ),
         ]));
-        lines.push(Line::from(vec![label("ETA"), Span::styled(format_duration(remaining), text)]));
-        lines.push(block_gauge_line("BURN", progress, &format!("{:.0}%", progress * 100.0), p.accent, p));
-        lines.push(block_gauge_line("SPEED", velocity, &format!("{velocity:.2}c"), p.accent, p));
+        lines.push(Line::from(vec![
+            label("ETA"),
+            Span::styled(format_duration(remaining), text),
+        ]));
+        lines.push(block_gauge_line(
+            "BURN",
+            progress,
+            &format!("{:.0}%", progress * 100.0),
+            p.accent,
+            p,
+        ));
+        lines.push(block_gauge_line(
+            "SPEED",
+            velocity,
+            &format!("{velocity:.2}c"),
+            p.accent,
+            p,
+        ));
         lines.push(Line::from(vec![
             label("cost"),
             Span::styled(format!("{:.1} deut", mv.fuel_cost_deuterium), dim),
@@ -179,13 +251,21 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
             lines.push(Line::from(vec![label("energy"), Span::styled(format!("{e:.0}"), text)]));
         }
         if let Some(rate) = sys.internal_clock_rate {
-            lines.push(Line::from(vec![label("clock"), Span::styled(format!("{rate:.2}×"), text)]));
+            lines.push(Line::from(vec![
+                label("clock"),
+                Span::styled(format!("{rate:.2}×"), text),
+            ]));
         }
     }
     lines.push(Line::from(vec![
         label("hold"),
         Span::styled(
-            format!("{} items · {} stocks · {} tanks", inv.items.len(), inv.resource_stocks.len(), inv.external_tanks.len()),
+            format!(
+                "{} items · {} stocks · {} tanks",
+                inv.items.len(),
+                inv.resource_stocks.len(),
+                inv.external_tanks.len()
+            ),
             dim,
         ),
     ]));

--- a/src/ui/panels/scanner.rs
+++ b/src/ui/panels/scanner.rs
@@ -9,8 +9,8 @@ use ratatui::{
 };
 
 use crate::ui::theme::{
-    knowledge_color, knowledge_label, map_cell_style, object_color, object_icon, object_type_label,
-    palette, pane_block, ratio_color, Palette,
+    knowledge_color, knowledge_label, map_cell_style, object_color, object_icon, object_type_label, palette,
+    pane_block, ratio_color, Palette,
 };
 // ── Scanner panel ─────────────────────────────────────────────────────────────
 //
@@ -114,7 +114,10 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
             Span::styled("  current sector", dim),
         ]));
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled("→ details in the SECTOR pane", Style::default().fg(p.accent))));
+        lines.push(Line::from(Span::styled(
+            "→ details in the SECTOR pane",
+            Style::default().fg(p.accent),
+        )));
         let obj_count = sector.objects.as_ref().map(|o| o.len()).unwrap_or(0);
         let summary = if obj_count > 0 {
             format!("{obj_count} object(s) here")
@@ -199,7 +202,10 @@ pub(crate) fn render_scanner_panel(frame: &mut Frame, area: Rect, state: &AppSta
             if !possible.is_empty() {
                 lines.push(Line::from(Span::styled("── possible ──", dim)));
                 for pobj in possible {
-                    lines.push(Line::from(vec![Span::styled("? ", dim), Span::styled(pobj.as_str(), text)]));
+                    lines.push(Line::from(vec![
+                        Span::styled("? ", dim),
+                        Span::styled(pobj.as_str(), text),
+                    ]));
                 }
             }
         }
@@ -265,8 +271,12 @@ pub(crate) fn sector_interest_color(s: &crate::api::types::SectorObservation, p:
             let has_star = objects
                 .iter()
                 .any(|o| matches!(o.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem));
-            let has_blackhole = objects.iter().any(|o| matches!(o.object_type, SectorObjectType::BlackHole));
-            let has_extreme = objects.iter().any(|o| matches!(o.danger_level, Some(DangerLevel::Extreme)));
+            let has_blackhole = objects
+                .iter()
+                .any(|o| matches!(o.object_type, SectorObjectType::BlackHole));
+            let has_extreme = objects
+                .iter()
+                .any(|o| matches!(o.danger_level, Some(DangerLevel::Extreme)));
             if has_extreme || has_blackhole {
                 return p.crit;
             }
@@ -323,7 +333,11 @@ pub(crate) fn resource_shares_line<'a>(
             continue;
         }
         any = true;
-        let val = if percent { format!("{:.0}%", v * 100.0) } else { format!("{v:.2}") };
+        let val = if percent {
+            format!("{:.0}%", v * 100.0)
+        } else {
+            format!("{v:.2}")
+        };
         spans.push(Span::styled(format!("{name} "), Style::default().fg(p.dim)));
         spans.push(Span::styled(format!("{val}  "), Style::default().fg(p.text)));
     }
@@ -416,7 +430,10 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
 
         // Planet / asteroid science (v63 fields).
         if let Some(cat) = &obj.category {
-            lines.push(Line::from(vec![Span::styled("  class ", dim), Span::styled(cat.as_str(), text)]));
+            lines.push(Line::from(vec![
+                Span::styled("  class ", dim),
+                Span::styled(cat.as_str(), text),
+            ]));
         }
         if let Some(h) = obj.habitability_score {
             lines.push(Line::from(vec![
@@ -425,7 +442,10 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
             ]));
         }
         if let Some(comp) = &obj.composition {
-            lines.push(Line::from(vec![Span::styled("  composition ", dim), Span::styled(comp.as_str(), text)]));
+            lines.push(Line::from(vec![
+                Span::styled("  composition ", dim),
+                Span::styled(comp.as_str(), text),
+            ]));
         }
         if obj.manny_mineable == Some(true) {
             lines.push(Line::from(Span::styled("  ⛏ mineable", Style::default().fg(p.warn))));
@@ -444,7 +464,11 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
         for target in targets {
             let tglyph = object_icon(&target.object_type).0;
             let tcolor = object_color(&target.object_type, p);
-            let name = target.name.as_deref().filter(|s| !s.trim().is_empty()).unwrap_or_else(|| object_type_label(&target.object_type));
+            let name = target
+                .name
+                .as_deref()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| object_type_label(&target.object_type));
             let mut spans: Vec<Span> = vec![
                 Span::raw("  "),
                 Span::styled(tglyph, Style::default().fg(tcolor)),
@@ -472,7 +496,11 @@ pub(crate) fn sector_object_lines<'a>(obj: &'a SectorObject, compact: bool, p: P
     for target in &obj.bookmark_targets {
         let tglyph = object_icon(&target.object_type).0;
         let tcolor = object_color(&target.object_type, p);
-        let name = target.name.as_deref().filter(|s| !s.trim().is_empty()).unwrap_or_else(|| object_type_label(&target.object_type));
+        let name = target
+            .name
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| object_type_label(&target.object_type));
         let mut spans: Vec<Span> = vec![
             Span::raw("  "),
             Span::styled(tglyph, Style::default().fg(tcolor)),

--- a/src/ui/preflight.rs
+++ b/src/ui/preflight.rs
@@ -57,7 +57,10 @@ pub(crate) fn render(
 
     // Bottom banner — GUPPI narrating the preflight.
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(" GUPPI — preflight self-check", Style::default().fg(p.accent)))),
+        Paragraph::new(Line::from(Span::styled(
+            " GUPPI — preflight self-check",
+            Style::default().fg(p.accent),
+        ))),
         rows[1],
     );
 }
@@ -93,9 +96,15 @@ fn probe_lines(
 
     if let Some(buf) = entry {
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled("⚠ NO API KEY", Style::default().fg(p.warn).add_modifier(Modifier::BOLD))));
+        lines.push(Line::from(Span::styled(
+            "⚠ NO API KEY",
+            Style::default().fg(p.warn).add_modifier(Modifier::BOLD),
+        )));
         lines.push(Line::from(Span::styled("get one at", dim)));
-        lines.push(Line::from(Span::styled("neumann-probe.net", Style::default().fg(p.accent))));
+        lines.push(Line::from(Span::styled(
+            "neumann-probe.net",
+            Style::default().fg(p.accent),
+        )));
         lines.push(Line::from(vec![
             Span::styled("KEY ›", Style::default().fg(p.accent)),
             Span::styled(buf.to_string(), text),
@@ -129,23 +138,36 @@ mod tests {
     fn text(steps: &[Step], entry: Option<&str>, note: Option<&str>) -> String {
         // Large enough for the 3×3 boot grid (Probe pane centre).
         let mut t = Terminal::new(TestBackend::new(100, 33)).unwrap();
-        t.draw(|f| render(f, f.area(), steps, entry, note, ColorMode::default())).unwrap();
+        t.draw(|f| render(f, f.area(), steps, entry, note, ColorMode::default()))
+            .unwrap();
         t.backend().buffer().content.iter().map(|c| c.symbol()).collect()
     }
 
     #[test]
     fn boot_grid_shows_probe_active_and_others_dark() {
-        let steps = [Step { label: "CONFIG", status: Status::Pending }];
+        let steps = [Step {
+            label: "CONFIG",
+            status: Status::Pending,
+        }];
         let out = text(&steps, None, None);
         assert!(out.contains("PROBE"), "the centre Probe pane is framed");
-        assert!(out.contains("SCANNER") && out.contains("MANNIES"), "surrounding panes are drawn too");
-        assert!(out.contains("· · ·"), "the eight subsystems sit dark until preflight clears");
+        assert!(
+            out.contains("SCANNER") && out.contains("MANNIES"),
+            "surrounding panes are drawn too"
+        );
+        assert!(
+            out.contains("· · ·"),
+            "the eight subsystems sit dark until preflight clears"
+        );
         assert!(out.contains("GUPPI"), "preflight banner");
     }
 
     #[test]
     fn onboarding_prompt_shows_where_to_get_the_key_and_the_buffer() {
-        let steps = [Step { label: "CONFIG", status: Status::Pending }];
+        let steps = [Step {
+            label: "CONFIG",
+            status: Status::Pending,
+        }];
         let out = text(&steps, Some("vng_abc123"), None);
         assert!(out.contains("NO API KEY"), "onboarding heading");
         assert!(out.contains("neumann-probe.net"), "where to get the key");
@@ -155,11 +177,27 @@ mod tests {
     #[test]
     fn link_failure_is_shown_with_actions() {
         let steps = [
-            Step { label: "CONFIG", status: Status::Ok("loaded".into()) },
-            Step { label: "REMOTE LINK", status: Status::Fail("401 unauthorized".into()) },
+            Step {
+                label: "CONFIG",
+                status: Status::Ok("loaded".into()),
+            },
+            Step {
+                label: "REMOTE LINK",
+                status: Status::Fail("401 unauthorized".into()),
+            },
         ];
-        let out = text(&steps, None, Some("[R]etry   [K] re-enter key\n[Enter] continue offline"));
-        assert!(out.contains("REMOTE LINK") && out.contains("401 unauthorized"), "the bad-key error is visible");
-        assert!(out.contains("[R]etry") && out.contains("re-enter key") && out.contains("continue offline"), "recovery actions offered");
+        let out = text(
+            &steps,
+            None,
+            Some("[R]etry   [K] re-enter key\n[Enter] continue offline"),
+        );
+        assert!(
+            out.contains("REMOTE LINK") && out.contains("401 unauthorized"),
+            "the bad-key error is visible"
+        );
+        assert!(
+            out.contains("[R]etry") && out.contains("re-enter key") && out.contains("continue offline"),
+            "recovery actions offered"
+        );
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,6 +1,4 @@
-use crate::api::types::{
-    DangerLevel, KnowledgeLevel, MovementPhase, ProbeStatus, SectorObjectType, SectorObservation,
-};
+use crate::api::types::{DangerLevel, KnowledgeLevel, MovementPhase, ProbeStatus, SectorObjectType, SectorObservation};
 use crate::app::ColorMode;
 use ratatui::{
     style::{Color, Modifier, Style},
@@ -110,8 +108,7 @@ pub(crate) fn map_cell_symbol(s: &SectorObservation) -> (&'static str, Style) {
                 return ("!", Style::default().fg(Color::Red));
             }
             if matches!(obj.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem) {
-                let has_minable = obj.minable_targets.as_ref()
-                    .is_some_and(|t| !t.is_empty());
+                let has_minable = obj.minable_targets.as_ref().is_some_and(|t| !t.is_empty());
                 return if has_minable {
                     ("★", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))
                 } else {
@@ -137,7 +134,14 @@ pub(crate) fn map_cell_style(s: &SectorObservation, p: Palette) -> (&'static str
             if matches!(obj.object_type, SectorObjectType::Star | SectorObjectType::SolarSystem) {
                 let has_minable = obj.minable_targets.as_ref().is_some_and(|t| !t.is_empty());
                 let style = Style::default().fg(p.warn);
-                return ("★", if has_minable { style.add_modifier(Modifier::BOLD) } else { style });
+                return (
+                    "★",
+                    if has_minable {
+                        style.add_modifier(Modifier::BOLD)
+                    } else {
+                        style
+                    },
+                );
             }
         }
         return ("●", Style::default().fg(p.good));
@@ -152,8 +156,9 @@ pub(crate) fn item_icon(item_type: &str) -> (&'static str, Color) {
         "atomic_3d_printer" => ("⚙", Color::Magenta),
         "additional_container" => ("□", Color::Cyan),
         "waypoint_bookmark" => ("◎", Color::Cyan),
-        "micro_conductor" | "ceramic_insulator" | "crystal_substrate"
-        | "dopant_matrix" | "integrated_circuit" => ("◈", Color::Yellow),
+        "micro_conductor" | "ceramic_insulator" | "crystal_substrate" | "dopant_matrix" | "integrated_circuit" => {
+            ("◈", Color::Yellow)
+        }
         _ => ("◈", Color::White),
     }
 }
@@ -252,9 +257,7 @@ pub(crate) fn probe_status_style(s: &ProbeStatus) -> Style {
     match s {
         ProbeStatus::Idle | ProbeStatus::Orbiting => Style::default().fg(Color::White),
         ProbeStatus::Preparing | ProbeStatus::Decelerating => Style::default().fg(Color::Yellow),
-        ProbeStatus::Accelerating => {
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
-        }
+        ProbeStatus::Accelerating => Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
         ProbeStatus::Cruising => Style::default().fg(Color::Cyan),
         ProbeStatus::Disabled => Style::default().fg(Color::Red),
         ProbeStatus::Dead | ProbeStatus::TrappedByBlackHole => {
@@ -303,7 +306,6 @@ pub(crate) fn block_gauge_line(label: &str, ratio: f64, value: &str, fill: Color
         Span::styled(format!(" {value:>5}"), Style::default().fg(p.text)),
     ])
 }
-
 
 pub fn format_duration(secs: i64) -> String {
     if secs <= 0 {

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -1,9 +1,8 @@
 use neumann_cockpit::api::types::{
-    AlertPhase, AlertStatus, AlertType, ContainerInventory, CraftingRecipe, DamageWarningRule,
-    DataFreshness, KnowledgeLevel, Manny, MannyLocationType, MannyTask, Mission, MissionStatus,
-    EndpointId, MannyTaskVisibility, MessageStatus, MissionStepStatus, MovementPhase, Probe,
-    ProbeImprovement, ProbeMessage, ScutNetwork, ScutRelayStatus, SectorObject,
-    ProbeAlert, ProbeInventory, ProbeMovement, ProbeStatus, SectorObjectType, SectorObservation,
+    AlertPhase, AlertStatus, AlertType, ContainerInventory, CraftingRecipe, DamageWarningRule, DataFreshness,
+    EndpointId, KnowledgeLevel, Manny, MannyLocationType, MannyTask, MannyTaskVisibility, MessageStatus, Mission,
+    MissionStatus, MissionStepStatus, MovementPhase, Probe, ProbeAlert, ProbeImprovement, ProbeInventory, ProbeMessage,
+    ProbeMovement, ProbeStatus, ScutNetwork, ScutRelayStatus, SectorObject, SectorObjectType, SectorObservation,
     SensorMode, StorageContainer,
 };
 
@@ -510,11 +509,17 @@ fn alerts_response_deser() {
     assert_eq!(r.alerts[0].status, AlertStatus::Unread);
     assert!(r.alerts[0].is_unread());
     assert_eq!(r.alerts[0].risk.as_ref().unwrap().percent, 30);
-    assert_eq!(r.alerts[0].container.as_ref().unwrap().object_id.as_deref(), Some("detached-container-7"));
+    assert_eq!(
+        r.alerts[0].container.as_ref().unwrap().object_id.as_deref(),
+        Some("detached-container-7")
+    );
     // read alert is no longer unread
     assert_eq!(r.alerts[1].alert_type, AlertType::IntelligentLife);
     assert!(!r.alerts[1].is_unread());
-    assert_eq!(r.alerts[1].planet.as_ref().unwrap().name.as_deref(), Some("Pale Signal"));
+    assert_eq!(
+        r.alerts[1].planet.as_ref().unwrap().name.as_deref(),
+        Some("Pale Signal")
+    );
     // object-detected carries resource types
     assert_eq!(r.alerts[2].object.as_ref().unwrap().resource_types, vec!["deuterium"]);
 }
@@ -530,7 +535,10 @@ fn damage_warnings_response_deser() {
 
 #[test]
 fn alert_unknown_type_fallback() {
-    let json = ALERTS_JSON.replace("storage_container_break\",\n      \"status\": \"unread", "supernova_imminent\",\n      \"status\": \"unread");
+    let json = ALERTS_JSON.replace(
+        "storage_container_break\",\n      \"status\": \"unread",
+        "supernova_imminent\",\n      \"status\": \"unread",
+    );
     let r: AlertsResponseProbe = deser(&json);
     assert_eq!(r.alerts[0].alert_type, AlertType::Unknown);
 }
@@ -634,7 +642,10 @@ fn manny_task_visibility_deserializes() {
         MannyTaskVisibility::ScutNetwork
     );
     assert_eq!(deser::<MannyTaskVisibility>(r#""local""#), MannyTaskVisibility::Local);
-    assert_eq!(deser::<MannyTaskVisibility>(r#""too_far""#), MannyTaskVisibility::TooFar);
+    assert_eq!(
+        deser::<MannyTaskVisibility>(r#""too_far""#),
+        MannyTaskVisibility::TooFar
+    );
 }
 
 #[test]
@@ -648,7 +659,10 @@ fn new_sector_object_types_deserialize() {
         deser::<SectorObjectType>(r#""deuterium_refuel_station""#),
         SectorObjectType::DeuteriumRefuelStation
     );
-    assert_eq!(deser::<SectorObjectType>(r#""scut_relay""#), SectorObjectType::ScutRelay);
+    assert_eq!(
+        deser::<SectorObjectType>(r#""scut_relay""#),
+        SectorObjectType::ScutRelay
+    );
 }
 
 #[test]


### PR DESCRIPTION
Makes `cargo fmt` usable and enforced. Closes #220.

## Commits (review in order)

1. **`build(ci)`** — the small, reviewable part:
   - `rustfmt.toml` (`edition 2021`, `max_width 120` — a generous width tuned to the codebase's hand-formatting so intentional multi-arg signatures / dense arms survive).
   - CI restructured into **four parallel jobs** — `fmt`, `clippy`, `test`, `build` — each its own box in the PR status list, one failure never hides another. `fmt` runs `cargo fmt --check` (no cache — it does not compile); rustfmt added to the toolchain.
2. **`style`** — the one-shot `cargo fmt` baseline (77 files, mechanical, no logic change — verify with `cargo fmt --check`). `#[rustfmt::skip]` guards the `WIZARD_INPUTS` / `WIZARD_OVERLAYS` registries so their one-line-per-entry tables stay compact (rustfmt would otherwise expand each closure-in-tuple entry to four lines).

## Verified

- `cargo fmt --check` clean · `cargo clippy --locked -- -D warnings` clean · `cargo test --locked` green (4 suites).

## Heads-up

If branch protection on `main` requires a status check named `ci`, update the required checks to `fmt` / `clippy` / `test` / `build` — otherwise merge will block.