### PR TITLE
refactor(app): unify the per-wizard error setters into set_wizard_error

### DIFF
--- a/src/app/inventory.rs
+++ b/src/app/inventory.rs
@@ -183,17 +183,6 @@ impl AppState {
             .unwrap_or(false)
     }
 
-    pub fn set_jettison_error(&mut self, msg: String) {
-        if let ActiveWizard::Jettison(jettison) = &mut self.active_wizard {
-            match jettison {
-                JettisonInput::ConfirmManny { error, .. } => *error = Some(msg),
-                JettisonInput::ConfirmRelay { error, .. } => *error = Some(msg),
-                JettisonInput::EnterAmount { error, .. } => *error = Some(msg),
-                _ => {}
-            }
-        }
-    }
-
     pub fn atomic_printer_recipes(&self) -> Vec<&CraftingRecipe> {
         self.recipes
             .iter()

--- a/src/app/mannies.rs
+++ b/src/app/mannies.rs
@@ -64,56 +64,6 @@ impl AppState {
         }
     }
 
-    pub fn set_repair_error(&mut self, msg: String) {
-        if let ActiveWizard::Repair(RepairInput::Typing { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_mine_error(&mut self, msg: String) {
-        if let ActiveWizard::Mine(MineInput::Configure { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    /// Surface a craft failure on whichever fabrication step is active.
-    pub fn set_fabrication_error(&mut self, msg: String) {
-        if let ActiveWizard::Fabrication(fab) = &mut self.active_wizard {
-            match fab {
-                FabricationInput::PickRecipe { error, .. } => *error = Some(msg),
-                FabricationInput::PickBuilder { error, .. } => *error = Some(msg),
-            }
-        }
-    }
-
-    /// Surface a probe-improvement failure on whichever step is active.
-    pub fn set_improve_error(&mut self, msg: String) {
-        if let ActiveWizard::Improve(improve) = &mut self.active_wizard {
-            match improve {
-                ImproveInput::PickImprovement { error, .. } => *error = Some(msg),
-                ImproveInput::PickBuilder { error, .. } => *error = Some(msg),
-            }
-        }
-    }
-
-    pub fn set_salvage_error(&mut self, msg: String) {
-        if let ActiveWizard::Salvage(SalvageInput::Confirm { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_recall_error(&mut self, msg: String) {
-        if let ActiveWizard::Recall(RecallInput::Confirm { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_refuel_error(&mut self, msg: String) {
-        if let ActiveWizard::Refuel(RefuelInput::Confirm { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
     /// Fleet probes eligible as a deuterium-transfer destination: every probe
     /// except the one currently piloted (the source). The same-sector
     /// constraint is enforced server-side, since the roster carries no
@@ -125,38 +75,6 @@ impl AppState {
             .filter(|p| Some(p.id) != source)
             .map(|p| (p.id, p.name.clone()))
             .collect()
-    }
-
-    pub fn set_transfer_deuterium_error(&mut self, msg: String) {
-        if let ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { error, .. }) =
-            &mut self.active_wizard
-        {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_mind_snapshot_error(&mut self, msg: String) {
-        if let ActiveWizard::MindSnapshot(MindSnapshotInput::Confirm { error }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_scut_relay_error(&mut self, msg: String) {
-        if let ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_mission_abandon_error(&mut self, msg: String) {
-        if let ActiveWizard::Missions(MissionsInput::ConfirmAbandon { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_message_send_error(&mut self, msg: String) {
-        if let ActiveWizard::Messages(MessagesInput::Compose { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
     }
 
     pub fn unread_message_count(&self) -> usize {
@@ -317,18 +235,6 @@ impl AppState {
             .unwrap_or_default()
     }
 
-    pub fn set_deploy_error(&mut self, msg: String) {
-        if let ActiveWizard::Deploy(DeployInput::EnterName { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_rename_manny_error(&mut self, msg: String) {
-        if let ActiveWizard::RenameManny(RenameMannyInput::Typing { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
     pub fn rename_manny_type_char(&mut self, c: char) {
         if let ActiveWizard::RenameManny(RenameMannyInput::Typing { buf, .. }) = &mut self.active_wizard {
             if buf.len() < 40 {
@@ -441,16 +347,6 @@ impl AppState {
         }
     }
 
-    pub fn set_detach_error(&mut self, msg: String) {
-        if let ActiveWizard::Detach(detach) = &mut self.active_wizard {
-            match detach {
-                DetachInput::PickMode { error, .. } => *error = Some(msg),
-                DetachInput::PickAsteroid { error, .. } => *error = Some(msg),
-                _ => {}
-            }
-        }
-    }
-
     pub fn collect_detachable_containers(&self) -> Vec<(String, String)> {
         self.probe
             .as_ref()
@@ -540,16 +436,6 @@ impl AppState {
             candidates,
             selection: 0,
         });
-    }
-
-    pub fn set_remote_mine_error(&mut self, msg: String) {
-        if let ActiveWizard::RemoteMine(rm) = &mut self.active_wizard {
-            match rm {
-                RemoteMineInput::Configure { error, .. } => *error = Some(msg),
-                RemoteMineInput::PickContainer { error, .. } => *error = Some(msg),
-                _ => {}
-            }
-        }
     }
 
     /// True when a Manny is idle and in a remote sector reachable via a shared

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -202,12 +202,6 @@ impl AppState {
         self.probe.as_ref().map(|p| (p.id as u64, p.name.clone()))
     }
 
-    pub fn set_rename_probe_error(&mut self, msg: String) {
-        if let ActiveWizard::RenameProbe(RenameProbeInput::Typing { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
     /// Switch the piloted probe to `id`. Records the new active id (and clears
     /// it back to `None` when `id` is the server default, so the client falls
     /// back to the pre-v81 `/api/probe` paths). The event loop reconciles the
@@ -273,47 +267,6 @@ impl AppState {
         self.update_inventory(inventory);
     }
 
-    pub fn set_rename_container_error(&mut self, msg: String) {
-        if let ActiveWizard::RenameContainer(RenameContainerInput::Typing { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_container_rules_error(&mut self, msg: String) {
-        if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_storage_move_error(&mut self, msg: String) {
-        if let ActiveWizard::StorageMove(
-            StorageMoveInput::ConfigureResource { error, .. } | StorageMoveInput::ConfigureItem { error, .. },
-        ) = &mut self.active_wizard
-        {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_drop_cargo_error(&mut self, msg: String) {
-        if let ActiveWizard::DropCargo(DropCargoInput::Confirm { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_assemble_probe_error(&mut self, msg: String) {
-        if let ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { error, .. }) = &mut self.active_wizard {
-            *error = Some(msg);
-        }
-    }
-
-    pub fn set_drop_container_error(&mut self, msg: String) {
-        if let ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet { error, .. }) =
-            &mut self.active_wizard
-        {
-            *error = Some(msg);
-        }
-    }
-
     pub fn set_toast(&mut self, msg: impl Into<String>) {
         self.toast = Some((msg.into(), Local::now()));
     }
@@ -323,6 +276,59 @@ impl AppState {
     /// `active_wizard` field there is now one way to close any wizard.
     pub fn close_wizard(&mut self) {
         self.active_wizard = ActiveWizard::None;
+    }
+
+    /// Set the inline error on whichever wizard step is currently open — the
+    /// active wizard is the one that just errored, since only one can be open.
+    /// Replaces the two dozen near-identical `set_<wizard>_error` setters with a
+    /// single slot-lookup. Travel, inspect and recover keep their own setters:
+    /// travel prefixes the message, and inspect/recover fall back to the status
+    /// bar when their picker step is not the active overlay.
+    pub fn set_wizard_error(&mut self, msg: String) {
+        let slot: Option<&mut Option<String>> = match &mut self.active_wizard {
+            ActiveWizard::Repair(RepairInput::Typing { error, .. }) => Some(error),
+            ActiveWizard::Mine(MineInput::Configure { error, .. }) => Some(error),
+            ActiveWizard::Fabrication(
+                FabricationInput::PickRecipe { error, .. } | FabricationInput::PickBuilder { error, .. },
+            ) => Some(error),
+            ActiveWizard::Improve(
+                ImproveInput::PickImprovement { error, .. } | ImproveInput::PickBuilder { error, .. },
+            ) => Some(error),
+            ActiveWizard::Salvage(SalvageInput::Confirm { error, .. }) => Some(error),
+            ActiveWizard::Recall(RecallInput::Confirm { error, .. }) => Some(error),
+            ActiveWizard::Refuel(RefuelInput::Confirm { error, .. }) => Some(error),
+            ActiveWizard::TransferDeuterium(TransferDeuteriumInput::EnterAmount { error, .. }) => Some(error),
+            ActiveWizard::MindSnapshot(MindSnapshotInput::Confirm { error }) => Some(error),
+            ActiveWizard::ScutRelay(ScutRelayInput::EnterNetworkName { error, .. }) => Some(error),
+            ActiveWizard::Missions(MissionsInput::ConfirmAbandon { error, .. }) => Some(error),
+            ActiveWizard::Messages(MessagesInput::Compose { error, .. }) => Some(error),
+            ActiveWizard::Deploy(DeployInput::EnterName { error, .. }) => Some(error),
+            ActiveWizard::RenameManny(RenameMannyInput::Typing { error, .. }) => Some(error),
+            ActiveWizard::Detach(DetachInput::PickMode { error, .. } | DetachInput::PickAsteroid { error, .. }) => {
+                Some(error)
+            }
+            ActiveWizard::RemoteMine(
+                RemoteMineInput::Configure { error, .. } | RemoteMineInput::PickContainer { error, .. },
+            ) => Some(error),
+            ActiveWizard::RenameProbe(RenameProbeInput::Typing { error, .. }) => Some(error),
+            ActiveWizard::RenameContainer(RenameContainerInput::Typing { error, .. }) => Some(error),
+            ActiveWizard::ContainerRules(ContainerRulesInput::Editing { error, .. }) => Some(error),
+            ActiveWizard::StorageMove(
+                StorageMoveInput::ConfigureResource { error, .. } | StorageMoveInput::ConfigureItem { error, .. },
+            ) => Some(error),
+            ActiveWizard::DropCargo(DropCargoInput::Confirm { error, .. }) => Some(error),
+            ActiveWizard::AssembleProbe(AssembleProbeInput::PickContainers { error, .. }) => Some(error),
+            ActiveWizard::DropContainer(DropStorageContainerInput::PickPlanet { error, .. }) => Some(error),
+            ActiveWizard::Jettison(
+                JettisonInput::ConfirmManny { error, .. }
+                | JettisonInput::ConfirmRelay { error, .. }
+                | JettisonInput::EnterAmount { error, .. },
+            ) => Some(error),
+            _ => None,
+        };
+        if let Some(e) = slot {
+            *e = Some(msg);
+        }
     }
 
     /// Common tail of a successful action: show a confirmation toast and stage

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -64,6 +64,27 @@ fn finish_action_sets_toast_and_stages_refetch() {
 }
 
 #[test]
+fn set_wizard_error_targets_the_active_wizard() {
+    let mut state = AppState::default();
+    // No wizard open → no-op, no panic.
+    state.set_wizard_error("ignored".into());
+    assert!(matches!(state.active_wizard, ActiveWizard::None));
+
+    // A wizard with an error-bearing step: the message lands in its slot.
+    state.active_wizard = ActiveWizard::Repair(RepairInput::Typing {
+        manny_id: "m".into(),
+        manny_name: "M".into(),
+        buf: String::new(),
+        error: None,
+    });
+    state.set_wizard_error("bad percent".into());
+    let ActiveWizard::Repair(RepairInput::Typing { error, .. }) = &state.active_wizard else {
+        panic!("the active wizard must be unchanged");
+    };
+    assert_eq!(error.as_deref(), Some("bad percent"));
+}
+
+#[test]
 fn parse_scan_coords_valid() {
     let mut state = AppState::default();
     state.scan_mode = ScanMode::Input("2 0 -2".into());

--- a/src/input/containers.rs
+++ b/src/input/containers.rs
@@ -72,7 +72,7 @@ pub(super) fn handle_rename_container_event(
                 (container_id.clone(), buf.trim().to_string())
             };
             if label.is_empty() {
-                state.set_rename_container_error("label cannot be empty".into());
+                state.set_wizard_error("label cannot be empty".into());
                 return;
             }
             let new_label = label.clone();

--- a/src/input/craft.rs
+++ b/src/input/craft.rs
@@ -97,7 +97,7 @@ fn commit_recipe(selection: usize, state: &mut AppState, client: &ApiClient, tx:
                 fetch_atomic_printer_craft(recipe_id, client.clone(), tx.clone());
                 state.log_event(LogEvent::craft(&recipe_name, true, state.active_probe_id));
             } else {
-                state.set_fabrication_error("no atomic printer in inventory".into());
+                state.set_wizard_error("no atomic printer in inventory".into());
             }
         }
         Fabricator::Manny => {
@@ -116,7 +116,7 @@ fn commit_recipe(selection: usize, state: &mut AppState, client: &ApiClient, tx:
             }
             let mannies = state.collect_idle_onboard_mannies();
             match mannies.len() {
-                0 => state.set_fabrication_error("no idle Manny on board".into()),
+                0 => state.set_wizard_error("no idle Manny on board".into()),
                 1 => {
                     let (manny_id, _) = mannies.into_iter().next().unwrap();
                     fetch_craft(manny_id, recipe_id, client.clone(), tx.clone());

--- a/src/input/fleet.rs
+++ b/src/input/fleet.rs
@@ -139,7 +139,7 @@ pub(super) fn handle_transfer_deuterium_event(
                     fetch_transfer_deuterium(mid, tid, amount, client.clone(), tx.clone());
                     state.log_event(LogEvent::transfer_deuterium(&tname, amount, state.active_probe_id));
                 }
-                _ => state.set_transfer_deuterium_error("enter a positive deuterium percentage".to_string()),
+                _ => state.set_wizard_error("enter a positive deuterium percentage".to_string()),
             }
         }
         _ => {}

--- a/src/input/improve.rs
+++ b/src/input/improve.rs
@@ -85,16 +85,16 @@ fn commit_improvement(selection: usize, state: &mut AppState, client: &ApiClient
         return;
     };
     if done {
-        state.set_improve_error("already installed".into());
+        state.set_wizard_error("already installed".into());
         return;
     }
     if !available {
-        state.set_improve_error("not unlocked yet".into());
+        state.set_wizard_error("not unlocked yet".into());
         return;
     }
     let mannies = state.collect_idle_onboard_mannies();
     match mannies.len() {
-        0 => state.set_improve_error("no idle Manny on board".into()),
+        0 => state.set_wizard_error("no idle Manny on board".into()),
         1 => {
             let (manny_id, _) = mannies.into_iter().next().unwrap();
             fetch_improve_probe(manny_id, id, client.clone(), tx.clone());

--- a/src/input/mine.rs
+++ b/src/input/mine.rs
@@ -374,7 +374,7 @@ pub(super) fn handle_remote_mine_event(
                         .map(|s| state.collect_detached_containers_in(s))
                         .unwrap_or_default();
                     if containers.is_empty() {
-                        state.set_remote_mine_error("no detached container in the Manny's sector".into());
+                        state.set_wizard_error("no detached container in the Manny's sector".into());
                         return;
                     }
                     state.active_wizard = ActiveWizard::RemoteMine(RemoteMineInput::PickContainer {

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -570,7 +570,7 @@ pub(super) fn handle_detach_event(
                 if mode == "hidden_on_asteroid" {
                     let asteroids = state.collect_asteroid_candidates();
                     if asteroids.is_empty() {
-                        state.set_detach_error("no asteroids in current sector — scan first".into());
+                        state.set_wizard_error("no asteroids in current sector — scan first".into());
                     } else {
                         state.active_wizard = ActiveWizard::Detach(DetachInput::PickAsteroid {
                             manny_id,

--- a/src/input/storage_move.rs
+++ b/src/input/storage_move.rs
@@ -192,13 +192,13 @@ fn handle_resource(code: KeyCode, state: &mut AppState, client: &ApiClient, tx: 
         }
         KeyCode::Enter => {
             if from_sel == to_sel {
-                state.set_storage_move_error("source and destination must differ".into());
+                state.set_wizard_error("source and destination must differ".into());
                 return;
             }
             let amount: f64 = match amount_buf.trim().parse() {
                 Ok(a) if a > 0.0 => a,
                 _ => {
-                    state.set_storage_move_error("amount must be a positive number".into());
+                    state.set_wizard_error("amount must be a positive number".into());
                     return;
                 }
             };
@@ -267,7 +267,7 @@ fn handle_item(code: KeyCode, state: &mut AppState, client: &ApiClient, tx: &mps
                 .map(|(id, _, _)| id.clone())
                 .collect();
             if ids.is_empty() {
-                state.set_storage_move_error("select at least one item with Space".into());
+                state.set_wizard_error("select at least one item with Space".into());
                 return;
             }
             let actor = actor_manny_id.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         // Refresh so the Probe pane identity picks up the new name.
                         state.finish_action(format!("probe renamed to {name}"), Refetch::All);
                     }
-                    ApiMessage::RenameProbeError(e) => state.set_rename_probe_error(e),
+                    ApiMessage::RenameProbeError(e) => state.set_wizard_error(e),
                     ApiMessage::ManniesUpdated(mannies) => state.update_mannies(mannies),
                     ApiMessage::SectorUpdated(sector) => {
                         let (sx, sy, sz) = (
@@ -229,15 +229,14 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.close_wizard();
                         state.finish_action("repair order sent", Refetch::Mannies);
                     }
-                    ApiMessage::RepairError(e) => state.set_repair_error(e),
+                    ApiMessage::RepairError(e) => state.set_wizard_error(e),
                     ApiMessage::MineStarted => {
                         state.close_wizard();
                         state.finish_action("mining order sent", Refetch::Mannies);
                     }
-                    ApiMessage::MineError(e) => {
-                        state.set_mine_error(e.clone());
-                        state.set_remote_mine_error(e);
-                    }
+                    // Either the local or remote-mine wizard is open; the single
+                    // set_wizard_error targets whichever it is.
+                    ApiMessage::MineError(e) => state.set_wizard_error(e),
                     ApiMessage::JettisonDone(inv) => {
                         state.update_inventory(inv);
                         state.close_wizard();
@@ -245,49 +244,49 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         // drifting item, or deployed SCUT relay) — refresh everything.
                         state.finish_action("jettisoned", Refetch::All);
                     }
-                    ApiMessage::JettisonError(e) => state.set_jettison_error(e),
+                    ApiMessage::JettisonError(e) => state.set_wizard_error(e),
                     ApiMessage::CraftStarted => {
                         state.close_wizard();
                         state.finish_action("craft order sent", Refetch::Mannies);
                     }
-                    ApiMessage::CraftError(e) => state.set_fabrication_error(e),
+                    ApiMessage::CraftError(e) => state.set_wizard_error(e),
                     ApiMessage::SalvageStarted => {
                         state.close_wizard();
                         state.finish_action("salvage order sent", Refetch::Mannies);
                     }
-                    ApiMessage::SalvageError(e) => state.set_salvage_error(e),
+                    ApiMessage::SalvageError(e) => state.set_wizard_error(e),
                     ApiMessage::RecallStarted => {
                         state.close_wizard();
                         state.finish_action("recall order sent", Refetch::Mannies);
                     }
-                    ApiMessage::RecallError(e) => state.set_recall_error(e),
+                    ApiMessage::RecallError(e) => state.set_wizard_error(e),
                     ApiMessage::DeuteriumRefuelStarted => {
                         state.close_wizard();
                         state.finish_action("refuel order sent", Refetch::All);
                     }
-                    ApiMessage::DeuteriumRefuelError(e) => state.set_refuel_error(e),
+                    ApiMessage::DeuteriumRefuelError(e) => state.set_wizard_error(e),
                     ApiMessage::DeuteriumTransferStarted => {
                         state.close_wizard();
                         state.finish_action("deuterium transfer order sent", Refetch::All);
                     }
-                    ApiMessage::DeuteriumTransferError(e) => state.set_transfer_deuterium_error(e),
+                    ApiMessage::DeuteriumTransferError(e) => state.set_wizard_error(e),
                     ApiMessage::MindSnapshotReassigned(probe) => {
                         state.close_wizard();
                         state.update_probe(probe);
                         state.finish_action("mind snapshot reassigned", Refetch::All);
                     }
-                    ApiMessage::MindSnapshotReassignError(e) => state.set_mind_snapshot_error(e),
+                    ApiMessage::MindSnapshotReassignError(e) => state.set_wizard_error(e),
                     ApiMessage::MissionsFetched(missions) => state.missions = missions,
                     ApiMessage::MissionAbandoned(_) => {
                         state.active_wizard = ActiveWizard::Missions(MissionsInput::Browsing { selection: 0 });
                         state.finish_action("mission abandoned", Refetch::Missions);
                     }
-                    ApiMessage::MissionAbandonError(e) => state.set_mission_abandon_error(e),
+                    ApiMessage::MissionAbandonError(e) => state.set_wizard_error(e),
                     ApiMessage::ScutRelayTurnedOn => {
                         state.close_wizard();
                         state.finish_action("relay turn-on order sent", Refetch::All);
                     }
-                    ApiMessage::ScutRelayTurnOnError(e) => state.set_scut_relay_error(e),
+                    ApiMessage::ScutRelayTurnOnError(e) => state.set_wizard_error(e),
                     ApiMessage::ScutNetworkFetched(network) => {
                         if matches!(state.active_wizard, ActiveWizard::ScutNetwork(ScutNetworkInput::Viewing { .. })) {
                             state.scut_network_view = Some(network);
@@ -299,7 +298,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.active_wizard = ActiveWizard::Messages(MessagesInput::Browsing { sent_tab: false, selection: 0 });
                         state.finish_action("message sent", Refetch::Messages);
                     }
-                    ApiMessage::MessageSendError(e) => state.set_message_send_error(e),
+                    ApiMessage::MessageSendError(e) => state.set_wizard_error(e),
                     ApiMessage::MessageMarkedRead(m) => {
                         if let Some(slot) = state.messages.iter_mut().find(|x| x.id == m.id) {
                             *slot = m;
@@ -314,12 +313,12 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.close_wizard();
                         state.finish_action("waypoint deploy order sent", Refetch::All);
                     }
-                    ApiMessage::DeployError(e) => state.set_deploy_error(e),
+                    ApiMessage::DeployError(e) => state.set_wizard_error(e),
                     ApiMessage::AtomicPrinterCraftStarted => {
                         state.close_wizard();
                         state.finish_action("atomic printer craft started", Refetch::All);
                     }
-                    ApiMessage::AtomicPrinterCraftError(e) => state.set_fabrication_error(e),
+                    ApiMessage::AtomicPrinterCraftError(e) => state.set_wizard_error(e),
                     ApiMessage::RecipesFetched(recipes) => state.recipes = recipes,
                     ApiMessage::ProbeImprovementsFetched(improvements) => {
                         state.probe_improvements = improvements;
@@ -328,7 +327,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.close_wizard();
                         state.finish_action("probe improvement started", Refetch::All);
                     }
-                    ApiMessage::ImproveProbeError(e) => state.set_improve_error(e),
+                    ApiMessage::ImproveProbeError(e) => state.set_wizard_error(e),
                     ApiMessage::InspectStarted => {
                         state.close_wizard();
                         state.finish_action("inspect order sent", Refetch::Mannies);
@@ -343,7 +342,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.close_wizard();
                         state.finish_action("detach order sent", Refetch::All);
                     }
-                    ApiMessage::DetachError(e) => state.set_detach_error(e),
+                    ApiMessage::DetachError(e) => state.set_wizard_error(e),
                     ApiMessage::AlertsFetched(a) => state.alerts = a,
                     ApiMessage::DamageWarningsFetched(w, rule) => {
                         state.damage_warnings = w;
@@ -371,13 +370,13 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.close_wizard();
                         state.set_toast("container renamed");
                     }
-                    ApiMessage::RenameContainerError(e) => state.set_rename_container_error(e),
+                    ApiMessage::RenameContainerError(e) => state.set_wizard_error(e),
                     ApiMessage::UpdateContainerRulesDone(c, inv) => {
                         state.apply_container_update(c, inv);
                         state.close_wizard();
                         state.set_toast("routing rules updated");
                     }
-                    ApiMessage::UpdateContainerRulesError(e) => state.set_container_rules_error(e),
+                    ApiMessage::UpdateContainerRulesError(e) => state.set_wizard_error(e),
                     ApiMessage::StorageMoveDone(manny, inv) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -388,7 +387,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.close_wizard();
                         state.set_toast("storage move order sent");
                     }
-                    ApiMessage::StorageMoveError(e) => state.set_storage_move_error(e),
+                    ApiMessage::StorageMoveError(e) => state.set_wizard_error(e),
                     ApiMessage::AssembleProbeStarted(manny, inv) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -400,7 +399,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         // The new drone appears in the roster once assembled.
                         state.finish_action("drone assembly started (~3h)", Refetch::All);
                     }
-                    ApiMessage::AssembleProbeError(e) => state.set_assemble_probe_error(e),
+                    ApiMessage::AssembleProbeError(e) => state.set_wizard_error(e),
                     ApiMessage::DropMannyCargoStarted(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -411,7 +410,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         // Recoverable objects may reappear in the sector.
                         state.finish_action("cargo dropped", Refetch::All);
                     }
-                    ApiMessage::DropMannyCargoError(e) => state.set_drop_cargo_error(e),
+                    ApiMessage::DropMannyCargoError(e) => state.set_wizard_error(e),
                     ApiMessage::DropStorageContainerStarted(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -422,7 +421,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         // Container + drop kit leave the inventory.
                         state.finish_action("drop container order sent", Refetch::All);
                     }
-                    ApiMessage::DropStorageContainerError(e) => state.set_drop_container_error(e),
+                    ApiMessage::DropStorageContainerError(e) => state.set_wizard_error(e),
                     ApiMessage::RenameMannyDone(manny) => {
                         if let Some(ref mut mannies) = state.mannies {
                             if let Some(m) = mannies.iter_mut().find(|m| m.id == manny.id) {
@@ -432,7 +431,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                         state.close_wizard();
                         state.set_toast("manny renamed");
                     }
-                    ApiMessage::RenameMannyError(e) => state.set_rename_manny_error(e),
+                    ApiMessage::RenameMannyError(e) => state.set_wizard_error(e),
                     ApiMessage::VersionFetched(v) => state.api_version = Some(v),
                     ApiMessage::VisitedSectorsFetched(v) => state.visited_sectors = v,
                     ApiMessage::ActionError(e) => state.set_error(e),


### PR DESCRIPTION
## What

With one `active_wizard` field (since #219), the ~two dozen near-identical `set_<wizard>_error` methods — scattered across `app/mod.rs`, `mannies.rs`, `inventory.rs` — all did the same thing: reach the error slot of the currently-open wizard step.

## How

Replace 24 of them with a single `set_wizard_error(msg)` — one match returning the active wizard's `&mut Option<String>` error slot, then setting it. The active wizard is always the one that just errored, since only one can be open.

**Three keep bespoke setters** (behaviour not reducible to the slot):
- `set_travel_error` — prefixes the message with `"API: "`.
- `set_inspect_error` / `set_recover_error` — fall back to the status bar when their picker step is not the active overlay (single-candidate / object-first flows).

`set_scan_error` is unrelated (the scan overlay, not a wizard) and untouched.

Call sites updated in `main.rs` + `input/`; the `MineError` arm collapses its former `set_mine_error` + `set_remote_mine_error` double-set into one `set_wizard_error`.

## Tests

- New `set_wizard_error_targets_the_active_wizard` (sets the open wizard's slot; no-ops with no wizard).
- 287 tests green; `cargo fmt --check` + `cargo clippy -- -D warnings` clean.
- Net **−99 lines**.

Closes #208.