### PR TITLE
chore: drop the stale module-wide allow(dead_code)

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -3,7 +3,6 @@
 //! These types back the 3×3 tiling dashboard. They are consumed by later
 //! blocs (navigation, drill-in, rendering); U1 only establishes the state
 //! that `AppState` carries, so most of it is not read yet.
-#![allow(dead_code)]
 
 /// Rows moved by one PageUp/PageDown in a pane list.
 const PANE_PAGE: usize = 10;

--- a/src/app/mode.rs
+++ b/src/app/mode.rs
@@ -4,7 +4,6 @@
 //! later blocs. U1 only wires the state and its default (`Normal`); the
 //! `Menu`/`Command` payloads are populated by blocs U5/U6. The `Prompt`
 //! variant (wrapping the existing `*Input` wizards) is added in U5.
-#![allow(dead_code)]
 
 /// An action a contextual menu item can fire. Each maps to launching one of
 /// the existing wizards (bloc U5 wires the Mannies pane; more panes follow).


### PR DESCRIPTION
## What

`src/app/grid.rs` and `src/app/mode.rs` carried `#![allow(dead_code)]` at module scope, left over from the phased cockpit-v2 construction (the "bloc U1/U5" comments). Everything they gated is now wired up.

Removing both allows leaves **zero** dead-code warnings — `cargo clippy --locked -- -D warnings` is clean. `src/api/types.rs` keeps its allow (an API mirror whose fields aren't all consumed yet); that one is legitimate and untouched.

Closes #215.