### PR TITLE
docs: mdBook user guide + GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+# Build the mdBook user guide and deploy it to GitHub Pages. Runs only when the
+# docs (or this workflow) change. Requires Pages to be set to "GitHub Actions"
+# as its source in the repository settings (one-time).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; never cancel an in-flight one mid-publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: 0.5.4
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Install mdBook
+        run: |
+          tarball="mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          url="https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/${tarball}"
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL "$url" | tar -xz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - name: Build the book
+        run: mdbook build docs
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: docs/book
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.claude/*.lock
+/docs/book

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![Release](https://img.shields.io/github/v/release/MagiCrazy/neumann-cockpit)](https://github.com/MagiCrazy/neumann-cockpit/releases/latest)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org/)
+[![Docs](https://img.shields.io/badge/docs-user%20guide-blue.svg)](https://magicrazy.github.io/neumann-cockpit/)
 
 A terminal UI cockpit for [Von Neumann Game](https://github.com/gnieark/Von-Neumann-Game) — control your probe and its mannies from the command line.
+
+📖 **[User guide](https://magicrazy.github.io/neumann-cockpit/)** — install, configure, the cockpit, and automation (queue, scripting, headless).
 
 The official game instance runs at **[https://neumann-probe.net](https://neumann-probe.net)** (default endpoint).
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,22 @@
+[book]
+title = "neumann-cockpit"
+description = "User guide for the neumann-cockpit terminal UI — a cockpit for the Von Neumann Game."
+authors = ["MagiCrazy"]
+language = "en"
+src = "src"
+
+[rust]
+edition = "2021"
+
+[output.html]
+default-theme = "ayu"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/MagiCrazy/neumann-cockpit"
+edit-url-template = "https://github.com/MagiCrazy/neumann-cockpit/edit/main/docs/{path}"
+
+[output.html.search]
+enable = true
+
+[output.html.fold]
+enable = true
+level = 1

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,26 @@
+# Summary
+
+[Introduction](introduction.md)
+
+# User guide
+
+- [Getting started](getting-started/index.md)
+  - [Installation](getting-started/installation.md)
+  - [Configuration](getting-started/configuration.md)
+  - [First run](getting-started/first-run.md)
+- [The cockpit](cockpit/index.md)
+  - [The grid & navigation](cockpit/grid.md)
+  - [The panes](cockpit/panes.md)
+  - [Actions & command mode](cockpit/actions.md)
+  - [Themes & display](cockpit/display.md)
+- [Automation](automation/index.md)
+  - [Production queue](automation/queue.md)
+  - [Action scripting](automation/scripting.md)
+  - [Headless runner](automation/headless.md)
+- [Reference](reference/index.md)
+  - [Keybindings](reference/keybindings.md)
+  - [Configuration reference](reference/configuration.md)
+
+# Project
+
+- [Architecture & contributing](project/architecture.md)

--- a/docs/src/automation/headless.md
+++ b/docs/src/automation/headless.md
@@ -1,0 +1,48 @@
+# Headless runner
+
+Play an [action script](scripting.md) from a **file**, with no TUI, streaming the ship's-log to stdout. Good for cron jobs, unattended resupply runs, or scripting the cockpit from a shell.
+
+```bash
+neumann-cockpit --script run.ncs
+# short form:
+neumann-cockpit -s run.ncs
+```
+
+A bare launch (`neumann-cockpit`, no `--script`) is the interactive cockpit, unchanged.
+
+## The script file
+
+One command per line — the same grammar as the interactive console. Blank lines and `#` comments are ignored:
+
+```text
+# resupply run
+detach box by Alpha mode hidden_on_asteroid at Rock
+mine metals 900 by all to box
+recover box by Alpha
+```
+
+## Output
+
+Ship's-log lines stream to stdout as the run progresses — a timestamp, the narrated captain's-log summary for each fired step, a `✓`/`✗` per step, and a final status line:
+
+```text
+14:09:02  » Detached a storage container, hiding it on an asteroid.
+14:09:05    ✓ step 1/3 done
+14:12:40  » Dispatched 3 mannies to mine «metals», hauling to a detached container.
+14:16:55    ✓ step 2/3 done
+...
+14:20:11  ✓ script complete — 3/3
+```
+
+The same entries are **persisted** to the local ship's-log database, so a headless run also shows up in the next interactive session's ship's log.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | the script completed |
+| `1`  | the script halted on an error (a step failed to resolve or an action errored), or startup failed (bad config, unreadable file, no link) |
+
+This makes it compose in shell scripts — chain runs with `&&`, or alert on a non-zero exit.
+
+> The runner loads your config non-interactively: there is no key onboarding here. If the config is missing or the API key is invalid, it errors to stderr and exits — launch the interactive cockpit once to set your key first.

--- a/docs/src/automation/index.md
+++ b/docs/src/automation/index.md
@@ -1,0 +1,9 @@
+# Automation
+
+Three ways to let the cockpit work for you, from least to most hands-off:
+
+- **[Production queue](queue.md)** — queue up crafts; the executor runs them in parallel across your builders and the atomic printer, auto-draining as each finishes.
+- **[Action scripting](scripting.md)** — compose a sequence of heterogeneous actions ("detach a container → travel → mine → recover it") that runs strictly one step at a time, with fan-out/join for parallel mining.
+- **[Headless runner](headless.md)** — play a script from a file with no TUI, streaming the ship's-log to stdout, for cron jobs and unattended runs.
+
+All three share one sequencing engine, so they behave consistently: a step fires, completion is polled (a manny going idle again, a movement arriving), and progress shows in the status bar even with the console closed.

--- a/docs/src/automation/queue.md
+++ b/docs/src/automation/queue.md
@@ -1,0 +1,19 @@
+# Production queue
+
+The **production console** is one unified crafting catalog spanning both fabricators — the atomic printer and manny crafting. Open it with `:craft`, `:queue`, or **Fabricate** from the Mannies/Inventory pane menu.
+
+It shows three panels: the **recipe catalog**, the **selected-recipe detail** (ingredients owned vs required), and the live **production queue**.
+
+## Queueing
+
+- On the catalog, `+`/`-` (or `h`/`l`) set a **quantity**, and `Enter` adds the recipe ×qty to the queue. Identical trailing steps coalesce into one `×N`.
+- A manny recipe resolves its builder like an immediate craft: pre-chosen from the Mannies pane, the sole idle onboard manny, or a builder picker.
+- `Tab` focuses the queue panel to manage it: `+`/`-` a step's repeat, `x` remove, `c` clear.
+
+## How it runs
+
+The queue **auto-runs** — it drains as steps complete, no explicit "go". It is organised into **lanes**: one per builder manny plus one for the atomic printer. A lane runs one craft at a time, but lanes run in **parallel**, so an idle manny starts its next craft while another is still working.
+
+It **pauses** with `p` (and automatically on a craft failure — inspect, fix, resume), is capped at 32 steps, and is **session-only** (not persisted). A status-bar chip `⛭ done/total` shows progress with the console closed.
+
+> For a sequence of *different* action types (not just crafts) that must run in order, use [action scripting](scripting.md) instead.

--- a/docs/src/automation/scripting.md
+++ b/docs/src/automation/scripting.md
@@ -1,0 +1,59 @@
+# Action scripting
+
+Compose a **sequence** of heterogeneous pilot actions — "detach a container → travel → mine → bring it back" — that runs **strictly one step at a time**: a step fires only once the previous one has completed.
+
+Open the console with `:script`.
+
+## The editor (vim-style)
+
+The console is a modal editor over the current script:
+
+- **Insert mode** — type a command line; `Enter` validates and appends it (a syntax error shows inline), `Esc` switches to Normal mode.
+- **Normal mode** — `j`/`k` move the selection, `x` removes a step, `c` clears the script, `i` re-enters Insert, `R` **runs** the script, `p` pauses/resumes, `Esc` closes.
+
+Unlike the auto-running production queue, a script is **composed, then explicitly run** with `R`. A status-bar chip `≡ done/total` shows progress with the console closed.
+
+## Command lines
+
+Each line is one action. The MVP verbs:
+
+| Verb | Grammar |
+|------|---------|
+| `travel` | `<x y z \| +dx dy dz>` |
+| `mine` | `[res[,res]] [amount] [by <manny\|all\|A,B>] [at <asteroid>] [to <container>]` |
+| `repair` | `[percent] [by <manny>]` |
+| `salvage` | `[by <manny>] [at <wreck>]` |
+| `detach` | `<container> [by <manny>] [mode <drifting\|hidden_on_asteroid>] [at <asteroid>]` |
+| `recover` | `[by <manny>] [at <container>]` |
+
+Targets are matched by **case-insensitive substring** of a name (manny, asteroid, container), or an exact id. Where a target is unambiguous — the sole idle manny, the only asteroid in the sector — you can omit it.
+
+## Two ideas that make it work
+
+### Late binding
+
+A line is checked for **syntax** when you add it, but its **targets are resolved against live state only when the step fires** — not when you type it. This is what lets a `mine` follow a `travel` into a not-yet-scanned sector: the asteroid only exists once the probe *arrives*, and the step binds to it then.
+
+### Fork/join
+
+A single step can **fan out** to several builders and acts as a **barrier**. A `mine … by all` (every idle manny) or `by Alpha,Bravo` (named) fires one mine per manny in parallel, and the step is complete only once **every** one of them is idle again. The next step waits for that join.
+
+This is the canonical resupply run:
+
+```text
+detach box by Alpha
+mine metals 900 by all to box
+recover box by Alpha
+```
+
+1. Alpha detaches the container into the sector.
+2. **All** idle mannies mine into it, in parallel — the step holds until the last finishes.
+3. Only then does the recover run.
+
+## When a step fails
+
+If a target can't be resolved, or an action errors while in flight, the script **halts**: the step is marked `✗` with the reason and the script pauses. Fix it (edit the line, or wait) and press `R` to resume — failed steps are retried.
+
+Scripts are capped at 32 steps and are **session-only**. To run one unattended, from a file, see the [headless runner](headless.md).
+
+> `by all` grabs *every* idle onboard manny at fire time — including the one that just finished the preceding step. To keep some aside, name them explicitly: `by Bravo,Charlie`.

--- a/docs/src/cockpit/actions.md
+++ b/docs/src/cockpit/actions.md
@@ -1,0 +1,29 @@
+# Actions & command mode
+
+Two ways to act: the **contextual menu** (`Enter`) and the **command line** (`:`).
+
+## Contextual menu — `Enter`
+
+`Enter` builds a menu from the active pane **and** the current selection. Unavailable items are shown greyed with the reason. Picking an item launches the matching wizard — a short guided flow (pick a target, confirm, fire). Panes with rich flows (Missions, Comms, Storage, Sector objects) open their dedicated overlay instead of the popup.
+
+In a menu: `1`–`9` fire the nth item, `j`/`k` move, `Enter` fires the selection, `Esc` closes.
+
+## Command mode — `:`
+
+Press `:` for a vim-style command line. `Tab` completes and cycles the verb and its enumerable arguments; `↑`/`↓` browse history; ghost-text shows the argument usage.
+
+| Command | Argument | Does |
+|---------|----------|------|
+| `focus` | `<pane>` | zoom that pane |
+| `travel` | `<x y z \| +dx dy dz>` | travel to absolute or relative coordinates |
+| `goto` | `<x y z>` | centre the map |
+| `filter` | `<all\|objects\|minable\|danger>` | filter the scan history |
+| `craft` | `[recipe]` | open the production console, or enqueue a recipe |
+| `queue` | | open the production console |
+| `script` | | open the [action-scripting](../automation/scripting.md) console |
+| `mine` | `[res] [amt] [by/at/to …]` | open the mine wizard, or fire a mine directly |
+| `probe` | `<id\|name>` | pilot a fleet probe |
+| `theme` | `<mode>` | set the colour mode |
+| `refresh` · `zoom` · `help` · `q` | | refresh · toggle zoom · help · quit |
+
+`travel` accepts a leading `+` for relative moves (e.g. `travel +2 0 0`). `mine` is **hybrid**: bare `:mine` opens the wizard, a full line fires directly — resolving the builder manny and asteroid from context, overridable with `by`/`at`, destination defaulting to the probe (`to <container>` redirects).

--- a/docs/src/cockpit/display.md
+++ b/docs/src/cockpit/display.md
@@ -1,0 +1,26 @@
+# Themes & display
+
+## Colour modes — `F2`
+
+Four phosphor colour modes cycle with `F2` (or `:theme <mode>`, or the `theme` config key):
+
+| Mode | Look |
+|------|------|
+| `mono-green` | classic green phosphor (default) |
+| `mono-amber` | amber phosphor |
+| `phosphor-semantic` | green base with green/yellow/red status |
+| `modern-16` | named ANSI colours, for terminals without truecolor |
+
+Gauges read green above 50 %, yellow 25–50 %, red below 25 %.
+
+## Hints line — `F1`
+
+A second status line lists the keys valid for the active pane. `F1` toggles it; the `hints` config key sets the default.
+
+## Live updates
+
+Time-derived values — progress bars, mining %, movement countdowns, the clock — tick **every second** without any input. Data is re-fetched when an action needs it, when a movement completes (the timer follows the probe's `arrival_at`), and otherwise at most once a minute. The bottom-right `⟳` shows how long since the last sync.
+
+## Boot sequence
+
+On startup the probe core boots first (the centre-pane preflight), then the eight surrounding subsystems come online centre-out, each typing a themed self-check (SUDDAR array, SCUT link, autofactory, manny bay…). Any key skips straight into the live cockpit.

--- a/docs/src/cockpit/grid.md
+++ b/docs/src/cockpit/grid.md
@@ -1,0 +1,36 @@
+# The grid & navigation
+
+Nine panes are addressed by a **square of keys** on the keyboard — identical on AZERTY and QWERTY:
+
+```text
+ e  r  t     Scanner   Map      Comms
+ d  f  g     Sector    Probe    Missions
+ c  v  b     Inventory Storage  Mannies
+```
+
+The centre key `f` is always the **Probe** pane.
+
+## Keys
+
+| Key            | Action                                             |
+|----------------|----------------------------------------------------|
+| `e r t d f g c v b` | activate a pane                               |
+| `j` / `k` (or `↑` / `↓`) | move the cursor in the active pane        |
+| `l` / `→`      | drill **in** (e.g. Missions → steps, Comms → a message) |
+| `h` / `←`      | drill **out**                                      |
+| `Tab` / `Shift+Tab` | cycle panes forward / back                    |
+| `z`            | **zoom** the active pane full-screen               |
+| `Enter`        | open the pane's contextual action menu             |
+| `:`            | command mode                                       |
+| `i`            | jump to the next idle Manny (focuses Mannies)      |
+| `F1` / `F2`    | toggle hints / cycle colour mode                   |
+| `F5`           | refresh · `?` help · `q` quit                      |
+| `Esc`          | close menu / leave zoom / drill up                 |
+
+## Zoom
+
+`z` blows the active pane up to full screen — useful for the Map, the ship's log, or a long list. `Esc` (or `z` again) returns to the grid.
+
+## Responsive layout
+
+The grid fits as many whole panes as your terminal allows: **3×3** on a large terminal, **2×2** on a half-screen, a single row on a short wide split, or one pane when tiny. It slides the visible window to keep the active pane on screen, and a **position mini-map** (the nine keys in three groups) appears in the status bar whenever the grid is reduced, so you always know where you are.

--- a/docs/src/cockpit/index.md
+++ b/docs/src/cockpit/index.md
@@ -1,0 +1,17 @@
+# The cockpit
+
+The cockpit is a **3×3 grid of nine panes**, keyboard-first, built on one model: **navigate then act**.
+
+- **[The grid & navigation](grid.md)** — the pane keys, cursor movement, drilling, zoom, and how the layout adapts to your terminal size.
+- **[The panes](panes.md)** — what each of the nine panes shows and does.
+- **[Actions & command mode](actions.md)** — the `Enter` contextual menu and the `:` command line.
+- **[Themes & display](display.md)** — colour modes, the hints line, live updates, and the boot sequence.
+
+At a glance:
+
+```text
+ NAV  COCKPIT › MANNIES        ⟳ · ≣ SCUT · ! 2 · API vN · 14:09
+ ↑↓ move · hl drill · z zoom · Enter act · ertdfgcvb pane · F1 hints
+```
+
+The status bar shows the current mode, a breadcrumb, transient errors/toasts, and right-aligned meta (loading, SCUT relay, unread alerts, API version, clock). The second **hints line** (toggle `F1`) lists the keys valid for the active pane.

--- a/docs/src/cockpit/panes.md
+++ b/docs/src/cockpit/panes.md
@@ -1,0 +1,30 @@
+# The panes
+
+Each pane shows a slice of state and offers actions via `Enter`. Move the cursor with `j`/`k`, drill with `l`/`h`, zoom with `z`.
+
+## Scanner (`e`)
+Scan history: symbol, coordinates, and distance for every sector you've seen, filterable. `Enter` offers **Travel here** to the selected observation. Scan neighbours, a direction (distance 2), or arbitrary coordinates.
+
+## Map (`r`)
+Compact sector summary. `z` opens the full **isometric map** (pan with `h j k l`, `g` travels to the centred sector, `c` re-centres on coordinates). `Enter` also offers **Travel to coordinates…**, **Jump to visited sector…**, and **Waypoints…** — each with a fuel/ETA preview.
+
+## Comms (`t`)
+A category root: **Messages**, **Alerts**, **Warnings**, each with an unread count and a preview. Drill in (`l`) to open the inbox/sent messaging overlay (read full-screen, `c` composes to a probe or planet), or an in-pane list where `Enter` acknowledges an alert/warning.
+
+## Sector (`d`)
+The objects in your current sector — asteroids (with reserves), detached containers, dormant constructs, planets (class + habitability). Drill into an object and `Enter` for its actions: **mine, inspect, salvage, recover, deploy waypoint**, or **turn on relay** for an inactive SCUT relay.
+
+## Probe (`f`, centre)
+Status, fuel, hull integrity, movement ETA and speed gauges. Its top-right corner pins the active probe's **sigil** (a deterministic identicon) so drones are told apart at a glance. `Enter`: switch probe (multi-probe fleets), set default, rename, inspect the SCUT network, install **probe improvements**, and — if the probe is dead or trapped — reassign its mind snapshot. Zoom (`z`) unfolds the full fleet roster.
+
+## Missions (`g`)
+Two categories: **Missions** (active directives with steps/status; `Enter` → abandon) and **Ship's log** (the captain's-log — newest-first narrated entries of your actions and server events).
+
+## Inventory (`c`)
+Cargo stocks and onboard items. `Enter`: **Fabricate**, **Move stock**, **Jettison**, and **Deploy waypoint…** (when a waypoint bookmark is held).
+
+## Storage (`v`)
+Storage containers with capacity bars. `Enter`: view contents, rename, and edit routing rules (none → priority → exclusion → strict).
+
+## Mannies (`b`)
+The manny roster with live task progress. `Enter` opens the richest menu: fabricate, mine, repair, salvage, inspect, recover/detach a container, refuel, **transfer deuterium** to another probe, drop cargo, **assemble a probe**, recall/abandon, rename. A mining manny that turns up a hidden container flags it in its detail.

--- a/docs/src/getting-started/configuration.md
+++ b/docs/src/getting-started/configuration.md
@@ -1,0 +1,36 @@
+# Configuration
+
+The cockpit reads `~/.config/neumann-cockpit/config.toml` at startup.
+
+## Get an API key
+
+Create an account on [neumann-probe.net](https://neumann-probe.net), open **Settings**, and generate an API key. It is shown **only once** — copy it right away.
+
+## The config file
+
+You rarely need to write this by hand (see [First run](first-run.md)), but if you prefer:
+
+```bash
+mkdir -p ~/.config/neumann-cockpit
+cp config.example.toml ~/.config/neumann-cockpit/config.toml
+```
+
+```toml
+base_url = "https://neumann-probe.net"
+api_key  = "vng_your_api_key_here"
+# theme = "mono-green"   # mono-green | mono-amber | phosphor-semantic | modern-16
+# hints = true           # show the contextual hints line
+```
+
+| Key        | Required | Meaning                                                        |
+|------------|----------|----------------------------------------------------------------|
+| `base_url` | yes      | Game API endpoint (defaults to `https://neumann-probe.net`).   |
+| `api_key`  | yes      | Your `vng_…` API key.                                          |
+| `theme`    | no       | Colour mode; `F2` cycles it at runtime.                        |
+| `hints`    | no       | Show the contextual hints line (`F1` toggles). Defaults `true`.|
+
+Unknown keys are ignored, so older config files keep loading. See the full [configuration reference](../reference/configuration.md).
+
+## Where state lives
+
+Scan history and the ship's log are kept in a local SQLite database under your XDG **state** directory — separate from the config. You never edit it by hand.

--- a/docs/src/getting-started/first-run.md
+++ b/docs/src/getting-started/first-run.md
@@ -1,0 +1,20 @@
+# First run
+
+Launch it:
+
+```bash
+neumann-cockpit
+```
+
+Startup runs a **preflight** inside the centre (Probe) pane before the live cockpit appears. It performs three checks:
+
+1. **CONFIG** — if the config is missing or has no real key, an onboarding prompt appears right in the Probe pane: it tells you where to get a key, lets you paste it in, and writes `~/.config/neumann-cockpit/config.toml` for you. `Esc` / `Ctrl-C` quits cleanly.
+2. **ARCHIVE** — opens the local SQLite database and loads your scan history.
+3. **REMOTE LINK** — contacts the game API. On a bad key or an outage you get in-pane actions:
+   - `[R]` retry the link
+   - `[K]` re-enter the API key (re-runs onboarding)
+   - `[Enter]` continue **offline** (degraded mode — an error toast; `F5` retries later)
+
+Once the link is up, a short self-check animation assembles the cockpit centre-out. **Any key** drops you into the live cockpit.
+
+From here, head to **[The cockpit](../cockpit/index.md)**.

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -1,0 +1,15 @@
+# Getting started
+
+Three steps to your first flight:
+
+1. **[Install](installation.md)** — grab a prebuilt binary or build from source.
+2. **[Configure](configuration.md)** — point the cockpit at the game and give it your API key.
+3. **[First run](first-run.md)** — the boot preflight walks you through onboarding if anything is missing.
+
+The short version:
+
+```bash
+neumann-cockpit
+```
+
+On the very first run you don't need to create any file — the boot screen detects the missing key, tells you where to get one, and writes the config for you.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,0 +1,28 @@
+# Installation
+
+## Prebuilt binaries (recommended)
+
+Binaries for **Linux, macOS, and Windows** are published on the [releases page](https://github.com/MagiCrazy/neumann-cockpit/releases/latest). Every archive ships a matching `.sha256` — download, verify, then extract:
+
+```bash
+# Linux x86_64 example
+base=https://github.com/MagiCrazy/neumann-cockpit/releases/latest/download
+curl -sLO "$base/neumann-cockpit-linux-x86_64.tar.gz"
+curl -sLO "$base/neumann-cockpit-linux-x86_64.tar.gz.sha256"
+sha256sum -c neumann-cockpit-linux-x86_64.tar.gz.sha256
+tar xzf neumann-cockpit-linux-x86_64.tar.gz
+./neumann-cockpit
+```
+
+On **Windows**, a double-clicked binary works: the boot screen comes up first and every startup failure (including the missing-key case) is handled in the TUI rather than flashing a console and vanishing.
+
+## Build from source
+
+Requires a stable Rust toolchain (`rustup` recommended).
+
+```bash
+git clone https://github.com/MagiCrazy/neumann-cockpit
+cd neumann-cockpit
+cargo build --release
+./target/release/neumann-cockpit
+```

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,26 @@
+# neumann-cockpit
+
+A terminal UI **cockpit** for the [Von Neumann Game](https://github.com/gnieark/Von-Neumann-Game) — pilot your probe and its mannies from the command line. The official game instance runs at **[neumann-probe.net](https://neumann-probe.net)** (the default endpoint).
+
+It is a single **phosphor cockpit**: a 3×3 tiling dashboard of nine panes, keyboard-first, built around one idea — *navigate then act*. Jump to a pane, move the cursor, then press `Enter` for its contextual actions or `:` for a command line.
+
+```text
+┌═ SCANNER ═════┐┌═ MAP ═════════┐┌═ COMMS ═══════┐
+│ scan history  ││ sector coords ││ alerts / msgs │
+└═══════════════┘└═══════════════┘└═══════════════┘
+┌═ SECTOR ══════┐┌═ PROBE ═══════┐┌═ MISSIONS ════┐
+│ objects here  ││ status · fuel ││ active list   │
+└═══════════════┘└═══════════════┘└═══════════════┘
+┌═ INVENTORY ═══┐┌═ STORAGE ═════┐┌═ MANNIES ═════┐
+│ cargo · stocks││ containers    ││ ● manny list  │
+└═══════════════┘└═══════════════┘└═══════════════┘
+```
+
+## What this guide covers
+
+- **[Getting started](getting-started/index.md)** — install, configure, and the first-run onboarding.
+- **[The cockpit](cockpit/index.md)** — the grid, the nine panes, contextual actions, command mode, and display options.
+- **[Automation](automation/index.md)** — the production queue, vim-style action scripting, and the headless script runner.
+- **[Reference](reference/index.md)** — the keybinding cheat sheet and every config option.
+
+Developers: the codebase architecture lives in [`CLAUDE.md`](https://github.com/MagiCrazy/neumann-cockpit/blob/main/CLAUDE.md); see **[Architecture & contributing](project/architecture.md)**.

--- a/docs/src/project/architecture.md
+++ b/docs/src/project/architecture.md
@@ -1,0 +1,9 @@
+# Architecture & contributing
+
+This guide is for **pilots**. If you want to hack on the cockpit itself:
+
+- **Architecture** — the codebase is documented in depth in [`CLAUDE.md`](https://github.com/MagiCrazy/neumann-cockpit/blob/main/CLAUDE.md): the boot preflight, the `tokio::select!` event loop, the `AppState` domain split, the API layer, the theme/UI layout, and every implemented endpoint. It is the single source of truth for how the code is put together — this book intentionally does not duplicate it.
+- **Contributing** — [`CONTRIBUTING.md`](https://github.com/MagiCrazy/neumann-cockpit/blob/main/CONTRIBUTING.md) covers the dev setup, the checks CI runs (`cargo test`, `clippy`, `rustfmt`), and the commit/PR conventions.
+- **Changelog** — [`CHANGELOG.md`](https://github.com/MagiCrazy/neumann-cockpit/blob/main/CHANGELOG.md) is generated from Conventional Commits.
+
+Bug reports, ideas, and pull requests are welcome on [GitHub](https://github.com/MagiCrazy/neumann-cockpit).

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -1,0 +1,34 @@
+# Configuration reference
+
+## File location
+
+`~/.config/neumann-cockpit/config.toml` (XDG config directory).
+
+## Keys
+
+```toml
+base_url = "https://neumann-probe.net"
+api_key  = "vng_your_api_key_here"
+theme    = "mono-green"
+hints    = true
+```
+
+| Key        | Type   | Default                       | Meaning |
+|------------|--------|-------------------------------|---------|
+| `base_url` | string | `https://neumann-probe.net`   | Game API endpoint. |
+| `api_key`  | string | —                             | Your `vng_…` API key (generated once in the web UI). |
+| `theme`    | string | `mono-green`                  | Colour mode: `mono-green`, `mono-amber`, `phosphor-semantic`, `modern-16`. `F2` cycles at runtime. |
+| `hints`    | bool   | `true`                        | Show the contextual hints line. `F1` toggles at runtime. |
+
+Unknown keys are ignored, so legacy config files keep loading.
+
+## State (not config)
+
+Scan history and the **ship's log** are persisted in a local SQLite database (`cockpit.db`) under your XDG **state** directory. It is created and managed automatically — you never edit it. A legacy `scan_history.json`, if present, is migrated into the database once and then removed.
+
+## Command-line
+
+| Flag | Effect |
+|------|--------|
+| _(none)_ | launch the interactive cockpit |
+| `--script <file>`, `-s <file>` | [headless runner](../automation/headless.md): play a script, no TUI |

--- a/docs/src/reference/index.md
+++ b/docs/src/reference/index.md
@@ -1,0 +1,4 @@
+# Reference
+
+- **[Keybindings](keybindings.md)** — the full key cheat sheet.
+- **[Configuration reference](configuration.md)** — every `config.toml` key and where files live.

--- a/docs/src/reference/keybindings.md
+++ b/docs/src/reference/keybindings.md
@@ -1,0 +1,58 @@
+# Keybindings
+
+The same list is available in-app with `?`.
+
+## Global
+
+| Key | Action |
+|-----|--------|
+| `e r t / d f g / c v b` | activate a pane (Scanner Map Comms / Sector Probe Missions / Inventory Storage Mannies) |
+| `Tab` / `Shift+Tab` | cycle panes forward / back |
+| `:` | command mode |
+| `i` | jump to the next idle Manny |
+| `F1` | toggle the hints line |
+| `F2` | cycle colour mode |
+| `F5` | refresh |
+| `?` | help |
+| `q` | quit |
+
+## In a pane
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` (or `↑` / `↓`) | move the cursor |
+| `l` / `→` | drill in |
+| `h` / `←` | drill out |
+| `z` | zoom the active pane full-screen |
+| `Enter` | contextual action menu |
+| `Esc` | close menu / leave zoom / drill up |
+
+## In a menu
+
+| Key | Action |
+|-----|--------|
+| `1`–`9` | fire the nth item |
+| `j` / `k` | move |
+| `Enter` | fire the selection |
+| `Esc` | close |
+
+## Full isometric map (`z` on the Map pane)
+
+| Key | Action |
+|-----|--------|
+| `h j k l` | pan |
+| `g` | travel to the centred sector |
+| `c` | re-centre on coordinates |
+
+## Action-scripting console (`:script`)
+
+| Mode | Key | Action |
+|------|-----|--------|
+| Insert | `Enter` | add the typed line |
+| Insert | `Esc` | switch to Normal (manage) |
+| Normal | `i` | insert a new line |
+| Normal | `j` / `k` | move the selection |
+| Normal | `x` / `c` | remove step / clear |
+| Normal | `R` | run |
+| Normal | `p` | pause / resume |
+| Normal | `Esc` | close |


### PR DESCRIPTION
A user-facing documentation site built with **mdBook** and deployed to **GitHub Pages**. Fills the gap between the README (intro) and CLAUDE.md (dev architecture): a structured **user/player guide**.

## Contents (`docs/`)
- **Getting started** — installation, configuration, first-run onboarding.
- **The cockpit** — the grid & navigation, the nine panes, contextual actions & command mode, themes/display.
- **Automation** — production queue, action scripting (the DSL, late binding, fork/join), the headless runner (`--script`).
- **Reference** — keybinding cheat sheet, configuration reference.
- **Architecture & contributing** — points to `CLAUDE.md` / `CONTRIBUTING.md` rather than duplicating them.

## Deployment
- `.github/workflows/docs.yml` builds the book (mdBook v0.5.4, pinned) and publishes to Pages on pushes that touch `docs/**`. Actions are pinned by commit SHA, matching the existing CI.
- `docs/book` is gitignored; README gets a Docs badge + link.

## ⚠️ One-time setup required
Enable Pages with **Settings → Pages → Build and deployment → Source = GitHub Actions**, otherwise the `deploy` job fails. Once merged and enabled, the site is live at https://magicrazy.github.io/neumann-cockpit/.

## Notes
- Built and verified locally with `mdbook build` (no broken links).
- Scope is the **user guide** (per decision); the architecture chapter intentionally defers to `CLAUDE.md` to avoid drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)