### PR TITLE
fix(ui): make container routing-rules editor semantics unambiguous

### DIFF
--- a/src/input/containers.rs
+++ b/src/input/containers.rs
@@ -122,6 +122,12 @@ pub(super) fn handle_container_rules_event(
         KeyCode::Left | KeyCode::Char('h') => {
             cycle_selected(state, true);
         }
+        KeyCode::Char('d') => {
+            // "Dedicate this container to the [P] types": strict-exclude every
+            // other known type. This is the whitelist intent that [S] alone
+            // does not express (issue #234).
+            reserve_for_priority(state);
+        }
         KeyCode::Delete | KeyCode::Backspace => {
             // Clear the selected type back to "none".
             if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
@@ -168,6 +174,38 @@ pub(super) fn handle_container_rules_event(
     }
 }
 
+/// Reserve the container for its [P] (priority) types: every other known type
+/// is moved to strict exclusion (and dropped from plain exclusion), so nothing
+/// but the priority types can be auto-placed here — the "dedicate to X" intent
+/// that a bare strict-exclusion cannot express (issue #234). Requires at least
+/// one priority type; otherwise it sets a guiding error and changes nothing.
+fn reserve_for_priority(state: &mut AppState) {
+    if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
+        types,
+        priority,
+        exclusion,
+        strict_exclusion,
+        error,
+        ..
+    }) = &mut state.active_wizard
+    {
+        if priority.is_empty() {
+            *error = Some("mark the wanted type(s) [P] first, then [d] to reserve".into());
+            return;
+        }
+        for ty in types.iter() {
+            if priority.iter().any(|t| t == ty) {
+                continue;
+            }
+            exclusion.retain(|t| t != ty);
+            if !strict_exclusion.iter().any(|t| t == ty) {
+                strict_exclusion.push(ty.clone());
+            }
+        }
+        *error = None;
+    }
+}
+
 fn cycle_selected(state: &mut AppState, backward: bool) {
     if let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
         types,
@@ -181,5 +219,72 @@ fn cycle_selected(state: &mut AppState, backward: bool) {
         if let Some(ty) = types.get(*selection).cloned() {
             cycle_assignment(&ty, priority, exclusion, strict_exclusion, backward);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reserve_for_priority;
+    use crate::app::{ActiveWizard, AppState, ContainerRulesInput};
+
+    fn editing(priority: &[&str], exclusion: &[&str], strict: &[&str]) -> AppState {
+        let mut s = AppState::default();
+        s.active_wizard = ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
+            container_id: "c1".into(),
+            container_label: "hold".into(),
+            types: vec!["metals".into(), "ice".into(), "carbon".into(), "deuterium".into()],
+            priority: priority.iter().map(|s| s.to_string()).collect(),
+            exclusion: exclusion.iter().map(|s| s.to_string()).collect(),
+            strict_exclusion: strict.iter().map(|s| s.to_string()).collect(),
+            selection: 0,
+            error: None,
+        });
+        s
+    }
+
+    fn lists(s: &AppState) -> (Vec<String>, Vec<String>, Vec<String>, Option<String>) {
+        let ActiveWizard::ContainerRules(ContainerRulesInput::Editing {
+            priority,
+            exclusion,
+            strict_exclusion,
+            error,
+            ..
+        }) = &s.active_wizard
+        else {
+            panic!("not editing");
+        };
+        (
+            priority.clone(),
+            exclusion.clone(),
+            strict_exclusion.clone(),
+            error.clone(),
+        )
+    }
+
+    #[test]
+    fn reserve_strict_excludes_every_non_priority_type() {
+        // Dedicate to ice + carbon: metals and deuterium must be strict-excluded.
+        let mut s = editing(&["ice", "carbon"], &["metals"], &[]);
+        reserve_for_priority(&mut s);
+        let (priority, exclusion, strict, error) = lists(&s);
+        assert_eq!(priority, vec!["ice", "carbon"]);
+        assert!(
+            exclusion.is_empty(),
+            "plain exclusion should be cleared for reserved types"
+        );
+        assert!(strict.contains(&"metals".to_string()));
+        assert!(strict.contains(&"deuterium".to_string()));
+        assert!(!strict.contains(&"ice".to_string()));
+        assert!(!strict.contains(&"carbon".to_string()));
+        assert!(error.is_none());
+    }
+
+    #[test]
+    fn reserve_without_priority_sets_guiding_error_and_no_change() {
+        let mut s = editing(&[], &[], &[]);
+        reserve_for_priority(&mut s);
+        let (priority, exclusion, strict, error) = lists(&s);
+        assert!(priority.is_empty() && exclusion.is_empty() && strict.is_empty());
+        assert!(error.unwrap().contains("[P]"));
     }
 }

--- a/src/ui/overlays/containers.rs
+++ b/src/ui/overlays/containers.rs
@@ -81,7 +81,7 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
     let selection = *selection;
 
     let height = (types.len() as u16 + 8).clamp(10, 24);
-    let popup = centered_rect(58, height, area);
+    let popup = centered_rect(70, height, area);
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .title(format!(" ROUTING RULES — {container_label} "))
@@ -96,16 +96,18 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
         .constraints([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
 
+    // Directional wording: each tag says where the item goes, not the raw API
+    // term — so [S] reads as "never here", not as a whitelist (issue #234).
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled("P", Style::default().fg(p.good)),
-            Span::raw(" priority  "),
+            Span::raw(" prefer here  "),
             Span::styled("E", Style::default().fg(p.warn)),
-            Span::raw(" exclude  "),
+            Span::raw(" avoid  "),
             Span::styled("S", Style::default().fg(p.crit)),
-            Span::raw(" strict  "),
-            Span::styled("·", Style::default().fg(p.dim)),
-            Span::raw(" none"),
+            Span::raw(" never here  "),
+            Span::styled("[ ]", Style::default().fg(p.dim)),
+            Span::raw(" any"),
         ])),
         rows[0],
     );
@@ -113,21 +115,24 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
     let items: Vec<ListItem> = types
         .iter()
         .map(|ty| {
-            let (tag, color) = if priority.iter().any(|t| t == ty) {
-                ("[P]", p.good)
+            // Tag + a plain-language effect per type, so a pilot reads what the
+            // rule does without consulting the OpenAPI spec (issue #234).
+            let (tag, color, effect) = if priority.iter().any(|t| t == ty) {
+                ("[P]", p.good, "prefer here")
             } else if exclusion.iter().any(|t| t == ty) {
-                ("[E]", p.warn)
+                ("[E]", p.warn, "avoid if possible")
             } else if strict_exclusion.iter().any(|t| t == ty) {
-                ("[S]", p.crit)
+                ("[S]", p.crit, "never placed here")
             } else {
-                ("[ ]", p.dim)
+                ("[ ]", p.dim, "any container")
             };
             ListItem::new(Line::from(vec![
                 Span::styled(
                     format!("{tag} "),
                     Style::default().fg(color).add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(ty.clone(), Style::default().fg(p.text)),
+                Span::styled(format!("{ty:<20}"), Style::default().fg(p.text)),
+                Span::styled(effect, Style::default().fg(p.dim)),
             ]))
         })
         .collect();
@@ -155,6 +160,7 @@ pub(crate) fn render_container_rules_overlay(frame: &mut Frame, area: Rect, stat
             p,
             &[
                 FooterKey::nav("[Space]", "cycle"),
+                FooterKey::nav("[d]", "reserve"),
                 FooterKey::nav("[Del]", "clear"),
                 FooterKey::commit("[Enter]", "SAVE"),
                 FooterKey::nav("[Esc]", "cancel"),


### PR DESCRIPTION
## Context

Reported in-game: a container tagged **strict ice** + **strict carbon** received **metal**, while other containers could have taken it. This is **not** a server routing bug — the server behaved per spec — but a **UI semantics problem** (#234).

Per `api-specs/v86.yaml`, `strict_exclusion` *prevents* auto-placement of the listed types **into** that container. Tagging ice/carbon `[S]` therefore means "never place ice/carbon **here**" — it says nothing about metal, so metal is free to land there. The editor's legend (`P priority · E exclude · S strict`) let `[S]` read as a whitelist ("only these here"), the inverse of the pilot's intent.

## Changes

- **Directional legend**: `P prefer here · E avoid · S never here · [ ] any`.
- **Plain-language effect per type**, so a rule reads without the OpenAPI spec: `[P] ice  prefer here`, `[E] metal  avoid if possible`, `[S] carbon  never placed here`, `[ ] deuterium  any container`.
- **`[d]` reserve key**: dedicates the container to its `[P]` types by strict-excluding every other known type — the "dedicate this container to X" intent a bare strict-exclusion cannot express. Guarded: with no `[P]` type it sets a guiding error and changes nothing.
- Popup widened 58 → 70 so the extra footer key does not clip.

The routing decision itself stays entirely server-side; this only changes the clarity and affordances of how rules are configured (`update_container_rules` still PATCHes `{ priority, exclusion, strictExclusion }` unchanged).

## Tests

- `reserve_for_priority`: strict-excludes every non-priority type and clears their plain exclusion; empty-priority guard sets the error and mutates nothing.
- `cargo test` (318 passed), `cargo clippy` (clean), `cargo fmt --check` (clean).

## Acceptance

- [x] A pilot can tell, without reading the spec, that `[S]` keeps a type **out**, not in.
- [x] The "dedicate this container to type X" intent is achievable and discoverable (`[d]`).

Closes #234