### PR TITLE
feat(telemetry): vital-ratio sparklines in the zoomed Probe pane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ Scan history is persisted across runs in a local SQLite database (`cockpit.db`, 
 
 The same database holds the **ship's log** — an append-only `events` table recording pilot actions (travel, mine, deploy, drop/detach container, storage move…) as narrated captain's-log entries. Actions stage a pre-rendered line into `AppState::pending_journal` (mirroring `pending_fire`), which the event loop drains to persist and prepend to `AppState::journal`. The table is never trimmed (full history kept for long-term stats); only the most recent `store::JOURNAL_WINDOW` are loaded into memory at boot. The Missions-pane view (`AppState::ship_log_entries`) merges these captured actions with reconstructed server events (alerts + damage warnings, projected fresh from memory rather than persisted, since the server keeps them), newest first.
 
+The database also holds a **telemetry** time series (`telemetry` table, issue #201) — periodic samples of the piloted probe's vital ratios (fuel / integrity / cargo, each `0..1`), tagged by active probe id. `AppState::update_probe` samples on each sync, deduped against the last sample for that probe (idle probes don't flood the series); kept samples stage into `AppState::pending_telemetry` (mirroring `pending_journal`) and the event loop drains them to persist. Append-only, never trimmed; the recent `store::TELEMETRY_WINDOW` load into `AppState::telemetry` at boot. The zoomed Probe pane draws a Unicode sparkline (`theme::text_sparkline`) under each vital gauge from the active probe's tail.
+
 **Naming ceremony**: the rename wizards (probe / Manny / storage container) open pre-filled with a Culture-style name suggestion from `src/app/lexicon.rs` (`AppState::next_name_suggestion` cycles the bank); `Tab` regenerates a suggestion, `Enter` applies, editing is free-form, and `Esc` keeps the current name. The API has no name-at-creation (and an assembled drone only appears ~3 h later), so naming is always a post-hoc rename.
 
 ## Architecture
@@ -95,7 +97,7 @@ All other API calls (move, repair, mine, craft, storage container CRUD, storage 
 
 ### Theme & colours (`src/ui/theme.rs`)
 
-One unified phosphor theme (there is no classic/retro split any more). `theme.rs` holds the shared helpers: `Palette` + `palette(ColorMode)` (accent / dim / text / good / warn / crit per color mode), `pane_block(title, active, palette)` — the double-line (`BorderType::Double`) pane frame used by every pane, coloured accent when active and dim-accent otherwise — plus icons, labels, gauges (`make_line_gauge`, `gauge_color`), and `format_duration` / `format_age`. Color modes: `mono-green` (default), `mono-amber`, `phosphor-semantic`, `modern-16`; `F2` cycles them.
+One unified phosphor theme (there is no classic/retro split any more). `theme.rs` holds the shared helpers: `Palette` + `palette(ColorMode)` (accent / dim / text / good / warn / crit per color mode), `pane_block(title, active, palette)` — the double-line (`BorderType::Double`) pane frame used by every pane, coloured accent when active and dim-accent otherwise — plus icons, labels, gauges (`make_line_gauge`, `gauge_color`), `text_sparkline` (Unicode `▁▂▃▄▅▆▇█` trend line, used by the zoomed Probe telemetry), and `format_duration` / `format_age`. Color modes: `mono-green` (default), `mono-amber`, `phosphor-semantic`, `modern-16`; `F2` cycles them.
 
 ### UI (`src/ui/`)
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14,6 +14,7 @@ mod mode;
 mod queue;
 mod scan;
 mod script;
+mod telemetry;
 #[cfg(test)]
 mod tests;
 mod travel;
@@ -32,6 +33,7 @@ pub use mode::*;
 pub use queue::*;
 pub use scan::*;
 pub use script::*;
+pub use telemetry::*;
 pub use waypoints::*;
 
 use crate::api::types::{

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -85,6 +85,13 @@ pub struct AppState {
     /// Log entries staged by action handlers this tick, drained by the event
     /// loop to persist + prepend to `journal` (mirrors `pending_fire`).
     pub pending_journal: Vec<LogEvent>,
+    /// Vital-ratio time series (fuel / integrity / cargo), chronological, capped
+    /// at `store::TELEMETRY_WINDOW`; the zoomed Probe pane draws sparklines from
+    /// the active probe's tail (issue #201).
+    pub telemetry: Vec<TelemetrySample>,
+    /// Telemetry samples staged by `update_probe`, drained by the event loop to
+    /// persist (mirrors `pending_journal`); already appended to `telemetry`.
+    pub pending_telemetry: Vec<TelemetrySample>,
     /// Monotonic seed cycling the naming-ceremony lexicon (see
     /// `next_name_suggestion`); bumped each time a rename wizard suggests a name.
     pub name_suggestion_seed: usize,
@@ -202,6 +209,31 @@ impl AppState {
         self.consecutive_failures = 0;
         self.error = None;
         self.clamp_inventory_selection();
+        self.record_telemetry();
+    }
+
+    /// Sample the piloted probe's vital ratios into the telemetry series,
+    /// dropping a sample identical to the last one for the same probe so an
+    /// idle probe does not flood the series (issue #201). The kept sample is
+    /// appended to the in-memory series (capped) and staged for persistence.
+    fn record_telemetry(&mut self) {
+        let Some(probe) = &self.probe else { return };
+        let sample = TelemetrySample::from_probe(probe, self.active_probe_id);
+        if self
+            .telemetry
+            .iter()
+            .rev()
+            .find(|s| s.probe_id == sample.probe_id)
+            .is_some_and(|last| last.same_vitals(&sample))
+        {
+            return;
+        }
+        self.telemetry.push(sample.clone());
+        let overflow = self.telemetry.len().saturating_sub(crate::store::TELEMETRY_WINDOW);
+        if overflow > 0 {
+            self.telemetry.drain(0..overflow);
+        }
+        self.pending_telemetry.push(sample);
     }
 
     /// Apply a fleet roster refresh. Records the roster and default id, but

--- a/src/app/telemetry.rs
+++ b/src/app/telemetry.rs
@@ -1,0 +1,70 @@
+//! Telemetry time series — periodic samples of the probe's vital ratios
+//! (fuel / integrity / cargo), persisted so the zoomed Probe pane can draw
+//! sparklines of how they trend over a session (issue #201).
+//!
+//! Samples are taken on each probe refresh (`AppState::update_probe`) and
+//! deduplicated against the previous one, so an idle probe does not flood the
+//! series with identical points. They persist to the `telemetry` SQLite table
+//! (append-only) and the most recent [`store::TELEMETRY_WINDOW`](crate::store)
+//! are loaded into memory at boot, exactly like the ship's log.
+
+use chrono::{DateTime, Utc};
+
+use crate::api::types::Probe;
+
+/// One telemetry sample: the three vital ratios (each `0.0..=1.0`) at a point
+/// in time, tagged with the probe they belong to so a multi-probe series can
+/// be filtered per probe at render time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TelemetrySample {
+    pub occurred_at: DateTime<Utc>,
+    pub probe_id: Option<u64>,
+    pub fuel: f64,
+    pub integrity: f64,
+    pub cargo: f64,
+}
+
+impl TelemetrySample {
+    /// Derive a sample from a probe snapshot, mirroring the gauge maths in
+    /// `ui::panels::probe` so the sparkline tracks exactly what the gauges show.
+    /// `probe_id` is the active-probe tag (which may differ from the default),
+    /// so switching probes keeps each series distinct.
+    pub fn from_probe(probe: &Probe, probe_id: Option<u64>) -> Self {
+        let max_deuterium = probe.fuel.max_deuterium.unwrap_or(100.0);
+        let fuel = probe
+            .fuel
+            .deuterium
+            .map(|d| if max_deuterium > 0.0 { d / max_deuterium } else { 0.0 })
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0);
+        let integrity = probe
+            .systems
+            .as_ref()
+            .and_then(|s| s.integrity_percent)
+            .map(|i| i / 100.0)
+            .unwrap_or(1.0)
+            .clamp(0.0, 1.0);
+        let inv = &probe.inventory;
+        let cargo = if inv.capacity > 0.0 {
+            (inv.used_capacity / inv.capacity).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        Self {
+            occurred_at: Utc::now(),
+            probe_id,
+            fuel,
+            integrity,
+            cargo,
+        }
+    }
+
+    /// Whether the vital ratios match another sample (ignoring the timestamp),
+    /// so consecutive identical samples can be dropped from the series.
+    pub fn same_vitals(&self, other: &TelemetrySample) -> bool {
+        self.probe_id == other.probe_id
+            && self.fuel == other.fuel
+            && self.integrity == other.integrity
+            && self.cargo == other.cargo
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -503,6 +503,23 @@ fn update_probe_clamps_inventory_selection() {
     assert_eq!(state.inventory_selection, 0);
 }
 
+#[test]
+fn telemetry_samples_on_change_and_dedupes_identical() {
+    let mut state = AppState::default();
+    // First sync records a sample; an identical second sync is deduped.
+    state.update_probe(probe_with_inventory("[]", STOCK_METALS));
+    state.update_probe(probe_with_inventory("[]", STOCK_METALS));
+    assert_eq!(state.telemetry.len(), 1, "identical vitals are not resampled");
+
+    // A change in fuel produces a new sample, staged for persistence.
+    let mut p = probe_with_inventory("[]", STOCK_METALS);
+    p.fuel.deuterium = Some(50.0);
+    state.update_probe(p);
+    assert_eq!(state.telemetry.len(), 2);
+    assert_eq!(state.pending_telemetry.len(), 2, "both kept samples staged to persist");
+    assert!((state.telemetry[1].fuel - 0.5).abs() < 1e-9);
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────
 
 fn make_manny(id: &str, location_type: &str, can_receive_orders: bool, task: Option<&str>) -> Manny {

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
         conn,
         scan_history,
         journal,
+        telemetry,
         api_version,
         link_ok,
     } = ready;
@@ -108,6 +109,7 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
         booting: config.boot,
         scan_history,
         journal,
+        telemetry,
         api_version,
         ..Default::default()
     };
@@ -150,6 +152,17 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
                 state.journal.insert(0, ev);
             }
             state.journal.truncate(store::JOURNAL_WINDOW);
+        }
+
+        // Persist telemetry samples staged by update_probe (already appended to
+        // the in-memory series; the DB keeps the full history for stats).
+        if !state.pending_telemetry.is_empty() {
+            let staged: Vec<_> = state.pending_telemetry.drain(..).collect();
+            if let Some(tx) = &persist_tx {
+                for s in staged {
+                    let _ = tx.send(store::PersistMsg::AppendTelemetry(s));
+                }
+            }
         }
 
         // Production queue: advance the executor, then spawn any craft it staged

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -76,6 +76,7 @@ pub struct Ready {
     pub conn: Option<Connection>,
     pub scan_history: Vec<SectorObservation>,
     pub journal: Vec<LogEvent>,
+    pub telemetry: Vec<crate::app::TelemetrySample>,
     pub api_version: Option<u32>,
     pub link_ok: bool,
 }
@@ -133,12 +134,13 @@ pub async fn run(terminal: &mut Term, color: ColorMode) -> Result<Outcome> {
     // ── ARCHIVE (local SQLite store) ────────────────────────────────────
     log.begin("ARCHIVE");
     redraw(terminal, &log, None, None, color)?;
-    let (conn, scan_history, journal) = match store::open(&config::db_path()) {
+    let (conn, scan_history, journal, telemetry) = match store::open(&config::db_path()) {
         Ok(mut conn) => {
             let outcome = store::migrate_legacy_json(&mut conn, &config::history_path())
                 .unwrap_or(store::MigrationOutcome::NoLegacyFile);
             let history = store::load_observations(&conn);
             let journal = store::load_events(&conn);
+            let telemetry = store::load_telemetry(&conn);
             let msg = match outcome {
                 store::MigrationOutcome::Imported(n) => {
                     format!("{} sectors · migrated {n}", history.len())
@@ -146,11 +148,11 @@ pub async fn run(terminal: &mut Term, color: ColorMode) -> Result<Outcome> {
                 _ => format!("{} sectors · {} log", history.len(), journal.len()),
             };
             log.set(Status::Ok(msg));
-            (Some(conn), history, journal)
+            (Some(conn), history, journal, telemetry)
         }
         Err(e) => {
             log.set(Status::Warn(format!("disabled: {e}")));
-            (None, Vec::new(), Vec::new())
+            (None, Vec::new(), Vec::new(), Vec::new())
         }
     };
 
@@ -196,6 +198,7 @@ pub async fn run(terminal: &mut Term, color: ColorMode) -> Result<Outcome> {
         conn,
         scan_history,
         journal,
+        telemetry,
         api_version,
         link_ok,
     })))

--- a/src/store.rs
+++ b/src/store.rs
@@ -21,7 +21,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 use crate::api::types::SectorObservation;
-use crate::app::LogEvent;
+use crate::app::{LogEvent, TelemetrySample};
 
 /// Table + index DDL, shared by `open` and the tests.
 const SCHEMA: &str = "
@@ -53,6 +53,17 @@ CREATE TABLE IF NOT EXISTS events (
 );
 CREATE INDEX IF NOT EXISTS idx_events_occurred_at
     ON events (occurred_at);
+
+CREATE TABLE IF NOT EXISTS telemetry (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    occurred_at TEXT NOT NULL,
+    probe_id    INTEGER,
+    fuel        REAL NOT NULL,
+    integrity   REAL NOT NULL,
+    cargo       REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_telemetry_probe
+    ON telemetry (probe_id, id);
 ";
 
 /// How many recent ship's-log entries the cockpit loads into memory and keeps
@@ -60,6 +71,12 @@ CREATE INDEX IF NOT EXISTS idx_events_occurred_at
 /// full history is retained for long-term stats; this only bounds the in-memory
 /// working set and what the pane can scroll through.
 pub const JOURNAL_WINDOW: usize = 1000;
+
+/// How many recent telemetry samples are loaded into memory at boot (across all
+/// probes, newest first then reversed to chronological order). The `telemetry`
+/// table itself is append-only and never trimmed; this only bounds the working
+/// set the sparklines draw from.
+pub const TELEMETRY_WINDOW: usize = 512;
 
 /// Additive column migrations for databases that predate a column. `CREATE
 /// TABLE IF NOT EXISTS` never alters an existing table, so a new promoted
@@ -77,6 +94,8 @@ pub enum PersistMsg {
     UpsertObservation(SectorObservation),
     /// Append a ship's-log entry (append-only, trimmed to the retention cap).
     AppendEvent(LogEvent),
+    /// Append a telemetry sample (append-only vital-ratio time series).
+    AppendTelemetry(TelemetrySample),
 }
 
 /// What `migrate_legacy_json` did, so the boot preflight can report it.
@@ -215,6 +234,55 @@ pub fn load_events(conn: &Connection) -> Vec<LogEvent> {
     rows.filter_map(Result::ok).collect()
 }
 
+/// Append a telemetry sample. The series is append-only and never trimmed —
+/// the full history is kept for long-term stats; only the recent window is
+/// loaded into memory (see [`load_telemetry`]).
+pub fn append_telemetry(conn: &Connection, s: &TelemetrySample) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO telemetry (occurred_at, probe_id, fuel, integrity, cargo)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![
+            s.occurred_at.to_rfc3339(),
+            s.probe_id.map(|v| v as i64),
+            s.fuel,
+            s.integrity,
+            s.cargo,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Load the most recent [`TELEMETRY_WINDOW`] telemetry samples in chronological
+/// order (oldest first), so the in-memory series can be appended to and the
+/// sparklines read its tail. Best-effort: any error yields an empty series.
+pub fn load_telemetry(conn: &Connection) -> Vec<TelemetrySample> {
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT occurred_at, probe_id, fuel, integrity, cargo
+         FROM telemetry ORDER BY id DESC LIMIT ?1",
+    ) else {
+        return Vec::new();
+    };
+    let Ok(rows) = stmt.query_map(rusqlite::params![TELEMETRY_WINDOW as i64], |row| {
+        let occurred_at = row
+            .get::<_, String>(0)?
+            .parse::<DateTime<Utc>>()
+            .unwrap_or_else(|_| Utc::now());
+        Ok(TelemetrySample {
+            occurred_at,
+            probe_id: row.get::<_, Option<i64>>(1)?.map(|v| v as u64),
+            fuel: row.get(2)?,
+            integrity: row.get(3)?,
+            cargo: row.get(4)?,
+        })
+    }) else {
+        return Vec::new();
+    };
+    // Query is newest-first (by id); reverse to chronological (oldest-first).
+    let mut samples: Vec<_> = rows.filter_map(Result::ok).collect();
+    samples.reverse();
+    samples
+}
+
 /// One-time migration of the legacy `scan_history.json`: while the table is
 /// still empty, import every observation, then delete the JSON so it stops
 /// lingering. The import runs in a transaction and the file is removed **only
@@ -263,6 +331,9 @@ pub fn spawn_writer(conn: Connection) -> Sender<PersistMsg> {
                 }
                 PersistMsg::AppendEvent(ev) => {
                     let _ = append_event(&conn, &ev);
+                }
+                PersistMsg::AppendTelemetry(s) => {
+                    let _ = append_telemetry(&conn, &s);
                 }
             }
         }
@@ -386,6 +457,26 @@ mod tests {
         let loaded = load_events(&conn);
         assert_eq!(loaded.len(), JOURNAL_WINDOW);
         assert_eq!(loaded[0].summary, format!("entry {}", n - 1), "newest first");
+    }
+
+    #[test]
+    fn telemetry_round_trips_in_chronological_order() {
+        let conn = mem();
+        for i in 0..3 {
+            let s = TelemetrySample {
+                occurred_at: format!("2026-07-03T1{i}:00:00+00:00").parse().unwrap(),
+                probe_id: Some(1),
+                fuel: 1.0 - i as f64 * 0.1,
+                integrity: 1.0,
+                cargo: i as f64 * 0.2,
+            };
+            append_telemetry(&conn, &s).unwrap();
+        }
+        let loaded = load_telemetry(&conn);
+        assert_eq!(loaded.len(), 3);
+        // Oldest first: fuel decreases, cargo increases with insertion order.
+        assert!((loaded[0].fuel - 1.0).abs() < 1e-9, "chronological: oldest first");
+        assert!((loaded[2].cargo - 0.4).abs() < 1e-9);
     }
 
     #[test]

--- a/src/ui/panels/probe.rs
+++ b/src/ui/panels/probe.rs
@@ -1,5 +1,5 @@
 use crate::api::types::{MovementPhase, SensorMode};
-use crate::app::AppState;
+use crate::app::{AppState, TelemetrySample};
 use chrono::Utc;
 use ratatui::{
     layout::Rect,
@@ -12,8 +12,11 @@ use ratatui::{
 use crate::ui::sigil::sigil_lines;
 use crate::ui::theme::{
     block_gauge_line, format_duration, movement_phase_label, palette, pane_block, probe_status_label,
-    probe_status_style, ratio_color,
+    probe_status_style, ratio_color, text_sparkline,
 };
+
+/// How many recent samples the zoomed telemetry sparklines show.
+const SPARK_WIDTH: usize = 24;
 // ── Probe panel ───────────────────────────────────────────────────────────────
 
 pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState, focused: bool) {
@@ -136,6 +139,31 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
 
     // ── Vital gauges ──
     lines.push(Line::raw(""));
+    // Telemetry sparkline under each gauge when zoomed: the trend of that ratio
+    // over the recent samples for the active probe (issue #201). Needs ≥2
+    // points to read as a trend; aligns under the gauge bar (10-col label).
+    let series = |get: fn(&TelemetrySample) -> f64| -> Vec<f64> {
+        state
+            .telemetry
+            .iter()
+            .filter(|s| s.probe_id == state.active_probe_id)
+            .map(get)
+            .collect()
+    };
+    let spark = |values: Vec<f64>, ratio: f64| -> Option<Line<'static>> {
+        if !state.zoomed {
+            return None;
+        }
+        let s = text_sparkline(&values, SPARK_WIDTH);
+        if s.chars().count() < 2 {
+            return None;
+        }
+        Some(Line::from(vec![
+            Span::raw(" ".repeat(10)),
+            Span::styled(s, Style::default().fg(ratio_color(ratio, p))),
+        ]))
+    };
+
     let max_deuterium = probe.fuel.max_deuterium.unwrap_or(100.0);
     let fuel = probe
         .fuel
@@ -149,6 +177,9 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
         ratio_color(fuel, p),
         p,
     ));
+    if let Some(l) = spark(series(|s| s.fuel), fuel) {
+        lines.push(l);
+    }
     if let Some(sys) = &probe.systems {
         let integ = (sys.integrity_percent.unwrap_or(100.0) / 100.0).clamp(0.0, 1.0);
         lines.push(block_gauge_line(
@@ -158,6 +189,9 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
             ratio_color(integ, p),
             p,
         ));
+        if let Some(l) = spark(series(|s| s.integrity), integ) {
+            lines.push(l);
+        }
     }
     let inv = &probe.inventory;
     let cargo = if inv.capacity > 0.0 {
@@ -172,6 +206,9 @@ pub(crate) fn render_probe_panel(frame: &mut Frame, area: Rect, state: &AppState
         p.accent,
         p,
     ));
+    if let Some(l) = spark(series(|s| s.cargo), cargo) {
+        lines.push(l);
+    }
 
     // ── Movement (active) or current sector ──
     let active = probe.movement.as_ref().filter(|mv| {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -307,6 +307,25 @@ pub(crate) fn block_gauge_line(label: &str, ratio: f64, value: &str, fill: Color
     ])
 }
 
+/// Unicode sparkline over a series of ratios (each clamped to `0.0..=1.0`),
+/// mapping every value to one of eight block glyphs `▁▂▃▄▅▆▇█` and keeping the
+/// last `width` samples. An empty series or zero width yields "". Used for the
+/// zoomed Probe pane's telemetry trends (issue #201).
+pub(crate) fn text_sparkline(values: &[f64], width: usize) -> String {
+    const BARS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    if values.is_empty() || width == 0 {
+        return String::new();
+    }
+    let start = values.len().saturating_sub(width);
+    values[start..]
+        .iter()
+        .map(|&v| {
+            let idx = (v.clamp(0.0, 1.0) * (BARS.len() - 1) as f64).round() as usize;
+            BARS[idx]
+        })
+        .collect()
+}
+
 pub fn format_duration(secs: i64) -> String {
     if secs <= 0 {
         return "arriving…".to_string();
@@ -327,6 +346,14 @@ pub fn format_duration(secs: i64) -> String {
 mod tests {
     use super::*;
     use crate::app::ColorMode;
+
+    #[test]
+    fn sparkline_maps_extremes_and_keeps_tail() {
+        assert_eq!(text_sparkline(&[], 8), "");
+        assert_eq!(text_sparkline(&[0.0, 1.0], 8), "▁█");
+        // Only the last `width` samples are kept.
+        assert_eq!(text_sparkline(&[0.0, 0.0, 1.0], 1), "█");
+    }
 
     #[test]
     fn crit_style_reverses_only_in_mono() {


### PR DESCRIPTION
## Context

Show fuel / integrity / cargo trends over a session as sparklines in the zoomed Probe pane (#201). The issue suggested reusing the ship's-log `events` store, but that table is **narrative** (`kind`/`summary`/`data`), not a numeric series — so this adds a purpose-built telemetry time series instead.

## Design

- **Dedicated `telemetry` SQLite table** (`occurred_at, probe_id, fuel, integrity, cargo`, ratios `0..1`), append-only, never trimmed. New table → no `ALTER` migration needed.
- **Sampling** on each `update_probe`, deduped against the last sample for that probe so an idle probe doesn't flood the series. Kept samples stage into `pending_telemetry` and the event loop drains them to persist — mirroring the `pending_journal` pattern exactly.
- **In-memory series** (`AppState::telemetry`, capped at `TELEMETRY_WINDOW = 512`), loaded at boot by the preflight, tagged by active probe id so a fleet keeps distinct series. No runtime DB reads.
- **Rendering** via `theme::text_sparkline` (Unicode `▁▂▃▄▅▆▇█`, Line-composable — no ratatui `Sparkline` widget/area juggling): one line under each vital gauge, shown only when the pane is **zoomed** and the series has ≥2 points, coloured by the current ratio.

## Commits

1. Persistence foundations (table, `TelemetrySample`, append/load, persist message).
2. Sampling on probe sync + boot load + event-loop drain.
3. `text_sparkline` + zoomed Probe rendering + CLAUDE.md.

## Out of scope (later refinement)

- Per-resource stock series (MVP = aggregate cargo).
- Sparklines in other panes (Inventory).
- Real time-axis scaling (MVP = sample sequence).

## Tests

- Store: telemetry round-trips chronologically.
- App: samples on change, dedupes identical vitals, stages both kept samples.
- Theme: sparkline maps extremes (`▁`/`█`) and keeps the tail.
- `cargo test` (321 passed), `cargo clippy` (clean), `cargo fmt --check` (clean).

Closes #201