### PR TITLE
feat(notify): desktop notification on long-task completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,12 @@ base_url = "https://neumann-probe.net"
 api_key  = "vng_..."
 theme    = "mono-green"   # color mode (optional)
 hints    = true           # show the contextual hints line (optional)
+notifications = true      # desktop notification on long-task completion (optional)
 ```
 
 - `theme` — cockpit color mode: `mono-green` (default), `mono-amber`, `phosphor-semantic` (green base + green/yellow/red status), or `modern-16` (named ANSI for terminals without truecolor). `F2` cycles it at runtime.
 - `hints` — show the contextual hints line at the bottom (`F1` toggles at runtime). Defaults `true`.
+- `notifications` — emit a desktop notification (OSC 9 + terminal bell, `src/notify.rs`, issue #203) when a long task finishes: a travel arriving, or a Manny completing a long task (mining, crafting, repair, salvage, upgrade…). Completions are detected in `update_probe` / `update_mannies` (busy→idle diff), staged in `AppState::pending_notifications`, and drained by the event loop. Defaults `true`.
 
 Unknown keys are ignored, so legacy configs (`ui`, `phosphor`, `animations`, `theme = "retro"`) still load.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,3 +10,7 @@ api_key  = "vng_your_api_key_here"
 # Play the boot self-check animation on startup. Set false to drop straight
 # into the live cockpit (handy over tmux/ssh or on relaunch).
 #boot = true
+# Emit a desktop notification (OSC 9 + terminal bell) when a long task
+# finishes — travel arrival or a Manny completing a long task. Set false
+# to stay silent.
+#notifications = true

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -44,6 +44,24 @@ use crate::api::types::{
 use chrono::{DateTime, Local, Utc};
 use tokio::time::Instant;
 
+/// A short label for a Manny task worth a desktop notification when it
+/// completes, or `None` for quick/uninteresting tasks (moving cargo, returning,
+/// waiting, inspecting…) that would only add noise (issue #203).
+fn long_task_note(task: &crate::api::types::MannyTask) -> Option<&'static str> {
+    use crate::api::types::MannyTask;
+    Some(match task {
+        MannyTask::Mining => "mining",
+        MannyTask::Crafting | MannyTask::AssistingAtomicPrinter => "crafting",
+        MannyTask::Repair => "a repair",
+        MannyTask::Salvage => "salvaging",
+        MannyTask::ImprovingProbe => "a probe upgrade",
+        MannyTask::InstallingWaypointBookmark => "installing a waypoint",
+        MannyTask::RefillingDeuteriumTank => "refueling",
+        MannyTask::TurningOnScutRelay => "activating a relay",
+        _ => return None,
+    })
+}
+
 /// The follow-up refresh a successful action needs. Staged into
 /// `AppState::pending_refetch` by `finish_action` and dispatched once by the
 /// event loop (which owns the `ApiClient` + sender), mirroring how `pending_fire`
@@ -92,6 +110,11 @@ pub struct AppState {
     /// Telemetry samples staged by `update_probe`, drained by the event loop to
     /// persist (mirrors `pending_journal`); already appended to `telemetry`.
     pub pending_telemetry: Vec<TelemetrySample>,
+    /// Desktop-notification messages staged when a long task completes (travel
+    /// arrival, a Manny finishing a long task), drained by the event loop and
+    /// emitted via `notify::desktop_notify` when `config.notifications` is on
+    /// (issue #203).
+    pub pending_notifications: Vec<String>,
     /// Monotonic seed cycling the naming-ceremony lexicon (see
     /// `next_name_suggestion`); bumped each time a rename wizard suggests a name.
     pub name_suggestion_seed: usize,
@@ -198,6 +221,9 @@ pub struct AppState {
 
 impl AppState {
     pub fn update_probe(&mut self, probe: Probe) {
+        // A pending arrival that disappears this sync means the travel ended —
+        // notify (issue #203). Captured before the deadline is recomputed.
+        let was_traveling = self.movement_arrival.is_some();
         self.movement_arrival = probe
             .movement
             .as_ref()
@@ -210,6 +236,28 @@ impl AppState {
         self.error = None;
         self.clamp_inventory_selection();
         self.record_telemetry();
+        if was_traveling && self.movement_arrival.is_none() {
+            self.notify_travel_ended();
+        }
+    }
+
+    /// Stage a desktop notification for a travel that just ended, reading the
+    /// outcome (arrived / failed / destroyed) and destination from the probe's
+    /// movement snapshot.
+    fn notify_travel_ended(&mut self) {
+        use crate::api::types::MovementPhase;
+        let msg = match self.probe.as_ref().and_then(|p| p.movement.as_ref()) {
+            Some(m) => match m.phase.as_ref().unwrap_or(&m.status) {
+                MovementPhase::Failed => "Travel failed".to_string(),
+                MovementPhase::Destroyed => "Probe destroyed in transit".to_string(),
+                _ => format!(
+                    "Probe arrived at ({}, {}, {})",
+                    m.target.x as i64, m.target.y as i64, m.target.z as i64
+                ),
+            },
+            None => "Probe arrived".to_string(),
+        };
+        self.pending_notifications.push(msg);
     }
 
     /// Sample the piloted probe's vital ratios into the telemetry series,
@@ -279,6 +327,25 @@ impl AppState {
         let now = Utc::now();
         for m in &mut mannies {
             m.observed_at = Some(now);
+        }
+        // Notify on a long task completing: a Manny that was running a notable
+        // long task last sync and is now idle (issue #203). Comparing against
+        // the previous roster (by id) before it is replaced; the fire→busy lag
+        // is a None→Some transition, so it never produces a false completion.
+        if let Some(prev) = &self.mannies {
+            for m in &mannies {
+                if m.current_task.is_some() {
+                    continue;
+                }
+                let finished = prev
+                    .iter()
+                    .find(|p| p.id == m.id)
+                    .and_then(|p| p.current_task.as_ref())
+                    .and_then(long_task_note);
+                if let Some(note) = finished {
+                    self.pending_notifications.push(format!("{} finished {note}", m.name));
+                }
+            }
         }
         // Clamp selection in case list shrank.
         if !mannies.is_empty() {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -520,6 +520,64 @@ fn telemetry_samples_on_change_and_dedupes_identical() {
     assert!((state.telemetry[1].fuel - 0.5).abs() < 1e-9);
 }
 
+fn probe_with_movement(arrival: &str, phase: &str) -> Probe {
+    serde_json::from_str(&format!(
+        r#"{{
+        "id": 1, "name": "t", "status": "idle",
+        "fuel": {{"deuterium": 100.0}}, "sensorMode": "normal", "sector": null,
+        "movement": {{
+            "status": "{phase}", "origin": {{"x":0,"y":0,"z":0}}, "target": {{"x":1,"y":2,"z":3}},
+            "distance": 3, "fuelCostDeuterium": 1.0,
+            "startedAt": "2026-07-01T00:00:00+00:00", "arrivalAt": "{arrival}", "phase": "{phase}"
+        }},
+        "systems": null,
+        "inventory": {{"capacity":10.0,"usedCapacity":1.0,"freeCapacity":9.0,
+            "items":[],"resourceStocks":[],"externalTanks":[],"containers":[]}}
+    }}"#
+    ))
+    .unwrap()
+}
+
+#[test]
+fn travel_arrival_stages_a_notification() {
+    let mut state = AppState::default();
+    // Departing: a future arrival sets the deadline but is not a completion.
+    state.update_probe(probe_with_movement("2099-01-01T00:00:00+00:00", "cruising"));
+    assert!(state.pending_notifications.is_empty(), "departure is not a completion");
+    // Arriving: the pending arrival is now in the past → notify with the target.
+    state.update_probe(probe_with_movement("2000-01-01T00:00:00+00:00", "arrived"));
+    assert_eq!(
+        state.pending_notifications,
+        vec!["Probe arrived at (1, 2, 3)".to_string()]
+    );
+}
+
+#[test]
+fn manny_long_task_completion_notifies_but_short_and_lag_do_not() {
+    let mut state = AppState::default();
+    // Prime a mining Manny (busy). First roster → no previous to diff against.
+    state.update_mannies(vec![make_manny("m1", "sector", false, Some("mining"))]);
+    assert!(state.pending_notifications.is_empty());
+    // Mining → idle: a long task completed.
+    state.update_mannies(vec![make_manny("m1", "probe", true, None)]);
+    assert_eq!(state.pending_notifications, vec!["m1 finished mining".to_string()]);
+
+    // A short task (moving cargo) completing must not notify.
+    state.pending_notifications.clear();
+    state.update_mannies(vec![make_manny("m2", "probe", false, Some("moving_stockage"))]);
+    state.update_mannies(vec![make_manny("m2", "probe", true, None)]);
+    assert!(state.pending_notifications.is_empty(), "short tasks are not notified");
+
+    // The fire→busy lag (idle → busy) is not a completion.
+    state.pending_notifications.clear();
+    state.update_mannies(vec![make_manny("m3", "probe", true, None)]);
+    state.update_mannies(vec![make_manny("m3", "sector", false, Some("mining"))]);
+    assert!(
+        state.pending_notifications.is_empty(),
+        "starting a task is not a completion"
+    );
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────
 
 fn make_manny(id: &str, location_type: &str, can_receive_orders: bool, task: Option<&str>) -> Manny {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,11 @@ pub struct Config {
     /// straight into the live cockpit (handy over tmux/ssh or on relaunch).
     #[serde(default = "default_true")]
     pub boot: bool,
+    /// Emit a desktop notification (OSC 9 + terminal bell) when a long task
+    /// finishes — travel arrival, a Manny completing a long task. Set `false`
+    /// to stay silent (issue #203).
+    #[serde(default = "default_true")]
+    pub notifications: bool,
 }
 
 fn default_true() -> bool {
@@ -55,6 +60,7 @@ struct RawConfig {
     theme: Option<String>,
     hints: Option<bool>,
     boot: Option<bool>,
+    notifications: Option<bool>,
 }
 
 /// The outcome of inspecting the on-disk config at boot.
@@ -97,6 +103,7 @@ fn load_status_at(path: &std::path::Path) -> ConfigStatus {
         theme: raw.theme,
         hints: raw.hints.unwrap_or(true),
         boot: raw.boot.unwrap_or(true),
+        notifications: raw.notifications.unwrap_or(true),
     })
 }
 
@@ -155,6 +162,7 @@ mod tests {
             theme: theme.map(String::from),
             hints: true,
             boot: true,
+            notifications: true,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app;
 pub mod config;
 pub mod headless;
 pub mod input;
+pub mod notify;
 pub mod preflight;
 pub mod store;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,17 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
             }
         }
 
+        // Desktop notifications staged when a long task completed. Always drain
+        // (so they never accumulate); emit only when the pilot enabled them.
+        if !state.pending_notifications.is_empty() {
+            let staged: Vec<_> = state.pending_notifications.drain(..).collect();
+            if config.notifications {
+                for msg in staged {
+                    neumann_cockpit::notify::desktop_notify(&msg);
+                }
+            }
+        }
+
         // Production queue: advance the executor, then spawn any craft it staged
         // (the event loop owns the client + sender). A fresh mannies fetch lets
         // the next tick detect the craft going busy, then idle → complete.

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,0 +1,22 @@
+//! Desktop notifications for completed long tasks (issue #203).
+//!
+//! Emits an OSC 9 escape sequence — surfaced as a desktop notification by
+//! terminals that support it (iTerm2, WezTerm, ConEmu, kitty via its own
+//! protocol, …) — terminated with ST, followed by a bell as an audible
+//! fallback for terminals that ignore OSC 9. It is the terminal, not the OS,
+//! that decides how to present it, so this is cross-platform by construction.
+
+use std::io::{self, Write};
+
+/// Post a desktop notification carrying `message`. Best-effort: any write or
+/// flush error is ignored (a notification is never worth failing a frame over).
+/// Control characters in `message` are neutralised so they cannot break out of
+/// the escape sequence.
+pub fn desktop_notify(message: &str) {
+    let clean: String = message.chars().map(|c| if c.is_control() { ' ' } else { c }).collect();
+    // OSC 9 ; <text> ST  (notification), then BEL (audible fallback).
+    let seq = format!("\x1b]9;{clean}\x1b\\\x07");
+    let mut out = io::stdout();
+    let _ = out.write_all(seq.as_bytes());
+    let _ = out.flush();
+}

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -248,6 +248,7 @@ async fn onboard(
                             theme: None,
                             hints: true,
                             boot: true,
+                            notifications: true,
                         }));
                     }
                     Err(e) => error = Some(format!("write failed: {e}")),


### PR DESCRIPTION
## Context

Emit a cross-platform desktop notification when a long task finishes (#203). It is the terminal, not the OS, that surfaces it — so OSC 9 (iTerm2, WezTerm, ConEmu…) with a terminal-bell fallback works everywhere.

## Changes

- **`src/notify.rs`** — `desktop_notify(msg)` writes `OSC 9 ; <text> ST` (notification) + `BEL` (audible fallback), sanitising control chars. Best-effort; write errors ignored.
- **Completion detection**:
  - `update_probe` — a pending travel arrival that disappears this sync (arrived / failed / destroyed), with the destination coords.
  - `update_mannies` — a Manny that ran a notable long task last sync and is now idle, diffed by id against the previous roster. `long_task_note` filters out quick/noisy tasks (moving cargo, returning, waiting, inspecting). The fire→busy lag is a None→Some transition, so it never yields a false completion.
- Staged in `AppState::pending_notifications`, drained by the event loop; emitted only when the new **`notifications`** config key is on (default `true`, documented in `config.example.toml` + CLAUDE.md).

## Tests

- Travel: departure is not a completion; arrival stages `Probe arrived at (x, y, z)`.
- Manny: long-task completion notifies; a short task and the idle→busy lag do not.
- `cargo test` (323 passed), `cargo clippy` (clean), `cargo fmt --check` (clean).

## Out of scope

- Runtime toggle key (config-only for now).
- Per-terminal notification-protocol variants beyond OSC 9 (kitty/tmux passthrough).

Closes #203