### PR TITLE
test(api): HTTP-level tests for client.rs error and timeout paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +368,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deltae"
@@ -708,6 +736,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +790,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -790,6 +843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,9 +858,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1277,6 +1338,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "wiremock",
 ]
 
 [[package]]
@@ -1326,6 +1388,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2516,6 +2588,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3330,29 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ toml        = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "1"
+# Local HTTP mock server for client.rs error/timeout tests (offline, no network).
+wiremock = "0.6"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -21,8 +21,25 @@ pub struct ApiClient {
     active_probe_id: Option<u64>,
 }
 
+/// Connect timeout: bound establishing the TCP/TLS connection.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Overall request timeout: bound the whole request/response.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 impl ApiClient {
     pub fn new(base_url: String, api_key: String) -> Result<Self> {
+        Self::build(base_url, api_key, CONNECT_TIMEOUT, REQUEST_TIMEOUT)
+    }
+
+    /// Build a client with explicit timeouts. `new` uses the production values;
+    /// tests inject short ones to exercise the timeout path without a 30 s wait.
+    ///
+    /// reqwest has no default timeout: a half-open connection (suspend/resume,
+    /// wifi dropping mid-request) would otherwise hang a fetch task forever —
+    /// no ApiMessage ever arrives, `loading` stays true, and all three refresh
+    /// paths are gated on `!loading`. Bounding both the connect and the overall
+    /// request means a stuck fetch always fails and frees the refresh loop.
+    fn build(base_url: String, api_key: String, connect_timeout: Duration, timeout: Duration) -> Result<Self> {
         // Identify the client to the game server: app version + platform.
         // e.g. "neumann-cockpit/63.1.0 (linux; x86_64)".
         let user_agent = format!(
@@ -32,15 +49,10 @@ impl ApiClient {
             std::env::consts::ARCH,
         );
 
-        // reqwest has no default timeout: a half-open connection (suspend/resume,
-        // wifi dropping mid-request) would otherwise hang a fetch task forever —
-        // no ApiMessage ever arrives, `loading` stays true, and all three refresh
-        // paths are gated on `!loading`. Bound both the connect and the overall
-        // request so a stuck fetch always fails and frees the refresh loop.
         let client = Client::builder()
             .user_agent(user_agent)
-            .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(30))
+            .connect_timeout(connect_timeout)
+            .timeout(timeout)
             .build()
             .context("Failed to build HTTP client")?;
         let base_url = Url::parse(&base_url).context("Invalid base_url in config")?;
@@ -50,6 +62,13 @@ impl ApiClient {
             api_key,
             active_probe_id: None,
         })
+    }
+
+    /// Test-only constructor with a short overall timeout, for exercising the
+    /// timeout path against a deliberately slow mock server.
+    #[cfg(test)]
+    fn new_with_timeout(base_url: String, api_key: String, timeout: Duration) -> Result<Self> {
+        Self::build(base_url, api_key, timeout, timeout)
     }
 
     /// Return a clone of this client that targets `id` (or the default probe
@@ -912,5 +931,93 @@ mod tests {
         let c = client(None);
         assert_eq!(c.active_probe_id(), None);
         assert_eq!(c.with_active_probe(Some(7)).active_probe_id(), Some(7));
+    }
+
+    // ── HTTP-level error/timeout paths (issue #213) ─────────────────────────
+    // Exercised against a local wiremock server — offline, no network.
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client_for(server: &MockServer) -> ApiClient {
+        ApiClient::new(server.uri(), "vng_test".into()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn unauthorized_maps_to_api_key_hint() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/version"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let err = client_for(&server).get_api_version().await.unwrap_err();
+        assert!(
+            err.to_string().contains("api_key"),
+            "401 should hint at the api_key, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_error_includes_status_and_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/version"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("upstream boom"))
+            .mount(&server)
+            .await;
+        let err = client_for(&server).get_api_version().await.unwrap_err().to_string();
+        assert!(err.contains("500"), "GET error should carry the status: {err}");
+        assert!(err.contains("upstream boom"), "GET error should carry the body: {err}");
+    }
+
+    #[tokio::test]
+    async fn body_error_extracts_json_error_message() {
+        // send_with_body path (PATCH): a JSON `error.message` is surfaced verbatim.
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/api/probe/9"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "error": { "message": "target must be in the same sector" }
+            })))
+            .mount(&server)
+            .await;
+        let err = client_for(&server)
+            .patch_probe(9, Some("Falling Outside"), None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_eq!(err, "target must be in the same sector");
+    }
+
+    #[tokio::test]
+    async fn body_error_without_json_falls_back_to_raw_text() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/api/probe/9"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("plain failure"))
+            .mount(&server)
+            .await;
+        let err = client_for(&server)
+            .patch_probe(9, Some("x"), None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_eq!(err, "plain failure");
+    }
+
+    #[tokio::test]
+    async fn slow_response_times_out_rather_than_hanging() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/version"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(5)))
+            .mount(&server)
+            .await;
+        // A 200 ms overall timeout must fail fast, not wait for the 5 s response.
+        let c = ApiClient::new_with_timeout(server.uri(), "vng_test".into(), Duration::from_millis(200)).unwrap();
+        assert!(
+            c.get_api_version().await.is_err(),
+            "a slow response must time out to an error"
+        );
     }
 }


### PR DESCRIPTION
## Context

`client.rs` had 3 path-building tests and no HTTP integration — the 401 mapping, generic `error.message` extraction, and timeout behaviour were unverified (#213).

## Changes

- Add **`wiremock`** as a dev-dependency: a local mock HTTP server, so the tests run **offline / no network** (CI-safe).
- Refactor `new` to delegate to a private `build(base_url, api_key, connect_timeout, timeout)` (production values kept as consts), plus a `#[cfg(test)]` `new_with_timeout` — so the timeout path can be exercised with a 200 ms bound instead of the real 30 s.
- New tests:
  - `unauthorized_maps_to_api_key_hint` — 401 → error mentions `api_key`.
  - `get_error_includes_status_and_body` — GET 5xx carries status + body.
  - `body_error_extracts_json_error_message` — PATCH 422 with `{"error":{"message":…}}` → surfaced verbatim.
  - `body_error_without_json_falls_back_to_raw_text` — PATCH 5xx plain body → raw text.
  - `slow_response_times_out_rather_than_hanging` — a delayed response fails fast rather than hanging the fetch loop.

## Acceptance

- [x] Tests for 401, generic HTTP error with/without message, and timeout.
- [x] Runs offline in CI (local mock server, no network).

`cargo test` (328 passed), `cargo clippy` (clean).

Closes #213