### PR TITLE
fix(store): surface SQLite writer errors instead of swallowing them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ The database also holds a **telemetry** time series (`telemetry` table, issue #2
 - **ARCHIVE** — `store::open` + `migrate_legacy_json` (reports `MigrationOutcome`: imported N / already migrated / none) + `load_observations`.
 - **REMOTE LINK** — `get_api_version()` under an 8 s timeout, retried interactively: a bad key or outage shows in the Probe pane with actions — `[R]` retry · `[K]` re-enter key (re-runs onboarding) · `[Enter]` continue offline. Continuing enters **degraded mode** (an error toast; `F5` retries), per the API-KO decision.
 
-Once the link is up (or the pilot continues offline), it hands off to `run()`, which builds `AppState`, spawns the persistence writer from the preflight's connection, and plays the cosmetic boot animation that lights the eight subsystems centre-out (see UI › Boot).
+Once the link is up (or the pilot continues offline), it hands off to `run()`, which builds `AppState`, spawns the persistence writer from the preflight's connection, and plays the cosmetic boot animation that lights the eight subsystems centre-out (see UI › Boot). The writer returns a shared `degraded` flag it raises if any write fails (disk full, corruption); it never crashes the thread (keeps draining), and the event loop mirrors the flag into `AppState::persistence_degraded`, surfaced as a `⚠ save failing` status-bar chip (issue #216).
 
 ### Headless script runner (`src/headless.rs`, #198 extension)
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -92,6 +92,10 @@ pub struct AppState {
     pub consecutive_failures: u32,
     pub movement_arrival: Option<DateTime<Utc>>,
     pub error: Option<String>,
+    /// The SQLite writer raised a write failure (disk full, corruption…), so
+    /// history is no longer being saved. Read from the writer's shared flag each
+    /// tick and surfaced as a status-bar warning (issue #216).
+    pub persistence_degraded: bool,
     pub loading: bool,
     pub quit: bool,
     pub mannies_selection: usize,

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -84,7 +84,9 @@ pub async fn run(path: &Path) -> Result<i32> {
         }
         Err(_) => (None, Vec::new()),
     };
-    let persist_tx = conn.map(store::spawn_writer);
+    // Headless does not surface the degraded flag (no status bar); the writer
+    // still survives failing writes. Keep only the sender.
+    let persist_tx = conn.map(|c| store::spawn_writer(c).0);
 
     let (tx, mut rx) = mpsc::channel::<ApiMessage>(32);
     let mut state = AppState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,8 +119,12 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
         state.set_error("remote link down — press F5 to retry".into());
     }
     // The persistence writer takes the connection opened during preflight; on a
-    // DB error there we run without persistence (history already empty).
-    let persist_tx = conn.map(store::spawn_writer);
+    // DB error there we run without persistence (history already empty). It also
+    // hands back a `degraded` flag it raises if a write ever fails (issue #216).
+    let (persist_tx, persist_degraded) = match conn.map(store::spawn_writer) {
+        Some((tx, degraded)) => (Some(tx), Some(degraded)),
+        None => (None, None),
+    };
     let mut events = EventStream::new();
 
     // Short-lived tick that drives the boot assembly; runs only while booting.
@@ -140,6 +144,11 @@ async fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, ready: prefl
     state.loading = true;
 
     loop {
+        // Surface a persistence failure raised by the writer thread (#216).
+        if let Some(degraded) = &persist_degraded {
+            state.persistence_degraded = degraded.load(std::sync::atomic::Ordering::Relaxed);
+        }
+
         // Drain ship's-log entries staged by the previous tick's handlers:
         // persist each and prepend to the in-memory journal (newest first,
         // capped), mirroring how sector observations are persisted.

--- a/src/store.rs
+++ b/src/store.rs
@@ -15,7 +15,9 @@
 //! stats; only the most recent [`JOURNAL_WINDOW`] rows are loaded into memory.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use rusqlite::Connection;
@@ -318,32 +320,64 @@ pub fn migrate_legacy_json(conn: &mut Connection, json_path: &Path) -> rusqlite:
 }
 
 /// Spawn the writer thread, taking ownership of the connection, and return the
-/// channel to send persistence messages on. `rusqlite` is synchronous, so the
-/// writes run off the tokio runtime on this dedicated thread. Write errors are
-/// best-effort (dropped) until the tracing work lands.
-pub fn spawn_writer(conn: Connection) -> Sender<PersistMsg> {
+/// channel to send persistence messages on plus a shared `degraded` flag.
+/// `rusqlite` is synchronous, so the writes run off the tokio runtime on this
+/// dedicated thread.
+///
+/// A failing write (disk full, corruption, read-only fs) does **not** crash the
+/// thread — it keeps draining so the app never blocks on a full channel — but it
+/// sets the `degraded` flag so the cockpit can warn the pilot that history is no
+/// longer being saved (issue #216). The flag is sticky: once set it stays set
+/// for the session (a single failure means the DB is unhealthy).
+pub fn spawn_writer(conn: Connection) -> (Sender<PersistMsg>, Arc<AtomicBool>) {
     let (tx, rx): (Sender<PersistMsg>, Receiver<PersistMsg>) = mpsc::channel();
+    let degraded = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&degraded);
     std::thread::spawn(move || {
         for msg in rx {
-            match msg {
-                PersistMsg::UpsertObservation(obs) => {
-                    let _ = upsert_observation(&conn, &obs);
-                }
-                PersistMsg::AppendEvent(ev) => {
-                    let _ = append_event(&conn, &ev);
-                }
-                PersistMsg::AppendTelemetry(s) => {
-                    let _ = append_telemetry(&conn, &s);
-                }
+            let result = match msg {
+                PersistMsg::UpsertObservation(obs) => upsert_observation(&conn, &obs),
+                PersistMsg::AppendEvent(ev) => append_event(&conn, &ev),
+                PersistMsg::AppendTelemetry(s) => append_telemetry(&conn, &s),
+            };
+            if result.is_err() {
+                flag.store(true, Ordering::Relaxed);
             }
         }
     });
-    tx
+    (tx, degraded)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn writer_flags_degraded_on_failure_and_keeps_draining() {
+        // A schema-less connection: every INSERT hits a missing table and errors.
+        let conn = Connection::open_in_memory().unwrap();
+        let (tx, degraded) = spawn_writer(conn);
+
+        tx.send(PersistMsg::AppendEvent(LogEvent::action("test", "one", None)))
+            .unwrap();
+        // Wait for the writer to process it and raise the flag (bounded poll).
+        let mut set = false;
+        for _ in 0..200 {
+            if degraded.load(Ordering::Relaxed) {
+                set = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(set, "a failing write must set the degraded flag");
+
+        // The thread survived: it is still draining, so a further send succeeds.
+        assert!(
+            tx.send(PersistMsg::AppendEvent(LogEvent::action("test", "two", None)))
+                .is_ok(),
+            "writer thread must survive a failing write and keep draining"
+        );
+    }
 
     fn obs(x: f64, y: f64, z: f64) -> SectorObservation {
         serde_json::from_str(&format!(

--- a/src/ui/cockpit_v2/mod.rs
+++ b/src/ui/cockpit_v2/mod.rs
@@ -352,6 +352,14 @@ fn render_status_line(frame: &mut Frame, area: Rect, state: &AppState, p: Palett
         };
         meta.push((label, style));
     }
+    // Persistence degraded: the SQLite writer hit a failing write, so history
+    // is no longer being saved (issue #216). Warn, bold, so it stands out.
+    if state.persistence_degraded {
+        meta.push((
+            "⚠ save failing".to_string(),
+            Style::default().fg(p.warn).add_modifier(Modifier::BOLD),
+        ));
+    }
     let unread = state.unread_alert_count();
     if unread > 0 {
         // Urgency signal: crit_style survives the mono palettes (bold+REVERSED).


### PR DESCRIPTION
## Context

`spawn_writer` discarded every write result (`let _ = upsert_observation(...)` / `append_event(...)` / `append_telemetry(...)`), so a persistently failing write — disk full, corruption, read-only fs — was completely invisible; the comment marked it provisional (#216).

## Changes

- `spawn_writer` now checks each write and, on error, raises a shared **sticky `degraded` flag** (`Arc<AtomicBool>`) it returns alongside the sender. It **keeps draining** the channel on failure — the thread never crashes, so the app never blocks on a full queue.
- The event loop mirrors the flag into `AppState::persistence_degraded` each tick; the status bar shows a bold `⚠ save failing` warn chip when set.
- Headless keeps only the sender (no status bar to surface it), still benefiting from the survive-on-failure behaviour.

## Design notes

- The flag is **sticky** (once set, stays set for the session): a single write failure means the DB is unhealthy, and we don't want the warning to flap.
- No stderr logging: the TUI owns the alternate screen, so a stderr write would corrupt the display — the status-bar chip is the observable surface instead.

## Tests

- `writer_flags_degraded_on_failure_and_keeps_draining`: a schema-less connection makes every INSERT fail; the flag is raised and a subsequent send still succeeds (thread survived).
- `cargo test` (329 passed), `cargo clippy` (clean), `cargo fmt --check` (clean).

## Acceptance

- [x] Write failures are observable to the pilot (`⚠ save failing` chip).
- [x] Writer thread survives a failing write and continues draining.

Closes #216