### PR TITLE
feat(storage): detach a container by attaching it to another probe (API v91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ The four reused panels (Probe / Inventory / Scanner / Mannies) keep their intern
 | `/api/probe/mannies/{id}/install-bookmark` | POST | ✓ |
 | `/api/probe/mannies/{id}/inspect-sector-object` | POST | ✓ |
 | `/api/probe/mannies/{id}/recover-storage-container` | POST | ✓ |
-| `/api/probe/mannies/{id}/detach-storage-container` | POST | ✓ |
+| `/api/probe/mannies/{id}/detach-storage-container` | POST | ✓ (modes: drifting · hidden_on_asteroid · attach_to_probe (v91)) |
 | `/api/probe/mannies/{id}/drop-manny-cargo` | POST | ✓ |
 | `/api/probe/inventory/{id}/jettison` | POST | ✓ |
 | `/api/probe/atomic-printer/craft` | POST | ✓ |

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -86,9 +86,10 @@ pub const RESOURCE_TYPES: [&str; 4] = ["deuterium", "metals", "ice", "carbon_com
 
 pub const RESOURCE_LABELS: [&str; 4] = ["deuterium", "metals", "ice", "carbon"];
 
-pub const DETACH_MODES: [(&str, &str); 2] = [
+pub const DETACH_MODES: [(&str, &str); 3] = [
     ("drifting", "drifting — leave in sector"),
     ("hidden_on_asteroid", "hidden — attach to asteroid"),
+    ("attach_to_probe", "attach — to another probe"),
 ];
 
 pub enum ObjectActionInput {
@@ -600,6 +601,17 @@ pub enum DetachInput {
         container_id: String,
         container_name: String,
         asteroids: Vec<(String, String)>,
+        selection: usize,
+        error: Option<String>,
+    },
+    /// `attach_to_probe` mode (API v91): pick another owned probe in the same
+    /// sector to reattach the container (and its contents) to.
+    PickTargetProbe {
+        manny_id: String,
+        manny_name: String,
+        container_id: String,
+        container_name: String,
+        probes: Vec<(u64, String)>,
         selection: usize,
         error: Option<String>,
     },

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -102,6 +102,14 @@ impl LogEvent {
         )
     }
 
+    pub fn attach_container_to_probe(container: &str, target: &str, probe_id: Option<u64>) -> Self {
+        Self::action(
+            kind::CONTAINER,
+            format!("Detached container «{container}» to reattach to probe «{target}»."),
+            probe_id,
+        )
+    }
+
     /// "Installed waypoint «name»."
     pub fn deploy_waypoint(name: &str, probe_id: Option<u64>) -> Self {
         Self::action(kind::WAYPOINT, format!("Installed waypoint «{name}»."), probe_id)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -434,9 +434,11 @@ impl AppState {
             ActiveWizard::Messages(MessagesInput::Compose { error, .. }) => Some(error),
             ActiveWizard::Deploy(DeployInput::EnterName { error, .. }) => Some(error),
             ActiveWizard::RenameManny(RenameMannyInput::Typing { error, .. }) => Some(error),
-            ActiveWizard::Detach(DetachInput::PickMode { error, .. } | DetachInput::PickAsteroid { error, .. }) => {
-                Some(error)
-            }
+            ActiveWizard::Detach(
+                DetachInput::PickMode { error, .. }
+                | DetachInput::PickAsteroid { error, .. }
+                | DetachInput::PickTargetProbe { error, .. },
+            ) => Some(error),
             ActiveWizard::RemoteMine(
                 RemoteMineInput::Configure { error, .. } | RemoteMineInput::PickContainer { error, .. },
             ) => Some(error),

--- a/src/app/script.rs
+++ b/src/app/script.rs
@@ -427,7 +427,10 @@ impl AppState {
                 } else {
                     mode.join("")
                 };
-                if !DETACH_MODES.iter().any(|(m, _)| *m == mode) {
+                // Scripts support only the modes whose target resolves from the
+                // line; attach_to_probe (v91) needs a probe picker, so it stays
+                // interactive-only for now.
+                if mode != "drifting" && mode != "hidden_on_asteroid" {
                     return Err("detach: mode must be drifting or hidden_on_asteroid".into());
                 }
                 let object_id = if mode == "hidden_on_asteroid" {

--- a/src/input/pickers.rs
+++ b/src/input/pickers.rs
@@ -513,6 +513,11 @@ pub(super) fn handle_detach_event(
                 return;
             }
         }
+        ActiveWizard::Detach(DetachInput::PickTargetProbe { selection, probes, .. }) => {
+            if list_move(code, selection, probes.len()) {
+                return;
+            }
+        }
         _ => {}
     }
     match &state.active_wizard {
@@ -566,36 +571,54 @@ pub(super) fn handle_detach_event(
                         *selection,
                     )
                 };
-                let mode = DETACH_MODES[sel].0;
-                if mode == "hidden_on_asteroid" {
-                    let asteroids = state.collect_asteroid_candidates();
-                    if asteroids.is_empty() {
-                        state.set_wizard_error("no asteroids in current sector — scan first".into());
-                    } else {
-                        state.active_wizard = ActiveWizard::Detach(DetachInput::PickAsteroid {
-                            manny_id,
-                            manny_name,
-                            container_id,
-                            container_name,
-                            asteroids,
-                            selection: 0,
-                            error: None,
-                        });
+                match DETACH_MODES[sel].0 {
+                    "hidden_on_asteroid" => {
+                        let asteroids = state.collect_asteroid_candidates();
+                        if asteroids.is_empty() {
+                            state.set_wizard_error("no asteroids in current sector — scan first".into());
+                        } else {
+                            state.active_wizard = ActiveWizard::Detach(DetachInput::PickAsteroid {
+                                manny_id,
+                                manny_name,
+                                container_id,
+                                container_name,
+                                asteroids,
+                                selection: 0,
+                                error: None,
+                            });
+                        }
                     }
-                } else {
-                    fetch_detach(
-                        manny_id,
-                        container_id,
-                        "drifting".into(),
-                        None,
-                        client.clone(),
-                        tx.clone(),
-                    );
-                    state.log_event(LogEvent::detach_container(
-                        &container_name,
-                        false,
-                        state.active_probe_id,
-                    ));
+                    "attach_to_probe" => {
+                        let probes = state.other_fleet_probes();
+                        if probes.is_empty() {
+                            state.set_wizard_error("no other probe in the fleet".into());
+                        } else {
+                            state.active_wizard = ActiveWizard::Detach(DetachInput::PickTargetProbe {
+                                manny_id,
+                                manny_name,
+                                container_id,
+                                container_name,
+                                probes,
+                                selection: 0,
+                                error: None,
+                            });
+                        }
+                    }
+                    _ => {
+                        fetch_detach(
+                            manny_id,
+                            container_id,
+                            "drifting".into(),
+                            None,
+                            client.clone(),
+                            tx.clone(),
+                        );
+                        state.log_event(LogEvent::detach_container(
+                            &container_name,
+                            false,
+                            state.active_probe_id,
+                        ));
+                    }
                 }
             }
             _ => {}
@@ -631,6 +654,46 @@ pub(super) fn handle_detach_event(
                     tx.clone(),
                 );
                 state.log_event(LogEvent::detach_container(&container_name, true, state.active_probe_id));
+            }
+            _ => {}
+        },
+        ActiveWizard::Detach(DetachInput::PickTargetProbe { .. }) => match code {
+            KeyCode::Esc => state.close_wizard(),
+            KeyCode::Enter => {
+                let (manny_id, container_id, target_id, target_name, container_name) = {
+                    let ActiveWizard::Detach(DetachInput::PickTargetProbe {
+                        manny_id,
+                        container_id,
+                        container_name,
+                        probes,
+                        selection,
+                        ..
+                    }) = &state.active_wizard
+                    else {
+                        return;
+                    };
+                    let (tid, tname) = probes[*selection].clone();
+                    (
+                        manny_id.clone(),
+                        container_id.clone(),
+                        tid,
+                        tname,
+                        container_name.clone(),
+                    )
+                };
+                fetch_detach(
+                    manny_id,
+                    container_id,
+                    "attach_to_probe".into(),
+                    Some(target_id.to_string()),
+                    client.clone(),
+                    tx.clone(),
+                );
+                state.log_event(LogEvent::attach_container_to_probe(
+                    &container_name,
+                    &target_name,
+                    state.active_probe_id,
+                ));
             }
             _ => {}
         },

--- a/src/ui/overlays/pickers.rs
+++ b/src/ui/overlays/pickers.rs
@@ -672,5 +672,32 @@ pub(crate) fn render_detach_overlay(frame: &mut Frame, area: Rect, state: &AppSt
                 "HIDE HERE",
             );
         }
+
+        DetachInput::PickTargetProbe {
+            manny_name,
+            container_name,
+            probes,
+            selection,
+            error,
+            ..
+        } => {
+            let labels: Vec<String> = probes.iter().map(|(id, n)| format!("{n}  ·  #{id}")).collect();
+            let names: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+            let height = (probes.len() as u16 + 8).min(18);
+            let prompt = format!("Attach to probe  (manny: {manny_name})");
+            render_pick_list(
+                frame,
+                area,
+                p,
+                &format!(" DETACH — {container_name} → probe "),
+                52,
+                height,
+                Some(&prompt),
+                &names,
+                *selection,
+                error.as_deref(),
+                "ATTACH",
+            );
+        }
     }
 }

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -10,7 +10,7 @@ use ratatui::buffer::Buffer;
 use ratatui::Terminal;
 
 use crate::api::types::Probe;
-use crate::app::{ActiveWizard, AppState, ColorMode, ContainerRulesInput, Pane, TransferProbeInput};
+use crate::app::{ActiveWizard, AppState, ColorMode, ContainerRulesInput, DetachInput, Pane, TransferProbeInput};
 use crate::ui::theme::{palette, ratio_color};
 
 /// Flatten a rendered buffer to text, one line per row, for `contains` checks.
@@ -157,4 +157,23 @@ fn transfer_probe_overlay_lists_targets() {
         text.contains("Falling Outside") && text.contains("Sleeper Service"),
         "targets listed"
     );
+}
+
+#[test]
+fn detach_attach_to_probe_overlay_lists_target_probes() {
+    // attach_to_probe detach mode (API v91): the target-probe picker renders.
+    let mut state = AppState::default();
+    state.active_wizard = ActiveWizard::Detach(DetachInput::PickTargetProbe {
+        manny_id: "m1".into(),
+        manny_name: "Grey Area".into(),
+        container_id: "c1".into(),
+        container_name: "cargo-hold-2".into(),
+        probes: vec![(2, "Falling Outside".into())],
+        selection: 0,
+        error: None,
+    });
+    let text = buffer_text(&render_cockpit(&state, 90, 24));
+    assert!(text.contains("cargo-hold-2"), "container named");
+    assert!(text.contains("Attach to probe"), "prompt shown");
+    assert!(text.contains("Falling Outside"), "target probe listed");
 }


### PR DESCRIPTION
## Context

Phase 2 of the API v96 catch-up (#238): the **`attach_to_probe`** detach mode (v91).

## Changes

The detach wizard's mode step now offers a third option — **"attach — to another probe"**. Choosing it opens a target-probe picker (`DetachInput::PickTargetProbe`) listing the other fleet probes (`other_fleet_probes`), and `Enter` fires `detach-storage-container` with `mode=attach_to_probe` and `objectId=<target probe id>`, reattaching the container and its contents to that probe once the task completes.

- `DETACH_MODES` gains the mode; new `PickTargetProbe` step + overlay picker; `set_wizard_error` covers it; a captain's-log entry (`attach_container_to_probe`).
- The `ApiClient::detach_storage_container` wrapper already took a generic `mode`/`objectId`, so no client change was needed.
- **Scripts** stay restricted to `drifting`/`hidden_on_asteroid` — `attach_to_probe` needs the interactive probe picker, so the scripted path rejects it with a clear error rather than firing without a target.

The same-sector requirement is server-validated.

## Tests

- `detach_attach_to_probe_overlay_lists_target_probes` (TestBackend): the picker renders the container, prompt, and target probe.
- `cargo test` (335 passed), `cargo clippy` (clean), `cargo fmt --check` (clean).

Part of #238.