### PR TITLE
fix(mannies): label the transfer/install/assemble task states (API v81/v86/v93/v96)

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -68,6 +68,14 @@ pub enum MannyTask {
     InspectingAsteroid,
     InspectingSectorObject,
     ImprovingProbe,
+    /// Ferrying deuterium to another fleet probe (API v86).
+    TransferringDeuteriumToProbe,
+    /// Transferring the Manny itself to another fleet probe (API v93).
+    TransferringToProbe,
+    /// Equipping an active SCUT relay with a transit beacon (API v96).
+    InstallingScutTransitBeacon,
+    /// Assembling a new probe from two additional containers (API v81).
+    AssemblingProbe,
     Returning,
     WaitingForSpace,
     MovingStockage,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -58,6 +58,10 @@ fn long_task_note(task: &crate::api::types::MannyTask) -> Option<&'static str> {
         MannyTask::InstallingWaypointBookmark => "installing a waypoint",
         MannyTask::RefillingDeuteriumTank => "refueling",
         MannyTask::TurningOnScutRelay => "activating a relay",
+        MannyTask::TransferringDeuteriumToProbe => "a deuterium transfer",
+        MannyTask::TransferringToProbe => "transferring to a probe",
+        MannyTask::InstallingScutTransitBeacon => "installing a transit beacon",
+        MannyTask::AssemblingProbe => "assembling a probe",
         _ => return None,
     })
 }

--- a/src/ui/panels/mannies.rs
+++ b/src/ui/panels/mannies.rs
@@ -66,6 +66,10 @@ pub(crate) fn manny_task_label(task: Option<&MannyTask>) -> &'static str {
         Some(MannyTask::InspectingAsteroid) => "inspecting",
         Some(MannyTask::InspectingSectorObject) => "inspecting",
         Some(MannyTask::ImprovingProbe) => "improving probe",
+        Some(MannyTask::TransferringDeuteriumToProbe) => "transferring deuterium",
+        Some(MannyTask::TransferringToProbe) => "transferring to probe",
+        Some(MannyTask::InstallingScutTransitBeacon) => "installing beacon",
+        Some(MannyTask::AssemblingProbe) => "assembling probe",
         Some(MannyTask::Returning) => "returning",
         Some(MannyTask::WaitingForSpace) => "waiting for space",
         Some(MannyTask::MovingStockage) => "moving cargo",
@@ -326,6 +330,22 @@ mod tests {
         assert_eq!(truncate_ellipsis("Battery pack", 5), "Batt…");
         assert_eq!(truncate_ellipsis("Battery pack", 1), "…");
         assert_eq!(truncate_ellipsis("Battery pack", 0), "");
+    }
+
+    #[test]
+    fn new_v96_task_states_have_labels_not_placeholder() {
+        use super::manny_task_label;
+        use crate::api::types::MannyTask;
+        for (raw, expected) in [
+            ("transferring_deuterium_to_probe", "transferring deuterium"),
+            ("transferring_to_probe", "transferring to probe"),
+            ("installing_scut_transit_beacon", "installing beacon"),
+            ("assembling_probe", "assembling probe"),
+        ] {
+            let task: MannyTask = serde_json::from_str(&format!("\"{raw}\"")).unwrap();
+            assert_ne!(task, MannyTask::Unknown, "{raw} must not fall back to Unknown");
+            assert_eq!(manny_task_label(Some(&task)), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Context

Found while wrapping up the v96 catch-up (#238): the `MannyTask` enum was missing four task states the server actually sends, so a Manny running any of them deserialized to the `Unknown` fallback and displayed a bare **"?"** in the Mannies list / overview / detail:

- `transferring_deuterium_to_probe` (v86)
- `transferring_to_probe` (v93 — the action we just added)
- `installing_scut_transit_beacon` (v96 — likewise)
- `assembling_probe` (v81)

## Changes

- Add the four variants to `MannyTask` (serde snake_case matches the spec enum).
- `manny_task_label`: "transferring deuterium" / "transferring to probe" / "installing beacon" / "assembling probe".
- `long_task_note`: recognise them so their completion raises a desktop notification (#203) instead of being silently skipped.

No behavioural change beyond display + notification — these are all long tasks that were already running server-side; the cockpit just showed "?" for them.

## Tests

- `new_v96_task_states_have_labels_not_placeholder`: each raw value deserializes to a real variant (not `Unknown`) with the expected label.
- `cargo test` (339 passed), `cargo clippy` (clean), `cargo fmt --check` (clean).

Part of #238.