### PR TITLE
feat(diagnostics): server latency & health diagnostic report (headless MVP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ cargo build          # debug build
 cargo build --release
 cargo run            # run the TUI (requires config, see below)
 cargo run -- --script run.ncs   # headless: play an action script, no TUI (see Headless)
+cargo run -- --diagnostic       # headless: API latency/health report to stdout (see Diagnostics)
 cargo clippy         # lints
 cargo test           # unit tests (app, input, store, client) + TestBackend render tests (ui/tests.rs) + serde fixtures (tests/)
 ```
@@ -57,6 +58,12 @@ Once the link is up (or the pilot continues offline), it hands off to `run()`, w
 ### Headless script runner (`src/headless.rs`, #198 extension)
 
 `main()` checks `headless::script_arg(argv)` **before** touching the terminal: `--script <file>` / `-s <file>` / `--script=<file>` runs `headless::run()` and `process::exit`s with its code; a bare launch is the interactive cockpit, unchanged. The runner plays an action script from a file with **no TUI**: it loads the config non-interactively (no key onboarding — errors to stderr), opens the same SQLite DB, `fetch_all`s and waits until the probe + mannies rosters are primed, then parses the file (one command per line; blank lines and `#` comments skipped) via `parse_script_line` and runs it through the **same** `advance_script` executor (sequential, fork/join, late binding). It reuses the cockpit's `fetch_*` spawners and a minimal `ApiMessage` dispatch (refresh `probe`/`mannies`/`sector`; route the six MVP verb errors to `script_note_error`). Ship's-log entries are streamed to stdout (`HH:MM:SS » narrated summary`, plus `✓`/`✗` per step and a final status line) **and** persisted to the `events` table, so a headless run appears in the next TUI session's ship's log. Exit code: `0` on completion, `1` if the script halted on an error. This is the first non-TUI surface; #229 tracks a headless **status** mode sharing the same seams.
+
+### API diagnostics (`src/api/metrics.rs` + `headless::run_diagnostic`, #247)
+
+Every `ApiClient` send path (`get` / `send_with_body`) is instrumented: it times the `send()`, classifies the outcome (2xx / HTTP error / transport error / timeout via `reqwest::Error::is_timeout`), and records a `RequestSample { label, elapsed_ms, status, timed_out, ok }` into a bounded in-memory ring (`Metrics`, `RING_CAP` 1024) shared across every clone through `Arc<Mutex<_>>` (so `with_active_probe` clones and per-task clones all feed one ring — `ApiClient::metrics()` hands out the handle). `endpoint_label(method, path)` collapses numeric path segments to `:id` and drops the query string so requests aggregate per endpoint; `Metrics::aggregate()` yields per-label `{count, p50, p95, max, errors, timeouts}` (nearest-rank percentiles), sorted slowest-p95 first. Purely client-side — no server endpoint.
+
+The **MVP surface is headless** (the in-cockpit overlay is the deferred follow-up): `main()` checks `headless::diagnostic_arg(argv)` before the terminal — `--diagnostic` / `--diagnostic=N` / `--status latency` (the #229 alias), default `DEFAULT_DIAGNOSTIC_ROUNDS` (3) — and runs `headless::run_diagnostic(rounds)`. It fires N bursts of the **read-only** endpoints (`probe_endpoints`: version, probes, probe, mannies, sector, alerts, damage-warnings, missions, improvements, visited-sectors, crafting-recipes — no mutations, safe anytime), then prints the aggregate as a fixed-width table (copy-pasteable into a bug report) with a `⚠` on any p95 over `SLOW_THRESHOLD_MS` (1000 ms) and a session summary. Exit `0`, or `1` only when every request failed. Persistence to a SQLite `diagnostics` table (cross-session, mirroring the telemetry series #201) is deferred to the overlay follow-up.
 
 ### Event loop (`src/main.rs`)
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,3 +1,4 @@
+use super::metrics::{endpoint_label, Metrics, MetricsHandle, RequestSample};
 use super::types::{
     ContainerInventory, CraftingRecipe, DamageWarningRule, EndpointId, Manny, Mission, Pagination, Probe, ProbeAlert,
     ProbeImprovement, ProbeInventory, ProbeListResponse, ProbeMessage, ProbeMovement, ProbeSentMessage, ScutNetwork,
@@ -6,13 +7,16 @@ use super::types::{
 use anyhow::{Context, Result};
 use reqwest::{Client, StatusCode, Url};
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(Clone)]
 pub struct ApiClient {
     client: Client,
     base_url: Url,
     api_key: String,
+    /// Shared request-instrumentation ring (#247). An `Arc`, so every clone —
+    /// including `with_active_probe` — records into the same ring.
+    metrics: MetricsHandle,
     /// The probe every per-probe endpoint targets. `None` means the player's
     /// default probe and reproduces the pre-v81 paths (`/api/probe/…`) exactly;
     /// `Some(id)` targets a specific probe via the `/api/probe/{id}/…` mirrors
@@ -61,7 +65,28 @@ impl ApiClient {
             base_url,
             api_key,
             active_probe_id: None,
+            metrics: Metrics::handle(),
         })
+    }
+
+    /// A handle onto the shared instrumentation ring, for the diagnostic report.
+    pub fn metrics(&self) -> MetricsHandle {
+        self.metrics.clone()
+    }
+
+    /// Record one request sample into the shared ring. Best-effort: a poisoned
+    /// lock is ignored rather than propagated (instrumentation must never break
+    /// a request path).
+    fn record(&self, label: String, elapsed: Duration, status: Option<u16>, timed_out: bool) {
+        if let Ok(mut m) = self.metrics.lock() {
+            m.record(RequestSample {
+                label,
+                elapsed_ms: elapsed.as_secs_f64() * 1000.0,
+                status,
+                timed_out,
+                ok: status.map(|s| (200..300).contains(&s)).unwrap_or(false),
+            });
+        }
     }
 
     /// Test-only constructor with a short overall timeout, for exercising the
@@ -108,14 +133,21 @@ impl ApiClient {
         path: &str,
         body: &B,
     ) -> Result<T> {
-        let resp = self
+        let label = endpoint_label(method.as_str(), path);
+        let start = Instant::now();
+        let sent = self
             .client
             .request(method.clone(), self.url(path))
             .bearer_auth(&self.api_key)
             .json(body)
             .send()
-            .await
-            .with_context(|| format!("{method} {path}"))?;
+            .await;
+        let (status_code, timed_out) = match &sent {
+            Ok(r) => (Some(r.status().as_u16()), false),
+            Err(e) => (None, e.is_timeout()),
+        };
+        self.record(label, start.elapsed(), status_code, timed_out);
+        let resp = sent.with_context(|| format!("{method} {path}"))?;
 
         let status = resp.status();
         if status == StatusCode::UNAUTHORIZED {
@@ -144,13 +176,15 @@ impl ApiClient {
     }
 
     async fn get<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T> {
-        let resp = self
-            .client
-            .get(self.url(path))
-            .bearer_auth(&self.api_key)
-            .send()
-            .await
-            .with_context(|| format!("GET {path}"))?;
+        let label = endpoint_label("GET", path);
+        let start = Instant::now();
+        let sent = self.client.get(self.url(path)).bearer_auth(&self.api_key).send().await;
+        let (status_code, timed_out) = match &sent {
+            Ok(r) => (Some(r.status().as_u16()), false),
+            Err(e) => (None, e.is_timeout()),
+        };
+        self.record(label, start.elapsed(), status_code, timed_out);
+        let resp = sent.with_context(|| format!("GET {path}"))?;
 
         let status = resp.status();
         if status == StatusCode::UNAUTHORIZED {
@@ -1059,5 +1093,60 @@ mod tests {
             c.get_api_version().await.is_err(),
             "a slow response must time out to an error"
         );
+    }
+
+    #[tokio::test]
+    async fn successful_request_records_a_sample() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/version"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"apiVersion": 96})))
+            .mount(&server)
+            .await;
+        let c = client_for(&server);
+        c.get_api_version().await.unwrap();
+
+        let m = c.metrics();
+        let m = m.lock().unwrap();
+        assert_eq!(m.len(), 1);
+        let agg = m.aggregate();
+        assert_eq!(agg[0].label, "GET /api/version");
+        assert_eq!(agg[0].errors, 0);
+        assert_eq!(agg[0].timeouts, 0);
+    }
+
+    #[tokio::test]
+    async fn timeout_is_recorded_as_a_timeout_sample() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/version"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(5)))
+            .mount(&server)
+            .await;
+        let c = ApiClient::new_with_timeout(server.uri(), "vng_test".into(), Duration::from_millis(200)).unwrap();
+        let _ = c.get_api_version().await;
+
+        let m = c.metrics();
+        let m = m.lock().unwrap();
+        assert_eq!(m.total_timeouts(), 1);
+        assert_eq!(m.total_errors(), 1, "a timeout counts as an error (no 2xx)");
+        assert_eq!(m.aggregate()[0].timeouts, 1);
+    }
+
+    #[tokio::test]
+    async fn clones_share_the_metrics_ring() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/version"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"apiVersion": 96})))
+            .mount(&server)
+            .await;
+        let c = client_for(&server);
+        let clone = c.with_active_probe(Some(7));
+        c.get_api_version().await.unwrap();
+        clone.get_api_version().await.unwrap();
+
+        // Both requests land in the same shared ring.
+        assert_eq!(c.metrics().lock().unwrap().len(), 2);
     }
 }

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -1,0 +1,205 @@
+//! Client-side request instrumentation (#247).
+//!
+//! Every `ApiClient` send path records a [`RequestSample`] into a bounded,
+//! in-memory ring shared across clones (behind `Arc<Mutex<_>>`). [`Metrics`]
+//! aggregates the ring into per-endpoint latency percentiles and error/timeout
+//! counts — the data behind the headless `--diagnostic` report and, later, the
+//! in-cockpit diagnostics overlay. Purely client-side: no server endpoint.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+/// Bound on retained samples. A diagnostic burst is a few dozen requests; a
+/// long cockpit session stays well under this. Oldest samples drop first.
+const RING_CAP: usize = 1024;
+
+/// A shared metrics ring: cheap to clone (an `Arc`), so every `ApiClient` clone
+/// records into the same ring.
+pub type MetricsHandle = Arc<Mutex<Metrics>>;
+
+/// One recorded request: the normalized endpoint label, how long the `send()`
+/// took, the HTTP status (absent when no response arrived), and whether the
+/// failure was a timeout.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RequestSample {
+    pub label: String,
+    pub elapsed_ms: f64,
+    /// `None` when no response arrived (timeout or transport error).
+    pub status: Option<u16>,
+    pub timed_out: bool,
+    /// A 2xx response.
+    pub ok: bool,
+}
+
+/// Aggregated stats for one endpoint label over the retained samples.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EndpointStats {
+    pub label: String,
+    pub count: usize,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub max_ms: f64,
+    /// Requests that did not return a 2xx (HTTP errors + transport failures).
+    pub errors: usize,
+    pub timeouts: usize,
+}
+
+/// A bounded ring of request samples.
+#[derive(Default)]
+pub struct Metrics {
+    ring: VecDeque<RequestSample>,
+}
+
+impl Metrics {
+    /// A shared, empty ring.
+    pub fn handle() -> MetricsHandle {
+        Arc::new(Mutex::new(Metrics::default()))
+    }
+
+    /// Record one sample, evicting the oldest when full.
+    pub fn record(&mut self, sample: RequestSample) {
+        if self.ring.len() == RING_CAP {
+            self.ring.pop_front();
+        }
+        self.ring.push_back(sample);
+    }
+
+    pub fn len(&self) -> usize {
+        self.ring.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ring.is_empty()
+    }
+
+    /// Total requests that failed (no 2xx) across every endpoint.
+    pub fn total_errors(&self) -> usize {
+        self.ring.iter().filter(|s| !s.ok).count()
+    }
+
+    /// Total requests that timed out across every endpoint.
+    pub fn total_timeouts(&self) -> usize {
+        self.ring.iter().filter(|s| s.timed_out).count()
+    }
+
+    /// Per-endpoint aggregate, one entry per label, sorted by descending p95
+    /// (slowest first — what a bug report leads with).
+    pub fn aggregate(&self) -> Vec<EndpointStats> {
+        let mut by_label: std::collections::BTreeMap<&str, Vec<&RequestSample>> = std::collections::BTreeMap::new();
+        for s in &self.ring {
+            by_label.entry(s.label.as_str()).or_default().push(s);
+        }
+        let mut stats: Vec<EndpointStats> = by_label
+            .into_iter()
+            .map(|(label, samples)| {
+                let mut lat: Vec<f64> = samples.iter().map(|s| s.elapsed_ms).collect();
+                lat.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                EndpointStats {
+                    label: label.to_string(),
+                    count: samples.len(),
+                    p50_ms: percentile(&lat, 50.0),
+                    p95_ms: percentile(&lat, 95.0),
+                    max_ms: lat.last().copied().unwrap_or(0.0),
+                    errors: samples.iter().filter(|s| !s.ok).count(),
+                    timeouts: samples.iter().filter(|s| s.timed_out).count(),
+                }
+            })
+            .collect();
+        stats.sort_by(|a, b| b.p95_ms.partial_cmp(&a.p95_ms).unwrap_or(std::cmp::Ordering::Equal));
+        stats
+    }
+}
+
+/// Nearest-rank percentile over an already-sorted slice (empty → 0). `p` is a
+/// percentage in `0..=100`.
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let rank = (p / 100.0 * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+/// Normalize a request into an aggregation label: `METHOD /path` with numeric
+/// path segments collapsed to `:id` and any query string dropped, so requests
+/// to the same endpoint with different ids aggregate together.
+pub fn endpoint_label(method: &str, path: &str) -> String {
+    let path = path.split('?').next().unwrap_or(path);
+    let normalized: Vec<&str> = path
+        .split('/')
+        .map(|seg| {
+            if !seg.is_empty() && seg.chars().all(|c| c.is_ascii_digit()) {
+                ":id"
+            } else {
+                seg
+            }
+        })
+        .collect();
+    format!("{method} {}", normalized.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_collapses_numeric_segments_and_drops_query() {
+        assert_eq!(
+            endpoint_label("POST", "/api/probe/123/mannies/456/mine"),
+            "POST /api/probe/:id/mannies/:id/mine"
+        );
+        assert_eq!(endpoint_label("GET", "/api/probe"), "GET /api/probe");
+        assert_eq!(
+            endpoint_label("GET", "/api/probe/probe-improvements-available?includeAll=1"),
+            "GET /api/probe/probe-improvements-available"
+        );
+    }
+
+    #[test]
+    fn percentile_matches_nearest_rank() {
+        let v = [10.0, 20.0, 30.0, 40.0, 50.0];
+        assert_eq!(percentile(&v, 50.0), 30.0);
+        assert_eq!(percentile(&v, 95.0), 50.0);
+        assert_eq!(percentile(&v, 0.0), 10.0);
+        assert_eq!(percentile(&[], 50.0), 0.0);
+    }
+
+    fn sample(label: &str, ms: f64, status: Option<u16>, timed_out: bool) -> RequestSample {
+        RequestSample {
+            label: label.to_string(),
+            elapsed_ms: ms,
+            status,
+            ok: status.map(|s| (200..300).contains(&s)).unwrap_or(false),
+            timed_out,
+        }
+    }
+
+    #[test]
+    fn aggregate_groups_and_counts_errors_and_timeouts() {
+        let mut m = Metrics::default();
+        m.record(sample("GET /a", 100.0, Some(200), false));
+        m.record(sample("GET /a", 300.0, Some(500), false));
+        m.record(sample("GET /a", 900.0, None, true));
+        m.record(sample("GET /b", 50.0, Some(200), false));
+
+        let agg = m.aggregate();
+        // Sorted by p95 desc: /a (900) before /b (50).
+        assert_eq!(agg[0].label, "GET /a");
+        assert_eq!(agg[0].count, 3);
+        assert_eq!(agg[0].max_ms, 900.0);
+        assert_eq!(agg[0].errors, 2, "one 500 + one timeout");
+        assert_eq!(agg[0].timeouts, 1);
+        assert_eq!(agg[1].label, "GET /b");
+        assert_eq!(m.total_errors(), 2);
+        assert_eq!(m.total_timeouts(), 1);
+    }
+
+    #[test]
+    fn ring_evicts_oldest_past_capacity() {
+        let mut m = Metrics::default();
+        for i in 0..(RING_CAP + 10) {
+            m.record(sample("GET /x", i as f64, Some(200), false));
+        }
+        assert_eq!(m.len(), RING_CAP);
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
+pub mod metrics;
 pub mod tasks;
 pub mod types;

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -39,6 +39,34 @@ pub fn script_arg(args: &[String]) -> Option<String> {
     None
 }
 
+/// Default number of measurement rounds when `--diagnostic` is given no count.
+const DEFAULT_DIAGNOSTIC_ROUNDS: u32 = 3;
+/// p95 above this (ms) flags an endpoint as slow in the report.
+const SLOW_THRESHOLD_MS: f64 = 1000.0;
+
+/// The diagnostic mode, if requested: `--diagnostic` / `--diagnostic=N` /
+/// `--status latency` (`--status=latency`). Returns the number of rounds to run
+/// (defaulting when unspecified or unparseable), or `None` for other launches.
+pub fn diagnostic_arg(args: &[String]) -> Option<u32> {
+    let mut it = args.iter().skip(1);
+    while let Some(a) = it.next() {
+        if let Some(n) = a.strip_prefix("--diagnostic=") {
+            return Some(n.parse().unwrap_or(DEFAULT_DIAGNOSTIC_ROUNDS).max(1));
+        }
+        if a == "--diagnostic" {
+            return Some(DEFAULT_DIAGNOSTIC_ROUNDS);
+        }
+        // `--status latency` (the #229 headless-status alias) or `--status=latency`.
+        if a == "--status=latency" {
+            return Some(DEFAULT_DIAGNOSTIC_ROUNDS);
+        }
+        if a == "--status" && it.next().map(|v| v == "latency").unwrap_or(false) {
+            return Some(DEFAULT_DIAGNOSTIC_ROUNDS);
+        }
+    }
+    None
+}
+
 /// Non-comment, non-blank lines of a script file (one command per line; `#`
 /// starts a comment).
 fn script_lines(text: &str) -> Vec<String> {
@@ -290,6 +318,101 @@ fn dispatch(state: &mut AppState, msg: ApiMessage) {
     }
 }
 
+/// Run the API diagnostic: fire `rounds` bursts of the read-only endpoints
+/// against the live server, then print a per-endpoint latency/health report to
+/// stdout (#247). Read-only: no mutating calls, so it is safe to run anytime.
+/// Exit code 0 unless every request failed (or config/link is unusable → 1).
+pub async fn run_diagnostic(rounds: u32) -> Result<i32> {
+    let config = match Config::load_status() {
+        ConfigStatus::Ready(c) => c,
+        _ => bail!("no valid config — launch the cockpit once to set your API key"),
+    };
+    let client = ApiClient::new(config.base_url.clone(), config.api_key.clone())?;
+
+    log_line(&format!("API diagnostic — {} · {rounds} round(s)", config.base_url));
+
+    for round in 1..=rounds {
+        probe_endpoints(&client).await;
+        log_line(&format!("round {round}/{rounds} complete"));
+    }
+
+    let metrics = client.metrics();
+    let metrics = metrics.lock().expect("metrics lock");
+    print_diagnostic_report(&metrics, &config.base_url, rounds);
+
+    // Success unless nothing got through at all.
+    let all_failed = !metrics.is_empty() && metrics.total_errors() == metrics.len();
+    Ok(if metrics.is_empty() || all_failed { 1 } else { 0 })
+}
+
+/// Fire one round of every read-only endpoint. Errors are swallowed here — each
+/// call is already recorded in the metrics ring (status / timeout / latency),
+/// which is what the report reads.
+async fn probe_endpoints(c: &ApiClient) {
+    let _ = c.get_api_version().await;
+    let _ = c.get_probes().await;
+    let _ = c.get_probe().await;
+    let _ = c.get_mannies().await;
+    let _ = c.get_probe_sector().await;
+    let _ = c.get_alerts().await;
+    let _ = c.get_damage_warnings().await;
+    let _ = c.get_missions().await;
+    let _ = c.get_probe_improvements(false).await;
+    let _ = c.get_visited_sectors().await;
+    let _ = c.get_crafting_recipes().await;
+}
+
+/// Print the aggregated per-endpoint report as a fixed-width table, copy-pasteable
+/// into a bug report. Slowest endpoint first; a `⚠` flags a slow p95.
+fn print_diagnostic_report(metrics: &crate::api::metrics::Metrics, base_url: &str, rounds: u32) {
+    let agg = metrics.aggregate();
+    println!();
+    println!("═══ API DIAGNOSTIC REPORT ═══");
+    println!("base_url : {base_url}");
+    println!(
+        "rounds   : {rounds}   requests: {}   errors: {}   timeouts: {}",
+        metrics.len(),
+        metrics.total_errors(),
+        metrics.total_timeouts()
+    );
+    println!("slow flag: p95 > {} ms", SLOW_THRESHOLD_MS as i64);
+    println!();
+    println!(
+        "{:<46} {:>4} {:>7} {:>7} {:>7} {:>4} {:>4}",
+        "ENDPOINT", "n", "p50", "p95", "max", "err", "t/o"
+    );
+    println!("{}", "─".repeat(82));
+    for s in &agg {
+        let slow = if s.p95_ms > SLOW_THRESHOLD_MS { " ⚠" } else { "" };
+        println!(
+            "{:<46} {:>4} {:>7.0} {:>7.0} {:>7.0} {:>4} {:>4}{slow}",
+            truncate(&s.label, 46),
+            s.count,
+            s.p50_ms,
+            s.p95_ms,
+            s.max_ms,
+            s.errors,
+            s.timeouts,
+        );
+    }
+    if let Some(slowest) = agg.first() {
+        println!();
+        println!("slowest: {} (p95 {:.0} ms)", slowest.label, slowest.p95_ms);
+    }
+    flush_stdout();
+}
+
+/// Truncate a label to `width` columns with an ellipsis, so a long endpoint
+/// path never breaks the table alignment.
+fn truncate(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        s.to_string()
+    } else {
+        let keep = width.saturating_sub(1);
+        format!("{}…", s.chars().take(keep).collect::<String>())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,6 +425,32 @@ mod tests {
         assert_eq!(a(&["nc", "--script=run.ncs"]).as_deref(), Some("run.ncs"));
         assert_eq!(a(&["nc"]), None, "bare launch stays interactive");
         assert_eq!(a(&["nc", "--script"]), None, "flag with no path");
+    }
+
+    #[test]
+    fn diagnostic_arg_recognises_flag_forms() {
+        let d = |v: &[&str]| diagnostic_arg(&v.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+        assert_eq!(d(&["nc", "--diagnostic"]), Some(DEFAULT_DIAGNOSTIC_ROUNDS));
+        assert_eq!(d(&["nc", "--diagnostic=5"]), Some(5));
+        assert_eq!(d(&["nc", "--diagnostic=0"]), Some(1), "clamped to at least one round");
+        assert_eq!(
+            d(&["nc", "--diagnostic=abc"]),
+            Some(DEFAULT_DIAGNOSTIC_ROUNDS),
+            "unparseable falls back"
+        );
+        assert_eq!(d(&["nc", "--status", "latency"]), Some(DEFAULT_DIAGNOSTIC_ROUNDS));
+        assert_eq!(d(&["nc", "--status=latency"]), Some(DEFAULT_DIAGNOSTIC_ROUNDS));
+        assert_eq!(d(&["nc"]), None, "bare launch is not diagnostic");
+        assert_eq!(d(&["nc", "--status"]), None, "status without latency arg");
+    }
+
+    #[test]
+    fn truncate_keeps_short_labels_and_ellipsises_long_ones() {
+        assert_eq!(truncate("GET /api/probe", 46), "GET /api/probe");
+        let long = "GET /api/probe/:id/mannies/:id/some-very-long-endpoint-name";
+        let t = truncate(long, 20);
+        assert_eq!(t.chars().count(), 20);
+        assert!(t.ends_with('…'));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,12 @@ async fn main() -> Result<()> {
         let code = neumann_cockpit::headless::run(std::path::Path::new(&path)).await?;
         std::process::exit(code);
     }
+    // Headless API diagnostic: `--diagnostic[=N]` / `--status latency` fires a
+    // burst of read-only requests and prints a latency/health report (#247).
+    if let Some(rounds) = neumann_cockpit::headless::diagnostic_arg(&args) {
+        let code = neumann_cockpit::headless::run_diagnostic(rounds).await?;
+        std::process::exit(code);
+    }
 
     // Enter the alternate screen FIRST — before any fallible startup. A missing
     // or keyless config used to error out of `main` before the terminal was set


### PR DESCRIPTION
## Summary

Implements the server latency & health diagnostic report (#247), MVP-first per the issue's decided surface: a **client-side instrumentation layer** plus a **headless `--diagnostic` report**. The in-cockpit overlay is the deferred follow-up (both share this instrumentation).

## What it does

- **Instruments the client** — every `ApiClient` send path (`get` / `send_with_body`) times the `send()`, classifies the outcome (2xx / HTTP error / transport error / timeout), and records a `RequestSample` into a bounded in-memory ring (`Metrics`, cap 1024) shared across all clones via `Arc<Mutex<_>>` (so `with_active_probe` and per-task clones feed one ring).
- **Aggregates** — `endpoint_label(method, path)` collapses numeric path segments to `:id` and drops the query string; `Metrics::aggregate()` yields per-endpoint `{count, p50, p95, max, errors, timeouts}`, sorted slowest-p95 first.
- **Headless report** — `--diagnostic[=N]` / `--status latency` (default 3 rounds), dispatched before the terminal like `--script`. Fires N bursts of the read-only endpoints (no mutations, safe anytime), then prints a fixed-width per-endpoint table (copy-pasteable into a bug report) with a `⚠` on any p95 over 1000 ms and a session summary. Exits 1 only when every request failed.

## Sample output (live server)

```
═══ API DIAGNOSTIC REPORT ═══
base_url : https://neumann-probe.net
rounds   : 2   requests: 22   errors: 0   timeouts: 0
slow flag: p95 > 1000 ms

ENDPOINT                                          n     p50     p95     max  err  t/o
──────────────────────────────────────────────────────────────────────────────────
GET /api/version                                  2     223     223     223    0    0
GET /api/crafting-recipes                         2     167     167     167    0    0
...
slowest: GET /api/version (p95 223 ms)
```

## Design notes

- Purely client-side — no new server endpoint, per the acceptance criteria.
- Read-only endpoints only in the probe burst; a diagnostic must be side-effect-free.
- Builds on the timeout work (#213) and the headless runner seam (#229 alias `--status latency`); complements degraded mode.

## Out of scope (deferred to the follow-up)

- In-cockpit diagnostics overlay rendering the same aggregates live.
- SQLite `diagnostics` persistence (cross-session history, mirroring the telemetry series #201).

## Testing

- `cargo test` — 328 pass, incl. label normalization, nearest-rank percentiles, error/timeout classification, ring eviction, shared-ring-across-clones, and arg parsing.
- `cargo clippy` / `cargo fmt --check` — clean.
- Ran `--diagnostic=2` against the live server end-to-end (output above).

Closes #247.
