### PR TITLE
fix(api): tolerate the v104 lightweight Manny inventory projection

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -77,14 +77,22 @@ impl ApiClient {
     /// Record one request sample into the shared ring. Best-effort: a poisoned
     /// lock is ignored rather than propagated (instrumentation must never break
     /// a request path).
-    fn record(&self, label: String, elapsed: Duration, status: Option<u16>, timed_out: bool) {
+    ///
+    /// `elapsed` times the `send()` only, so the latency columns stay
+    /// comparable across endpoints regardless of body size. `decode_failed`
+    /// marks a 2xx whose body did not deserialize — a server contract change
+    /// (this is exactly how the v104 lightweight Manny projection broke
+    /// `GET /api/probe`), which must count as an error and not as a success.
+    fn record(&self, label: String, elapsed: Duration, status: Option<u16>, timed_out: bool, decode_failed: bool) {
         if let Ok(mut m) = self.metrics.lock() {
+            let http_ok = status.map(|s| (200..300).contains(&s)).unwrap_or(false);
             m.record(RequestSample {
                 label,
                 elapsed_ms: elapsed.as_secs_f64() * 1000.0,
                 status,
                 timed_out,
-                ok: status.map(|s| (200..300).contains(&s)).unwrap_or(false),
+                ok: http_ok && !decode_failed,
+                decode_failed,
             });
         }
     }
@@ -142,18 +150,21 @@ impl ApiClient {
             .json(body)
             .send()
             .await;
-        let (status_code, timed_out) = match &sent {
-            Ok(r) => (Some(r.status().as_u16()), false),
-            Err(e) => (None, e.is_timeout()),
+        let elapsed = start.elapsed();
+        let resp = match sent {
+            Ok(r) => r,
+            Err(e) => {
+                self.record(label, elapsed, None, e.is_timeout(), false);
+                return Err(e).with_context(|| format!("{method} {path}"));
+            }
         };
-        self.record(label, start.elapsed(), status_code, timed_out);
-        let resp = sent.with_context(|| format!("{method} {path}"))?;
 
         let status = resp.status();
-        if status == StatusCode::UNAUTHORIZED {
-            anyhow::bail!("Unauthorized — check your api_key in config.toml");
-        }
         if !status.is_success() {
+            self.record(label, elapsed, Some(status.as_u16()), false, false);
+            if status == StatusCode::UNAUTHORIZED {
+                anyhow::bail!("Unauthorized — check your api_key in config.toml");
+            }
             let text = resp.text().await.unwrap_or_default();
             let msg = serde_json::from_str::<serde_json::Value>(&text)
                 .ok()
@@ -162,9 +173,9 @@ impl ApiClient {
             anyhow::bail!("{msg}");
         }
 
-        resp.json::<T>()
-            .await
-            .with_context(|| format!("Parsing {method} {path}"))
+        let decoded = resp.json::<T>().await;
+        self.record(label, elapsed, Some(status.as_u16()), false, decoded.is_err());
+        decoded.with_context(|| format!("Parsing {method} {path}"))
     }
 
     async fn post<T: for<'de> Deserialize<'de>, B: Serialize>(&self, path: &str, body: &B) -> Result<T> {
@@ -179,23 +190,28 @@ impl ApiClient {
         let label = endpoint_label("GET", path);
         let start = Instant::now();
         let sent = self.client.get(self.url(path)).bearer_auth(&self.api_key).send().await;
-        let (status_code, timed_out) = match &sent {
-            Ok(r) => (Some(r.status().as_u16()), false),
-            Err(e) => (None, e.is_timeout()),
+        let elapsed = start.elapsed();
+        let resp = match sent {
+            Ok(r) => r,
+            Err(e) => {
+                self.record(label, elapsed, None, e.is_timeout(), false);
+                return Err(e).with_context(|| format!("GET {path}"));
+            }
         };
-        self.record(label, start.elapsed(), status_code, timed_out);
-        let resp = sent.with_context(|| format!("GET {path}"))?;
 
         let status = resp.status();
-        if status == StatusCode::UNAUTHORIZED {
-            anyhow::bail!("Unauthorized — check your api_key in config.toml");
-        }
         if !status.is_success() {
+            self.record(label, elapsed, Some(status.as_u16()), false, false);
+            if status == StatusCode::UNAUTHORIZED {
+                anyhow::bail!("Unauthorized — check your api_key in config.toml");
+            }
             let body = resp.text().await.unwrap_or_default();
             anyhow::bail!("HTTP {status} on GET {path}: {body}");
         }
 
-        resp.json::<T>().await.with_context(|| format!("Parsing GET {path}"))
+        let decoded = resp.json::<T>().await;
+        self.record(label, elapsed, Some(status.as_u16()), false, decoded.is_err());
+        decoded.with_context(|| format!("Parsing GET {path}"))
     }
 
     pub async fn get_api_version(&self) -> Result<u32> {

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -27,8 +27,12 @@ pub struct RequestSample {
     /// `None` when no response arrived (timeout or transport error).
     pub status: Option<u16>,
     pub timed_out: bool,
-    /// A 2xx response.
+    /// A 2xx response whose body also deserialized into the endpoint's type.
+    /// A decode failure is an outage as far as the cockpit is concerned (the
+    /// fetch returns `Err`), so it must not read as a success in the report.
     pub ok: bool,
+    /// A 2xx response the client could not decode — a server contract change.
+    pub decode_failed: bool,
 }
 
 /// Aggregated stats for one endpoint label over the retained samples.
@@ -39,9 +43,12 @@ pub struct EndpointStats {
     pub p50_ms: f64,
     pub p95_ms: f64,
     pub max_ms: f64,
-    /// Requests that did not return a 2xx (HTTP errors + transport failures).
+    /// Requests that did not return usable data (HTTP errors + transport
+    /// failures + undecodable 2xx bodies).
     pub errors: usize,
     pub timeouts: usize,
+    /// Subset of `errors`: 2xx responses whose body failed to deserialize.
+    pub decode_errors: usize,
 }
 
 /// A bounded ring of request samples.
@@ -82,6 +89,11 @@ impl Metrics {
         self.ring.iter().filter(|s| s.timed_out).count()
     }
 
+    /// Total 2xx responses the client could not decode.
+    pub fn total_decode_errors(&self) -> usize {
+        self.ring.iter().filter(|s| s.decode_failed).count()
+    }
+
     /// Per-endpoint aggregate, one entry per label, sorted by descending p95
     /// (slowest first — what a bug report leads with).
     pub fn aggregate(&self) -> Vec<EndpointStats> {
@@ -102,6 +114,7 @@ impl Metrics {
                     max_ms: lat.last().copied().unwrap_or(0.0),
                     errors: samples.iter().filter(|s| !s.ok).count(),
                     timeouts: samples.iter().filter(|s| s.timed_out).count(),
+                    decode_errors: samples.iter().filter(|s| s.decode_failed).count(),
                 }
             })
             .collect();
@@ -171,7 +184,35 @@ mod tests {
             status,
             ok: status.map(|s| (200..300).contains(&s)).unwrap_or(false),
             timed_out,
+            decode_failed: false,
         }
+    }
+
+    /// A 2xx the client could not decode — a server contract change.
+    fn decode_failure(label: &str, ms: f64) -> RequestSample {
+        RequestSample {
+            label: label.to_string(),
+            elapsed_ms: ms,
+            status: Some(200),
+            ok: false,
+            timed_out: false,
+            decode_failed: true,
+        }
+    }
+
+    #[test]
+    fn undecodable_2xx_counts_as_an_error_not_a_success() {
+        let mut m = Metrics::default();
+        m.record(sample("GET /probe", 40.0, Some(200), false));
+        m.record(decode_failure("GET /probe", 42.0));
+
+        let agg = m.aggregate();
+        assert_eq!(agg[0].count, 2);
+        assert_eq!(agg[0].errors, 1, "the undecodable 200 is an error");
+        assert_eq!(agg[0].decode_errors, 1);
+        assert_eq!(agg[0].timeouts, 0);
+        assert_eq!(m.total_errors(), 1);
+        assert_eq!(m.total_decode_errors(), 1);
     }
 
     #[test]
@@ -189,6 +230,7 @@ mod tests {
         assert_eq!(agg[0].max_ms, 900.0);
         assert_eq!(agg[0].errors, 2, "one 500 + one timeout");
         assert_eq!(agg[0].timeouts, 1);
+        assert_eq!(agg[0].decode_errors, 0);
         assert_eq!(agg[1].label, "GET /b");
         assert_eq!(m.total_errors(), 2);
         assert_eq!(m.total_timeouts(), 1);

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -230,6 +230,10 @@ pub enum MannyTaskVisibility {
     Unknown,
 }
 
+/// One inventory entry. General probe and sector telemetry uses a *lightweight
+/// Manny projection* (API v104): `currentTask` and `taskProgressPercent` are
+/// omitted for `manny` entries, whose live task state now comes from the Manny
+/// endpoints only — hence both are optional here.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProbeInventoryItem {
@@ -239,7 +243,7 @@ pub struct ProbeInventoryItem {
     pub name: String,
     pub container_space: f64,
     pub current_task: Option<String>,
-    pub task_progress_percent: f64,
+    pub task_progress_percent: Option<f64>,
     pub location: Option<MannyLocation>,
     pub cargo: Option<MannyCargo>,
     pub container: Option<StorageContainerSummary>,

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -370,22 +370,23 @@ fn print_diagnostic_report(metrics: &crate::api::metrics::Metrics, base_url: &st
     println!("═══ API DIAGNOSTIC REPORT ═══");
     println!("base_url : {base_url}");
     println!(
-        "rounds   : {rounds}   requests: {}   errors: {}   timeouts: {}",
+        "rounds   : {rounds}   requests: {}   errors: {}   timeouts: {}   decode: {}",
         metrics.len(),
         metrics.total_errors(),
-        metrics.total_timeouts()
+        metrics.total_timeouts(),
+        metrics.total_decode_errors()
     );
     println!("slow flag: p95 > {} ms", SLOW_THRESHOLD_MS as i64);
     println!();
     println!(
-        "{:<46} {:>4} {:>7} {:>7} {:>7} {:>4} {:>4}",
-        "ENDPOINT", "n", "p50", "p95", "max", "err", "t/o"
+        "{:<46} {:>4} {:>7} {:>7} {:>7} {:>4} {:>4} {:>4}",
+        "ENDPOINT", "n", "p50", "p95", "max", "err", "t/o", "dec"
     );
-    println!("{}", "─".repeat(82));
+    println!("{}", "─".repeat(87));
     for s in &agg {
         let slow = if s.p95_ms > SLOW_THRESHOLD_MS { " ⚠" } else { "" };
         println!(
-            "{:<46} {:>4} {:>7.0} {:>7.0} {:>7.0} {:>4} {:>4}{slow}",
+            "{:<46} {:>4} {:>7.0} {:>7.0} {:>7.0} {:>4} {:>4} {:>4}{slow}",
             truncate(&s.label, 46),
             s.count,
             s.p50_ms,
@@ -393,6 +394,7 @@ fn print_diagnostic_report(metrics: &crate::api::metrics::Metrics, base_url: &st
             s.max_ms,
             s.errors,
             s.timeouts,
+            s.decode_errors,
         );
     }
     if let Some(slowest) = agg.first() {

--- a/src/ui/overlays/inventory_detail.rs
+++ b/src/ui/overlays/inventory_detail.rs
@@ -59,9 +59,11 @@ pub(crate) fn render_inventory_detail_overlay(frame: &mut Frame, area: Rect, sta
                 detail_kv(
                     p,
                     "Task",
-                    match item.current_task.as_deref() {
-                        None => "idle".into(),
-                        Some(t) => format!("{t}  {:.0}%", item.task_progress_percent),
+                    match (item.current_task.as_deref(), item.task_progress_percent) {
+                        (None, _) => "idle".into(),
+                        (Some(t), Some(pct)) => format!("{t}  {pct:.0}%"),
+                        // Lightweight Manny projection (API v104): no progress here.
+                        (Some(t), None) => t.to_string(),
                     },
                 ),
             ];

--- a/src/ui/panels/inventory.rs
+++ b/src/ui/panels/inventory.rs
@@ -115,7 +115,11 @@ pub(crate) fn render_inventory_panel(frame: &mut Frame, area: Rect, state: &AppS
                 None => (Span::styled("idle", Style::default().fg(p.dim)), String::new()),
                 Some(t) => (
                     Span::styled(t.to_string(), Style::default().fg(p.warn)),
-                    format!(" {:3.0}%", item.task_progress_percent),
+                    // Omitted on Mannies since API v104 — the Mannies pane owns
+                    // their live progress.
+                    item.task_progress_percent
+                        .map(|pct| format!(" {pct:3.0}%"))
+                        .unwrap_or_default(),
                 ),
             };
             frame.render_widget(

--- a/tests/serde_types.rs
+++ b/tests/serde_types.rs
@@ -218,6 +218,66 @@ fn inventory_items_and_stocks() {
     assert_eq!(inv.resource_stocks[0].amount, 0.5);
 }
 
+/// Live API v104 shape: general probe/sector telemetry uses a *lightweight
+/// Manny projection* that omits `currentTask` and `taskProgressPercent` on
+/// `manny` entries (their live task state comes from the Manny endpoints only).
+/// Trimmed from a real `GET /api/probe` body — the missing
+/// `taskProgressPercent` used to fail the whole probe fetch, the only fatal
+/// one, so the cockpit could not boot at all (#274).
+const INVENTORY_V104_LIGHTWEIGHT_MANNY_JSON: &str = r#"{
+  "capacity": 6.0,
+  "usedCapacity": 3.5909,
+  "freeCapacity": 2.4091,
+  "capacityUnit": "earth_container_equivalent",
+  "items": [
+    {
+      "id": "mny_05089385c297b2cc9a6ed410",
+      "type": "manny",
+      "name": "manny-01",
+      "containerSpace": 0.05,
+      "location": { "type": "probe" },
+      "cargo": {
+        "capacity": 0.05,
+        "deuterium": 0,
+        "metals": 0,
+        "ice": 0,
+        "organicCompounds": 0,
+        "capacityUnit": "earth_container_equivalent"
+      },
+      "container": { "id": "probe-core", "kind": "probe", "label": "Cargo Probe", "sortOrder": 0 },
+      "metadata": { "movable": true }
+    },
+    {
+      "id": "itm_9f1c",
+      "type": "atomic_3d_printer",
+      "name": "Atomic printer",
+      "containerSpace": 0.3,
+      "currentTask": null,
+      "taskProgressPercent": 0,
+      "container": { "id": "probe-core", "kind": "probe", "label": "Cargo Probe", "sortOrder": 0 }
+    }
+  ],
+  "resourceStocks": [],
+  "externalTanks": [],
+  "containers": []
+}"#;
+
+#[test]
+fn inventory_manny_entry_without_task_projection() {
+    let inv: ProbeInventory = deser(INVENTORY_V104_LIGHTWEIGHT_MANNY_JSON);
+    assert_eq!(inv.items.len(), 2);
+
+    let manny = &inv.items[0];
+    assert_eq!(manny.item_type, "manny");
+    assert_eq!(manny.current_task, None);
+    assert_eq!(manny.task_progress_percent, None, "omitted by the v104 projection");
+
+    // Non-Manny entries still carry both fields.
+    let printer = &inv.items[1];
+    assert_eq!(printer.item_type, "atomic_3d_printer");
+    assert_eq!(printer.task_progress_percent, Some(0.0));
+}
+
 // ── CraftingRecipe ────────────────────────────────────────────────────────────
 
 const RECIPE_MANNY_JSON: &str = r#"{


### PR DESCRIPTION
The cockpit does not boot against the live server (API **v104**; we track v96): `GET /api/probe` fails to deserialize, and it is the only *fatal* fetch.

API v104 introduced a *lightweight Manny inventory projection* — in general probe and sector telemetry, `currentTask` and `taskProgressPercent` are no longer sent for `manny` entries (live task state comes from the Manny endpoints only). Both keys are **absent**, not null:

```json
{
  "id": "mny_05089385c297b2cc9a6ed410",
  "type": "manny",
  "name": "manny-01",
  "containerSpace": 0.05,
  "location": { "type": "probe" },
  "cargo": { "capacity": 0.05, ... },
  "container": { "id": "probe-core", "kind": "probe", "label": "Cargo Probe", "sortOrder": 0 },
  "metadata": { "movable": true }
}
```

`current_task` was already `Option<String>` (serde derive tolerates an absent `Option` field, same as `location` / `cargo` on non-Manny items); `task_progress_percent: f64` was the single breaking field. `Manny.task_progress_percent`, from `GET /api/probe/mannies`, is unaffected — verified live, 0 omissions over 13 mannies.

## Changes

- **`ProbeInventoryItem.task_progress_percent: Option<f64>`**, with the `None` case handled in the inventory pane (no percentage) and the item detail overlay (task name alone). A Manny row in the inventory has no progress to show — the Mannies pane owns it.
- **Decode failures now count as errors in the instrumentation.** The `RequestSample` is recorded *after* the typed decode instead of right after `send()`, with a new `decode_failed` flag folded into `ok`. `--diagnostic` reported `errors: 0` throughout this outage because `Metrics` classified on the HTTP status only — exactly the class of breakage that tool exists to catch. The report gains a `dec` column and a session total. Latency still times `send()` only, so the percentile columns stay comparable across endpoints; the 401 branch keeps its behaviour (it is already non-2xx, only moved inside the `!is_success()` block).

## Verification

Live link restored. Before, `cargo run -- --script …` ended on `Error: remote link failed — no probe data within 15s`; now:

```
21:24:07  script loaded — 1 step(s)
21:24:07  » Laid in a course for sector «(3, -5, 4)».
21:24:07    ✗ step 1/1 failed — Destination is identical to the current sector.
```

(the remaining error is the expected server-side `same_destination` for `travel +0 0 0` — the probe is primed)

The instrumentation now catches the outage. Same live run with the pre-fix types and the post-fix report code:

```
rounds : 1  requests: 11  errors: 1  timeouts: 0  decode: 1
```

and with the fix: `errors: 0 … decode: 0`.

`cargo test` 329 + 39 green, including two new tests: a serde fixture pinned on a real v104 `/api/probe` inventory body (a `manny` entry missing both keys, an `atomic_3d_printer` entry keeping them) and a metrics aggregation test asserting an undecodable 2xx counts as an error. `cargo fmt --check` clean; `cargo clippy --all-targets` unchanged (135 pre-existing warnings before and after).

Scope is deliberately limited to unbreaking the live link. The rest of the v96 → v104 catch-up — rate limiting, `nextUsefulRefreshDelayMs`, probe models, batch Manny tasks, fleet-wide visited sectors — is sequenced in #275.

Closes #274
